### PR TITLE
Temporary source audit snapshot

### DIFF
--- a/.audit-snapshot-trigger
+++ b/.audit-snapshot-trigger
@@ -1,0 +1,1 @@
+Snapshot current master for read-only audit.

--- a/.github/workflows/audit-snapshot.yml
+++ b/.github/workflows/audit-snapshot.yml
@@ -1,0 +1,32 @@
+name: Source Audit Snapshot
+
+on:
+  push:
+    branches: [ audit-snapshot ]
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Create source snapshot
+        run: |
+          rm -rf .git node_modules .next
+          zip -r hardware-studio-audit.zip . \
+            -x 'hardware-studio-audit.zip' \
+            -x '.git/*' \
+            -x 'node_modules/*' \
+            -x '.next/*'
+
+      - name: Upload source snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: hardware-studio-source-audit
+          path: hardware-studio-audit.zip
+          retention-days: 1


### PR DESCRIPTION
Temporary read-only PR used only to package the current repository source for a full end-to-end audit. It will not be merged. The PR and temporary workflow will be removed after the snapshot artifact is downloaded.