### PR TITLE
Temporary current-source audit snapshot

### DIFF
--- a/.github/workflows/current-source-audit.yml
+++ b/.github/workflows/current-source-audit.yml
@@ -22,12 +22,12 @@ jobs:
             --exclude=.next \
             --exclude=node_modules \
             --exclude='*.log' \
-            -czf hardware-studio-current-source.tar.gz .
+            -czf /tmp/hardware-studio-current-source.tar.gz .
 
       - name: Upload source archive
         uses: actions/upload-artifact@v4
         with:
           name: hardware-studio-current-source
-          path: hardware-studio-current-source.tar.gz
+          path: /tmp/hardware-studio-current-source.tar.gz
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/current-source-audit.yml
+++ b/.github/workflows/current-source-audit.yml
@@ -1,9 +1,9 @@
 name: Current Source Audit Snapshot
 
 on:
-  push:
+  pull_request:
     branches:
-      - audit/current-repository-2026-08-02
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/current-source-audit.yml
+++ b/.github/workflows/current-source-audit.yml
@@ -1,0 +1,33 @@
+name: Current Source Audit Snapshot
+
+on:
+  push:
+    branches:
+      - audit/current-repository-2026-08-02
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create source archive
+        run: |
+          tar \
+            --exclude=.git \
+            --exclude=.next \
+            --exclude=node_modules \
+            --exclude='*.log' \
+            -czf hardware-studio-current-source.tar.gz .
+
+      - name: Upload source archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: hardware-studio-current-source
+          path: hardware-studio-current-source.tar.gz
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
Read-only audit transport for the current `master` source. This pull request must not be merged. It exists only to generate a short-lived source artifact for the requested repository-wide audit, after which the workflow and branch will be removed.