### PR TITLE
Build semantic Blueprint visuals and representation inspector

### DIFF
--- a/docs/research/VISUAL_REPRESENTATION_SYSTEM.md
+++ b/docs/research/VISUAL_REPRESENTATION_SYSTEM.md
@@ -1,0 +1,147 @@
+# Hardware Studio visual representation system
+
+Status: implemented first production vertical slice in `feature/visual-representation-system` for issue #60.
+
+## Product decision
+
+Hardware Studio must not use one visual language for every engineering concept.
+
+A system function, firmware state, electrical symbol, PCB footprint, educational illustration, package envelope, exact CAD body, lightweight render mesh, and supplier photo are different representations with different responsibilities and trust levels. They can be linked to one identity, but one representation must never silently substitute for another.
+
+The System Blueprint is a system-architecture editor. It is not a schematic editor, PCB editor, breadboard diagram, or mechanical CAD workbench.
+
+## Representation contract
+
+| Representation | Primary purpose | Engineering authority |
+| --- | --- | --- |
+| Architecture | Recognize a function/device and understand typed interfaces | Semantic system communication only |
+| Schematic | Electrical connectivity, pins, units, fields, and ERC | Authoritative only when supplied by a reviewed component revision |
+| Pictorial | Onboarding, identification, and educational wiring context | Educational only |
+| Footprint | Pads, drills, mask/paste, courtyard, origin, and PCB placement | Authoritative only when supplied by a reviewed footprint revision |
+| Package | Dimensions, height, tolerances, mounting, orientation, and keepouts | Authoritative only when exact selected-part package data exists |
+| Lightweight 3D | Smooth visual inspection and recognition | Visualization only |
+| Exact 3D | STEP/B-Rep solids, assembly transforms, and qualified interference | Authoritative only after CAD qualification |
+| Photo | Recognition and sourcing reference | Never geometry or connectivity authority |
+
+Every representation records status, trust, source, license, qualification text, and the narrow purpose for which it can be authoritative.
+
+## Visual families in the first slice
+
+The registry includes semantic handling for:
+
+- resistor;
+- capacitor;
+- LED;
+- push button and touch input;
+- microcontroller/module;
+- environmental, motion, and digital sensors;
+- voltage regulator;
+- battery;
+- USB-C connector;
+- motor/haptic actuator;
+- display;
+- programming/debug connector;
+- protection device;
+- enclosure;
+- PCB assembly;
+- firmware state;
+- software service;
+- validation activity;
+- product/system boundary;
+- safe generic functional fallback.
+
+Existing Blueprint nodes are mapped deterministically from current names, categories, descriptions, candidate components, and tags. This avoids a destructive migration and avoids creating a parallel visual-only catalog.
+
+## Architecture-editor behavior
+
+- Semantic SVG glyphs replace uniform generic block visuals.
+- Ports are typed as power, ground, data, control, analog, wireless, mechanical, thermal, or dependency.
+- New connections inherit their visual language from the typed port: color, line pattern, arrow, and optional animation for wireless relationships.
+- Node detail changes with zoom:
+  - low zoom: compact silhouette and label;
+  - medium zoom: family, status, and name;
+  - normal zoom: purpose, candidate hardware, and typed interface summary.
+- The library uses the same family resolver and visual glyphs as placed architecture nodes.
+- Every node can open the representation inspector.
+- Unknown concepts use a generic semantic function representation. They never receive invented schematic, footprint, package, or exact-CAD assets.
+
+## Representation inspector
+
+The inspector exposes all eight representations without collapsing trust boundaries.
+
+It shows:
+
+- current representation status and trust;
+- source, license, and qualification;
+- architecture ports and directions;
+- educational and vector previews;
+- explicit unresolved exact-package/CAD states;
+- links to Learn, Component Library, Schematic, and PCB workbenches;
+- low, balanced, and high visualization-quality profiles for lightweight 3D.
+
+The inspector never claims that opening another workbench has selected or synchronized an exact component instance when that relationship does not yet exist.
+
+## Lightweight 3D architecture
+
+The first slice uses a procedural Three.js visualization source so it does not download unlicensed third-party models or pretend a generic family model is a manufacturer part.
+
+The viewer:
+
+- is lazy-loaded only when the user selects Lightweight 3D;
+- requests a low-power WebGL context;
+- has bounded pixel ratios for low, balanced, and high profiles;
+- has no automatic rotation;
+- has no continuous animation loop;
+- renders only for initial display, resize, visibility return, and user orbit/zoom interaction;
+- pauses while outside the viewport;
+- disposes controls, observers, geometry, materials, renderer resources, and the WebGL context on close;
+- labels the preview as visualization-only.
+
+This viewer is not the CAD kernel and is excluded from dimensional, clearance, interference, mass, manufacturing, or release authority.
+
+## Performance budgets for this slice
+
+These are product budgets to verify as browser performance infrastructure matures in #10:
+
+- Architecture glyph: inline SVG, no network request.
+- Pictorial preview: inline SVG, no raster download.
+- Blueprint node: no WebGL context and no image request.
+- 3D module: not imported until its representation tab opens.
+- 3D active render: event-driven, not a permanent requestAnimationFrame loop.
+- Pixel ratio: 1.0 low, 1.35 balanced, 1.8 high, always capped below unrestricted device pixel ratio.
+- One representation inspector opens one WebGL context at most.
+- Closing the inspector releases the context and derived GPU resources.
+
+## Source and licensing policy
+
+The current visual assets are authored as repository SVG/procedural geometry and include no copied screenshots or random web images.
+
+Future imports must record:
+
+- source project/vendor;
+- source URL or package identifier;
+- license and redistribution terms;
+- source version;
+- content hash;
+- units;
+- coordinate system and orientation;
+- mapping to component-definition revision;
+- qualification status and reviewer.
+
+Unclear licensing means the asset cannot ship.
+
+## Open-source adapter direction
+
+Future adapter work should qualify structured data rather than screen captures:
+
+- KiCad symbols, footprints, fields, and STEP/VRML associations;
+- LibrePCB symbol/component/package/device relationships and pin-to-pad mapping;
+- manufacturer STEP and images only with explicit usage rights;
+- `kicad-cli` or reviewed parsers for deterministic vector preview and round-trip checks;
+- STEP-to-tessellation or glTF caches through #17 and #26.
+
+## Known boundary after this slice
+
+This implementation materially replaces the generic Blueprint visual grammar and establishes the production representation contracts. Issue #60 remains broader than this PR because exact selected-component revision linking, qualified imported symbol/footprint adapters, manufacturer assets, STEP qualification, deep object-level cross-probing, and browser visual/performance gates depend on #13, #15, #17, #26, and #10.
+
+Those missing capabilities remain explicitly unresolved rather than represented as complete.

--- a/src/__tests__/visualRepresentationRegistry.test.ts
+++ b/src/__tests__/visualRepresentationRegistry.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getVisualFamily,
+  portHandleId,
+  portKindFromHandleId,
+  REPRESENTATION_KINDS,
+  representationStatusCounts,
+  resolveVisualFamilyId,
+  visualFamilyRegistry,
+} from '../lib/visual/representationRegistry';
+
+describe('visual representation registry', () => {
+  it('ships unique visual families with every representation contract', () => {
+    expect(visualFamilyRegistry.length).toBeGreaterThanOrEqual(20);
+    const ids = visualFamilyRegistry.map((family) => family.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    visualFamilyRegistry.forEach((family) => {
+      expect(family.label.trim(), family.id).not.toBe('');
+      expect(family.description.trim(), family.id).not.toBe('');
+      expect(family.ports.length, family.id).toBeGreaterThan(0);
+      expect(new Set(family.ports.map((port) => port.id)).size, family.id).toBe(family.ports.length);
+
+      REPRESENTATION_KINDS.forEach((kind) => {
+        const representation = family.representations[kind];
+        expect(representation.kind).toBe(kind);
+        expect(representation.label.trim(), `${family.id}:${kind}`).not.toBe('');
+        expect(representation.description.trim(), `${family.id}:${kind}`).not.toBe('');
+        expect(representation.source.trim(), `${family.id}:${kind}`).not.toBe('');
+        expect(representation.license.trim(), `${family.id}:${kind}`).not.toBe('');
+        expect(representation.qualification.trim(), `${family.id}:${kind}`).not.toBe('');
+      });
+
+      const counts = representationStatusCounts(family);
+      expect(Object.values(counts).reduce((sum, value) => sum + value, 0)).toBe(REPRESENTATION_KINDS.length);
+    });
+  });
+
+  it('maps the bounded starter families and non-physical concepts deterministically', () => {
+    const fixtures = [
+      ['4.7k pull-up resistor', 'Electronics', 'resistor'],
+      ['100nF decoupling capacitor', 'Electronics', 'capacitor'],
+      ['RGB LED Indicator', 'Interaction', 'led'],
+      ['Push Button Input', 'Interaction', 'push-button'],
+      ['BLE MCU / Controller', 'Electronics', 'microcontroller'],
+      ['IMU Sensor', 'Electronics', 'sensor'],
+      ['3.3V LDO Regulator', 'Power', 'voltage-regulator'],
+      ['Curved LiPo Battery', 'Power', 'battery'],
+      ['USB Type-C Receptacle', 'Electronics', 'usb-c'],
+      ['Haptic Feedback Motor', 'Interaction', 'motor-actuator'],
+      ['OLED Display Panel', 'Interaction', 'display'],
+      ['SWD Programming Header', 'Electronics', 'debug-connector'],
+      ['ESD Protection Array', 'Electronics', 'protection-device'],
+      ['Outer Casing', 'Mechanical', 'enclosure'],
+      ['Main PCB Assembly', 'Electronics', 'pcb-assembly'],
+      ['Sleep State', 'Firmware', 'firmware-state'],
+      ['Mobile App Service', 'Software', 'software-service'],
+      ['Factory QA Test', 'Testing', 'validation'],
+      ['Hardware Product Container', 'Product', 'product-system'],
+    ] as const;
+
+    fixtures.forEach(([name, category, expected]) => {
+      expect(resolveVisualFamilyId({ name, category }), name).toBe(expected);
+    });
+  });
+
+  it('uses a safe generic semantic fallback instead of inventing a physical asset', () => {
+    const familyId = resolveVisualFamilyId({ name: 'Unknown experimental idea', category: 'Other' });
+    expect(familyId).toBe('generic-function');
+
+    const family = getVisualFamily(familyId);
+    expect(family.representations.schematic.status).toBe('unavailable');
+    expect(family.representations.footprint.status).toBe('unresolved');
+    expect(family.representations.exact3d.status).toBe('unavailable');
+  });
+
+  it('keeps exact CAD unresolved for physical starter families while providing a separate preview', () => {
+    const physicalFamilies = [
+      'microcontroller',
+      'battery',
+      'usb-c',
+      'motor-actuator',
+      'display',
+      'enclosure',
+      'pcb-assembly',
+    ] as const;
+
+    physicalFamilies.forEach((familyId) => {
+      const family = getVisualFamily(familyId);
+      expect(family.representations.render3d.status, familyId).toBe('provisional');
+      expect(family.representations.render3d.trust, familyId).toBe('preview');
+      expect(family.representations.exact3d.status, familyId).toBe('unresolved');
+      expect(family.representations.exact3d.trust, familyId).toBe('authoritative');
+    });
+  });
+
+  it('does not ship unlicensed photos as available assets', () => {
+    visualFamilyRegistry.forEach((family) => {
+      expect(family.representations.photo.status, family.id).toBe('unavailable');
+      expect(family.representations.photo.description.toLowerCase()).toMatch(/license|rights|manufacturer|random web/);
+    });
+  });
+
+  it('encodes and decodes typed architecture ports for connections', () => {
+    const family = getVisualFamily('microcontroller');
+    family.ports.forEach((port) => {
+      const handleId = portHandleId(port);
+      expect(handleId).toContain(port.id);
+      expect(portKindFromHandleId(handleId)).toBe(port.kind);
+    });
+
+    expect(portKindFromHandleId('legacy-handle')).toBeUndefined();
+    expect(portKindFromHandleId(null)).toBeUndefined();
+  });
+});

--- a/src/components/BlueprintCanvas.tsx
+++ b/src/components/BlueprintCanvas.tsx
@@ -1,4 +1,13 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   ReactFlow,
   MiniMap,
@@ -6,254 +15,285 @@ import {
   Background,
   useReactFlow,
   ReactFlowProvider,
+  useStore,
   Handle,
   Position,
   NodeProps,
   Connection,
   NodeChange,
+  MarkerType,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import { Eye, Info, Network, ShieldAlert } from 'lucide-react';
 import { useProjectStore } from '../store/projectStore';
 import { CustomNode, NodeData } from '../types';
 import { BlockLibraryItem } from '../data/blockLibrary';
+import {
+  ArchitecturePort,
+  portHandleId,
+  portKindFromHandleId,
+  portKindStyles,
+  resolveVisualFamily,
+  resolveVisualFamilyId,
+} from '../lib/visual/representationRegistry';
+import { ArchitectureGlyph } from './visual/DeviceVisual';
+import { RepresentationInspector } from './visual/RepresentationInspector';
 
-// Status colors styling helper
 const getStatusClasses = (status: NodeData['status']) => {
   switch (status) {
-    case 'MVP':
-      return {
-        bg: 'bg-emerald-50 text-emerald-800 border-emerald-200',
-        dot: 'bg-emerald-500'
-      };
-    case 'Later':
-      return {
-        bg: 'bg-slate-50 text-slate-600 border-slate-200',
-        dot: 'bg-slate-400'
-      };
-    case 'Future':
-      return {
-        bg: 'bg-purple-50 text-purple-800 border-purple-200',
-        dot: 'bg-purple-500'
-      };
-    case 'External':
-      return {
-        bg: 'bg-slate-100 text-slate-500 border-slate-200',
-        dot: 'bg-slate-400'
-      };
-    case 'Risk':
-      return {
-        bg: 'bg-rose-50 text-rose-800 border-rose-200',
-        dot: 'bg-rose-500 animate-pulse'
-      };
-    case 'Complete':
-      return {
-        bg: 'bg-blue-50 text-blue-800 border-blue-200',
-        dot: 'bg-blue-500'
-      };
-    default:
-      return {
-        bg: 'bg-gray-50 text-gray-700 border-gray-200',
-        dot: 'bg-gray-400'
-      };
+    case 'MVP': return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+    case 'Later': return 'border-slate-200 bg-slate-50 text-slate-600';
+    case 'Future': return 'border-purple-200 bg-purple-50 text-purple-800';
+    case 'External': return 'border-slate-200 bg-slate-100 text-slate-500';
+    case 'Risk': return 'border-rose-200 bg-rose-50 text-rose-800';
+    case 'Complete': return 'border-blue-200 bg-blue-50 text-blue-800';
+    default: return 'border-slate-200 bg-slate-50 text-slate-700';
   }
 };
 
-// Category indicator helper
-const getCategoryColor = (cat: string) => {
-  switch (cat) {
-    case 'Product': return 'bg-slate-800';
-    case 'Interaction': return 'bg-pink-500';
-    case 'Electronics': return 'bg-cyan-500';
-    case 'Firmware': return 'bg-violet-500';
-    case 'Mechanical': return 'bg-amber-500';
-    case 'Power': return 'bg-yellow-500';
-    case 'Software': return 'bg-indigo-500';
-    case 'Testing': return 'bg-rose-500';
-    default: return 'bg-slate-400';
-  }
-};
+interface RepresentationInspectorContextValue {
+  inspect: (data: NodeData) => void;
+}
 
-// --- CUSTOM BLOCK NODE ---
-const BlockNode: React.FC<NodeProps<CustomNode>> = ({ data, selected }) => {
-  const statusStyles = getStatusClasses(data.status);
-  const categoryBarColor = getCategoryColor(data.category);
+const RepresentationInspectorContext = createContext<RepresentationInspectorContextValue | null>(null);
+
+function useRepresentationInspector() {
+  const value = useContext(RepresentationInspectorContext);
+  if (!value) throw new Error('Architecture nodes require RepresentationInspectorContext');
+  return value;
+}
+
+function portPosition(index: number, count: number): string {
+  if (count <= 1) return '50%';
+  return `${24 + (52 * index) / (count - 1)}%`;
+}
+
+function splitPorts(ports: readonly ArchitecturePort[]) {
+  const inputs: ArchitecturePort[] = [];
+  const outputs: ArchitecturePort[] = [];
+  ports.forEach((port, index) => {
+    if (port.direction === 'input') inputs.push(port);
+    else if (port.direction === 'output') outputs.push(port);
+    else if (index % 2 === 0) inputs.push(port);
+    else outputs.push(port);
+  });
+  return { inputs, outputs };
+}
+
+const ArchitectureNode: React.FC<NodeProps<CustomNode>> = ({ data, selected }) => {
+  const family = resolveVisualFamily(data);
+  const familyId = resolveVisualFamilyId(data);
+  const zoom = useStore((state) => state.transform[2]);
+  const { inspect } = useRepresentationInspector();
+  const compact = zoom < 0.58;
+  const medium = zoom >= 0.58 && zoom < 0.88;
+  const { inputs, outputs } = splitPorts(family.ports);
+
+  const renderPorts = (ports: ArchitecturePort[], side: 'left' | 'right') => ports.map((port, index) => {
+    const styles = portKindStyles[port.kind];
+    const top = portPosition(index, ports.length);
+    const isLeft = side === 'left';
+    return (
+      <React.Fragment key={`${side}-${port.id}`}>
+        <Handle
+          type={isLeft ? 'target' : 'source'}
+          id={portHandleId(port)}
+          position={isLeft ? Position.Left : Position.Right}
+          title={`${port.label}: ${port.description}`}
+          className="!h-3 !w-3 !border-2 !border-white shadow-sm transition-transform hover:!scale-125"
+          style={{ top, backgroundColor: styles.color }}
+        />
+        {!compact && (
+          <span
+            className={`pointer-events-none absolute z-10 max-w-[82px] truncate rounded border border-slate-200 bg-white/95 px-1.5 py-0.5 text-[8px] font-bold text-slate-600 shadow-sm ${isLeft ? '-left-2 -translate-x-full text-right' : '-right-2 translate-x-full text-left'}`}
+            style={{ top, transform: `${isLeft ? 'translate(-100%, -50%)' : 'translate(100%, -50%)'}` }}
+            aria-hidden="true"
+          >
+            {port.label}
+          </span>
+        )}
+      </React.Fragment>
+    );
+  });
+
+  if (compact) {
+    return (
+      <div
+        className={`relative grid h-[92px] w-[118px] place-items-center rounded-[24px] border bg-white shadow-sm transition ${selected ? 'border-slate-950 ring-2 ring-slate-950/15' : 'border-slate-200'}`}
+        title={`${data.name}: ${family.description}`}
+      >
+        {renderPorts(inputs, 'left')}
+        {renderPorts(outputs, 'right')}
+        <div className="grid h-12 w-12 place-items-center rounded-2xl" style={{ backgroundColor: family.accent, color: family.color }}>
+          <ArchitectureGlyph familyId={familyId} className="h-8 w-8" />
+        </div>
+        <span className="absolute bottom-2 max-w-[100px] truncate text-[9px] font-bold text-slate-800">{data.name}</span>
+      </div>
+    );
+  }
 
   return (
-    <div 
-      className={`bg-white rounded-lg border text-slate-800 text-[11px] w-52 overflow-hidden transition-all duration-200 select-none shadow-[0_1px_3px_rgba(15,23,42,0.03),0_1px_2px_rgba(15,23,42,0.02)] ${
-        selected 
-          ? 'border-slate-900 shadow-[0_4px_12px_rgba(15,23,42,0.08),0_2px_4px_rgba(15,23,42,0.04)] ring-[1.5px] ring-slate-900' 
-          : 'border-slate-200 hover:border-slate-350 hover:shadow-[0_2px_6px_rgba(15,23,42,0.04)]'
-      }`}
+    <article
+      className={`relative w-[244px] overflow-visible rounded-[22px] border bg-white text-slate-800 shadow-[0_8px_28px_rgba(15,23,42,0.08)] transition-all duration-150 ${selected ? 'border-slate-950 ring-2 ring-slate-950/10' : 'border-slate-200 hover:border-slate-300'}`}
+      aria-label={`${data.name}, ${family.label} architecture node`}
     >
-      {/* Handles */}
-      <Handle type="target" position={Position.Left} className="w-1.5 h-1.5 bg-slate-400 hover:bg-slate-600 transition-colors" />
-      <Handle type="source" position={Position.Right} className="w-1.5 h-1.5 bg-slate-400 hover:bg-slate-600 transition-colors" />
+      {renderPorts(inputs, 'left')}
+      {renderPorts(outputs, 'right')}
 
-      {/* Top Accent Category Bar */}
-      <div className={`h-1 w-full ${categoryBarColor}`} />
-
-      <div className="p-3 space-y-2.5">
-        {/* Header */}
-        <div className="flex items-start justify-between gap-2">
-          <span className="text-[8px] font-mono font-bold tracking-widest text-slate-400 uppercase">
-            {data.category}
-          </span>
-          <span className={`text-[8px] font-extrabold px-1.5 py-0.5 rounded-md border uppercase tracking-wider scale-95 shrink-0 ${statusStyles.bg}`}>
-            {data.status}
-          </span>
+      <div className="overflow-hidden rounded-[21px]">
+        <div className="flex items-start gap-3 border-b border-slate-100 p-3.5" style={{ background: `linear-gradient(135deg, ${family.accent}, #ffffff)` }}>
+          <div className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl border border-white/80 bg-white/80 shadow-sm" style={{ color: family.color }}>
+            <ArchitectureGlyph familyId={familyId} className="h-8 w-8" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate text-[9px] font-extrabold uppercase tracking-[0.13em]" style={{ color: family.color }}>{family.shortLabel} · {data.category}</span>
+              <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[8px] font-extrabold uppercase tracking-wide ${getStatusClasses(data.status)}`}>{data.status}</span>
+            </div>
+            <h3 className="mt-1.5 line-clamp-2 text-[13px] font-extrabold leading-4 text-slate-950">{data.name}</h3>
+            {!medium && <p className="mt-1 line-clamp-2 text-[10px] leading-[16px] text-slate-600">{data.description || family.description}</p>}
+          </div>
         </div>
 
-        {/* Name */}
-        <div className="font-bold text-xs text-slate-900 leading-snug truncate" title={data.name}>
-          {data.name}
-        </div>
+        {!medium && (
+          <div className="space-y-2.5 p-3.5">
+            <div className="flex flex-wrap gap-1.5">
+              {family.ports.slice(0, 4).map((port) => (
+                <span key={port.id} className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-[8px] font-bold uppercase tracking-wide text-slate-600">
+                  <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: portKindStyles[port.kind].color }} />
+                  {portKindStyles[port.kind].label}
+                </span>
+              ))}
+              {family.ports.length > 4 && <span className="rounded-full border border-slate-200 bg-white px-2 py-1 text-[8px] font-bold text-slate-500">+{family.ports.length - 4}</span>}
+            </div>
 
-        {/* Description */}
-        {data.description && (
-          <p className="text-[10px] text-slate-500 leading-normal line-clamp-2">
-            {data.description}
-          </p>
-        )}
-
-        {/* Specs / Components Footer */}
-        {(data.candidateComponents || data.requirements) && (
-          <div className="flex items-center justify-between border-t border-slate-100 pt-2 text-[9px]">
-            {data.candidateComponents ? (
-              <span className="truncate max-w-[120px] bg-slate-100/80 text-slate-600 px-1.5 py-0.5 rounded font-mono text-[8px] border border-slate-200/50" title={data.candidateComponents}>
-                {data.candidateComponents}
-              </span>
-            ) : (
-              <span className="text-slate-400 italic">No component</span>
+            {data.candidateComponents && (
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-2.5 py-2">
+                <p className="text-[8px] font-bold uppercase tracking-wide text-slate-400">Candidate / linked hardware</p>
+                <p className="mt-1 line-clamp-2 text-[9px] leading-4 text-slate-600">{data.candidateComponents}</p>
+              </div>
             )}
           </div>
         )}
+
+        <button
+          type="button"
+          className="nodrag flex w-full items-center justify-between border-t border-slate-100 bg-white px-3.5 py-2 text-[9px] font-bold text-slate-600 transition hover:bg-slate-50 hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            inspect(data);
+          }}
+        >
+          <span className="inline-flex items-center gap-1.5"><Eye className="h-3.5 w-3.5" aria-hidden="true" />Inspect all representations</span>
+          <span aria-hidden="true">→</span>
+        </button>
       </div>
-    </div>
+    </article>
   );
 };
 
-// --- CUSTOM BOUNDARY NODE ---
 const BoundaryNode: React.FC<NodeProps<CustomNode>> = ({ data, selected }) => {
-  const isMvp = data.status === 'MVP';
-  const isLater = data.status === 'Later';
-  const isFuture = data.status === 'Future';
-
-  const boundaryColorClass = isMvp 
-    ? 'border-emerald-400 bg-emerald-500/[0.02] text-emerald-800' 
-    : isLater 
-      ? 'border-slate-350 bg-slate-500/[0.01] text-slate-700' 
-      : isFuture 
-        ? 'border-purple-400 bg-purple-500/[0.02] text-purple-800'
-        : 'border-slate-400 bg-slate-500/[0.02] text-slate-800';
-
+  const family = resolveVisualFamily(data);
   return (
-    <div 
-      className={`border-2 border-dashed rounded-xl h-full w-full p-4 pointer-events-none select-none relative transition-all ${boundaryColorClass} ${
-        selected ? 'ring-2 ring-slate-900 border-slate-900 shadow-sm' : ''
-      }`}
+    <div
+      className={`relative h-full w-full rounded-[28px] border-2 border-dashed p-4 text-slate-700 transition ${selected ? 'border-slate-950 ring-2 ring-slate-950/10' : 'border-slate-300'} bg-white/35`}
+      style={{ borderColor: selected ? '#0f172a' : family.color }}
     >
-      <div className="absolute -top-3 left-4 flex items-center space-x-1.5 select-none">
-        <span className={`text-[9px] font-extrabold uppercase tracking-widest border px-2 py-0.5 rounded-md shadow-sm bg-white ${
-          isMvp ? 'text-emerald-700 border-emerald-200' : 'text-slate-700 border-slate-200'
-        }`}>
-          {data.name} &bull; {data.status}
-        </span>
-        {data.notes && (
-          <span className="text-[9px] font-bold text-slate-400 bg-white px-2 py-0.5 rounded-md border border-slate-200/80 shadow-sm">
-            {data.notes}
-          </span>
-        )}
+      <div className="absolute -top-4 left-5 flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 shadow-sm">
+        <ArchitectureGlyph familyId={resolveVisualFamilyId(data)} className="h-4 w-4" />
+        <span className="text-[9px] font-extrabold uppercase tracking-[0.12em] text-slate-800">{data.name}</span>
+        <span className={`rounded-full border px-1.5 py-0.5 text-[7px] font-extrabold uppercase ${getStatusClasses(data.status)}`}>{data.status}</span>
       </div>
     </div>
   );
 };
 
-// Define node types memoized
 const nodeTypes = {
-  blockNode: BlockNode,
+  blockNode: ArchitectureNode,
   boundaryNode: BoundaryNode,
 };
 
 const BlueprintCanvasContent: React.FC = () => {
-  const { 
-    activeView, 
-    nodes, 
-    edges, 
-    setSelectedNodeId, 
-    updateNodePosition, 
+  const {
+    activeView,
+    nodes,
+    edges,
+    setSelectedNodeId,
+    updateNodePosition,
     addEdge,
-    addNode
+    addNode,
   } = useProjectStore();
-
+  const [inspectedNode, setInspectedNode] = useState<NodeData | null>(null);
+  const [isInspectorOpen, setIsInspectorOpen] = useState(false);
   const reactFlowInstance = useReactFlow();
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
 
-  // Filter nodes & edges for the current view
-  const viewNodes = useMemo(() => {
-    return nodes.filter(node => node.data.views && node.data.views.includes(activeView));
-  }, [nodes, activeView]);
+  const viewNodes = useMemo(
+    () => nodes.filter((node) => node.data.views && node.data.views.includes(activeView)),
+    [nodes, activeView],
+  );
 
-  const viewEdges = useMemo(() => {
-    return edges.filter(edge => edge.views && edge.views.includes(activeView));
-  }, [edges, activeView]);
+  const viewEdges = useMemo(
+    () => edges
+      .filter((edge) => edge.views && edge.views.includes(activeView))
+      .map((edge) => {
+        const kind = portKindFromHandleId(edge.sourceHandle) ?? portKindFromHandleId(edge.targetHandle);
+        const visual = kind ? portKindStyles[kind] : portKindStyles.dependency;
+        return {
+          ...edge,
+          type: 'smoothstep',
+          animated: kind === 'wireless',
+          style: { stroke: visual.color, strokeWidth: 2, strokeDasharray: visual.dash },
+          markerEnd: { type: MarkerType.ArrowClosed, color: visual.color, width: 16, height: 16 },
+          labelStyle: { fill: '#475569', fontSize: 10, fontWeight: 700 },
+          labelBgStyle: { fill: '#ffffff', fillOpacity: 0.92 },
+          labelBgPadding: [4, 3] as [number, number],
+          labelBgBorderRadius: 5,
+        };
+      }),
+    [edges, activeView],
+  );
 
-  // Handle position changes on drag end or drag progress
   const onNodesChange = useCallback((changes: NodeChange[]) => {
     changes.forEach((change) => {
-      if (change.type === 'position' && change.position && change.id) {
-        updateNodePosition(change.id, change.position);
-      }
+      if (change.type === 'position' && change.position && change.id) updateNodePosition(change.id, change.position);
     });
   }, [updateNodePosition]);
 
-  // Handle node selection
   const onNodeClick = useCallback((_: React.MouseEvent, node: CustomNode) => {
     setSelectedNodeId(node.id);
   }, [setSelectedNodeId]);
 
-  // Deselect node on clicking canvas background
-  const onPaneClick = useCallback(() => {
-    setSelectedNodeId(null);
-  }, [setSelectedNodeId]);
+  const onPaneClick = useCallback(() => setSelectedNodeId(null), [setSelectedNodeId]);
 
-  // Handle edge connects
   const onConnect = useCallback((params: Connection) => {
+    const kind = portKindFromHandleId(params.sourceHandle) ?? portKindFromHandleId(params.targetHandle);
     addEdge({
       id: `edge_${Date.now()}`,
       source: params.source,
       target: params.target,
+      sourceHandle: params.sourceHandle,
+      targetHandle: params.targetHandle,
       views: [activeView],
-      label: ''
+      label: kind ? portKindStyles[kind].label : '',
     });
   }, [addEdge, activeView]);
 
-  // Drag over handler for HTML5 drag-and-drop
   const onDragOver = useCallback((event: React.DragEvent) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
   }, []);
 
-  // Drop handler to place node on coordinates
   const onDrop = useCallback((event: React.DragEvent) => {
     event.preventDefault();
-
     if (!reactFlowWrapper.current || !reactFlowInstance) return;
-
-    const reactFlowBounds = reactFlowWrapper.current.getBoundingClientRect();
     const dataStr = event.dataTransfer.getData('application/reactflow-item');
-    
     if (!dataStr) return;
-    
+
     try {
       const item: BlockLibraryItem = JSON.parse(dataStr);
-      
-      // Calculate coordinates relative to flow viewport zoom & pan
-      const position = reactFlowInstance.screenToFlowPosition({
-        x: event.clientX - reactFlowBounds.left,
-        y: event.clientY - reactFlowBounds.top,
-      });
-
+      const position = reactFlowInstance.screenToFlowPosition({ x: event.clientX, y: event.clientY });
       addNode({
         type: item.type,
         position,
@@ -271,45 +311,74 @@ const BlueprintCanvasContent: React.FC = () => {
           notes: item.notes,
           testingNotes: item.testingNotes,
           views: [activeView],
-          positions: {}
-        }
+          positions: {},
+        },
       });
-    } catch (err) {
-      console.error("Failed to add node via drop:", err);
+    } catch (error) {
+      console.error('Failed to add architecture node from library', error);
     }
   }, [reactFlowInstance, activeView, addNode]);
 
+  const inspectorValue = useMemo<RepresentationInspectorContextValue>(() => ({
+    inspect: (data) => {
+      setInspectedNode(data);
+      setIsInspectorOpen(true);
+    },
+  }), []);
+
   return (
-    <div ref={reactFlowWrapper} className="w-full h-full relative" onDragOver={onDragOver} onDrop={onDrop}>
-      {activeView === 'hardware-studio' && (
-        <div className="absolute top-3 left-1/2 -translate-x-1/2 bg-amber-50 text-amber-800 border border-amber-200 rounded px-3 py-1 text-[10px] font-bold uppercase tracking-wider z-10 shadow-sm pointer-events-none">
-          External Software Layer — Not inside physical wearable device
+    <RepresentationInspectorContext.Provider value={inspectorValue}>
+      <div ref={reactFlowWrapper} className="relative h-full w-full" onDragOver={onDragOver} onDrop={onDrop}>
+        <div className="pointer-events-none absolute left-4 top-4 z-10 max-w-sm rounded-xl border border-slate-200 bg-white/95 px-3 py-2 shadow-sm backdrop-blur-sm">
+          <div className="flex items-center gap-2 text-[10px] font-extrabold uppercase tracking-[0.13em] text-slate-800"><Network className="h-4 w-4 text-indigo-600" aria-hidden="true" />System architecture</div>
+          <p className="mt-1 text-[10px] leading-4 text-slate-500">Semantic device and function visuals with typed ports. Use Schematic and PCB workbenches for exact electrical and footprint geometry.</p>
         </div>
-      )}
-      <ReactFlow
-        nodes={viewNodes}
-        edges={viewEdges}
-        nodeTypes={nodeTypes}
-        onNodesChange={onNodesChange}
-        onNodeClick={onNodeClick}
-        onPaneClick={onPaneClick}
-        onConnect={onConnect}
-        fitView
-      >
-        <Background gap={14} size={1} color="#e2e8f0" />
-        <Controls showInteractive={false} className="bg-white border border-gray-200 rounded shadow-sm text-slate-700" />
-        <MiniMap zoomable pannable nodeColor="#cbd5e1" className="border border-gray-200 rounded shadow-sm" />
-      </ReactFlow>
-    </div>
+
+        <div className="pointer-events-none absolute bottom-4 left-4 z-10 hidden max-w-md items-center gap-2 rounded-lg border border-amber-200 bg-amber-50/95 px-3 py-2 text-[10px] leading-4 text-amber-900 shadow-sm backdrop-blur-sm md:flex">
+          <ShieldAlert className="h-4 w-4 shrink-0" aria-hidden="true" />
+          Images and 3D previews improve recognition only; unresolved package, footprint, or CAD data remains unresolved.
+        </div>
+
+        <ReactFlow
+          nodes={viewNodes}
+          edges={viewEdges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onNodeClick={onNodeClick}
+          onPaneClick={onPaneClick}
+          onConnect={onConnect}
+          fitView
+          minZoom={0.2}
+          maxZoom={1.8}
+          defaultEdgeOptions={{ type: 'smoothstep' }}
+          proOptions={{ hideAttribution: false }}
+        >
+          <Background gap={18} size={1} color="#dbe3ed" />
+          <Controls showInteractive={false} className="rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm" />
+          <MiniMap
+            zoomable
+            pannable
+            nodeColor={(node) => resolveVisualFamily(node.data as NodeData).color}
+            maskColor="rgba(241,245,249,0.72)"
+            className="rounded-lg border border-slate-200 bg-white shadow-sm"
+          />
+        </ReactFlow>
+
+        <RepresentationInspector
+          key={`${inspectedNode?.name ?? 'none'}:${isInspectorOpen ? 'open' : 'closed'}`}
+          nodeData={inspectedNode}
+          open={isInspectorOpen}
+          onOpenChange={setIsInspectorOpen}
+        />
+      </div>
+    </RepresentationInspectorContext.Provider>
   );
 };
 
-export const BlueprintCanvas: React.FC = () => {
-  return (
-    <div className="flex-1 h-full min-h-0 bg-slate-50 flex flex-col relative overflow-hidden">
-      <ReactFlowProvider>
-        <BlueprintCanvasContent />
-      </ReactFlowProvider>
-    </div>
-  );
-};
+export const BlueprintCanvas: React.FC = () => (
+  <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-slate-50">
+    <ReactFlowProvider>
+      <BlueprintCanvasContent />
+    </ReactFlowProvider>
+  </div>
+);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,7 +35,9 @@ import {
   navigationDomains,
   NavigationIconKey,
 } from '../lib/navigationRegistry';
+import { getVisualFamily, resolveVisualFamilyId } from '../lib/visual/representationRegistry';
 import { useProjectStore } from '../store/projectStore';
+import { ArchitectureGlyph } from './visual/DeviceVisual';
 
 interface SidebarProps {
   onAddBlock?: (item: BlockLibraryItem) => void;
@@ -85,10 +87,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
   const isCanvasView = isCanvasNavigationItem(activeNavigationItem);
 
   const toggleCategory = (category: string) => {
-    setExpandedCategories((previous) => ({
-      ...previous,
-      [category]: !previous[category],
-    }));
+    setExpandedCategories((previous) => ({ ...previous, [category]: !previous[category] }));
   };
 
   const handleAddBlock = (item: BlockLibraryItem) => {
@@ -124,14 +123,12 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
 
   return (
     <aside className="z-20 flex h-full w-[272px] shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white shadow-sm">
-      <div className="max-h-[72vh] shrink-0 overflow-y-auto border-b border-slate-100 px-3 py-3 select-none">
+      <div className="max-h-[72vh] shrink-0 select-none overflow-y-auto border-b border-slate-100 px-3 py-3">
         <nav className="space-y-4" aria-label="Engineering workbenches">
           {navigationDomains.map((domain) => (
             <section key={domain.id} aria-labelledby={`nav-${domain.id}`}>
               <div className="mb-1.5 px-2">
-                <h2 id={`nav-${domain.id}`} className="text-[9px] font-extrabold uppercase tracking-[0.16em] text-slate-500">
-                  {domain.label}
-                </h2>
+                <h2 id={`nav-${domain.id}`} className="text-[9px] font-extrabold uppercase tracking-[0.16em] text-slate-500">{domain.label}</h2>
                 <p className="mt-0.5 text-[9px] leading-4 text-slate-400">{domain.purpose}</p>
               </div>
 
@@ -139,39 +136,21 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
                 {domain.items.map((item) => {
                   const Icon = iconByKey[item.icon];
                   const isActive = activeView === item.id;
-
                   return (
                     <button
                       key={item.id}
                       type="button"
                       onClick={() => setActiveView(item.id)}
                       aria-current={isActive ? 'page' : undefined}
-                      className={`group flex w-full items-start gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1 ${
-                        isActive
-                          ? 'border-slate-950 bg-slate-900 text-white shadow-sm'
-                          : 'border-transparent text-slate-700 hover:border-slate-200 hover:bg-slate-50 hover:text-slate-950'
-                      }`}
+                      className={`group flex w-full items-start gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1 ${isActive ? 'border-slate-950 bg-slate-900 text-white shadow-sm' : 'border-transparent text-slate-700 hover:border-slate-200 hover:bg-slate-50 hover:text-slate-950'}`}
                     >
-                      <Icon
-                        className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${
-                          isActive ? 'text-emerald-300' : 'text-slate-400 group-hover:text-slate-600'
-                        }`}
-                        aria-hidden="true"
-                      />
+                      <Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${isActive ? 'text-emerald-300' : 'text-slate-400 group-hover:text-slate-600'}`} aria-hidden="true" />
                       <span className="min-w-0 flex-1">
                         <span className="flex items-center justify-between gap-2">
                           <span className="truncate text-[11px] font-semibold leading-4">{item.label}</span>
-                          <span
-                            className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[7px] font-bold uppercase tracking-[0.08em] ${
-                              isActive ? 'bg-slate-800 text-slate-300' : 'bg-slate-100 text-slate-500'
-                            }`}
-                          >
-                            {item.badge}
-                          </span>
+                          <span className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[7px] font-bold uppercase tracking-[0.08em] ${isActive ? 'bg-slate-800 text-slate-300' : 'bg-slate-100 text-slate-500'}`}>{item.badge}</span>
                         </span>
-                        <span className={`mt-0.5 block text-[9px] leading-4 ${isActive ? 'text-slate-300' : 'text-slate-450'}`}>
-                          {item.purpose}
-                        </span>
+                        <span className={`mt-0.5 block text-[9px] leading-4 ${isActive ? 'text-slate-300' : 'text-slate-450'}`}>{item.purpose}</span>
                       </span>
                     </button>
                   );
@@ -185,17 +164,17 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
       <div className="min-h-0 flex-1 overflow-y-auto bg-slate-50/60">
         {isCanvasView ? (
           <div className="p-3">
-            <div className="mb-2.5 flex items-center justify-between px-0.5">
-              <h2 className="text-[9px] font-bold uppercase tracking-[0.16em] text-slate-500">Block Library</h2>
-              <span className="rounded bg-slate-200/70 px-1.5 py-0.5 text-[7px] font-bold uppercase tracking-[0.08em] text-slate-500">
-                Drag or click
-              </span>
+            <div className="mb-2.5 px-0.5">
+              <div className="flex items-center justify-between gap-2">
+                <h2 className="text-[9px] font-bold uppercase tracking-[0.16em] text-slate-500">Device & function library</h2>
+                <span className="rounded bg-slate-200/70 px-1.5 py-0.5 text-[7px] font-bold uppercase tracking-[0.08em] text-slate-500">Drag or click</span>
+              </div>
+              <p className="mt-1 text-[9px] leading-4 text-slate-400">Architecture visuals communicate purpose and interfaces. Exact symbols, footprints, and CAD remain separate.</p>
             </div>
 
             <div className="space-y-1.5">
               {Object.entries(blockLibrary).map(([category, items]) => {
                 const isExpanded = Boolean(expandedCategories[category]);
-
                 return (
                   <div key={category} className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
                     <button
@@ -205,33 +184,40 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
                       aria-expanded={isExpanded}
                     >
                       <span className="text-[9px] font-extrabold uppercase tracking-[0.12em] text-slate-700">{category}</span>
-                      {isExpanded ? (
-                        <ChevronDown className="h-3.5 w-3.5 text-slate-500" aria-hidden="true" />
-                      ) : (
-                        <ChevronRight className="h-3.5 w-3.5 text-slate-500" aria-hidden="true" />
-                      )}
+                      {isExpanded ? <ChevronDown className="h-3.5 w-3.5 text-slate-500" aria-hidden="true" /> : <ChevronRight className="h-3.5 w-3.5 text-slate-500" aria-hidden="true" />}
                     </button>
 
                     {isExpanded && (
-                      <div className="space-y-1 p-1.5">
-                        {items.map((libraryItem, index) => (
-                          <div
-                            key={`${libraryItem.name}-${index}`}
-                            draggable
-                            onDragStart={(event) => handleDragStart(event, libraryItem)}
-                            onClick={() => handleAddBlock(libraryItem)}
-                            className="group flex cursor-grab items-center justify-between rounded-md border border-slate-100 p-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-950"
-                            title={`${libraryItem.name}: ${libraryItem.description}`}
-                          >
-                            <div className="min-w-0 pr-1">
-                              <div className="truncate text-[10px] font-bold leading-tight text-slate-800">{libraryItem.name}</div>
-                              <div className="mt-1 line-clamp-2 text-[9px] leading-4 text-slate-500">{libraryItem.description}</div>
+                      <div className="space-y-1.5 p-1.5">
+                        {items.map((libraryItem, index) => {
+                          const familyId = resolveVisualFamilyId(libraryItem);
+                          const family = getVisualFamily(familyId);
+                          return (
+                            <div
+                              key={`${libraryItem.name}-${index}`}
+                              draggable
+                              onDragStart={(event) => handleDragStart(event, libraryItem)}
+                              onClick={() => handleAddBlock(libraryItem)}
+                              className="group flex cursor-grab items-center gap-2.5 rounded-xl border border-slate-100 bg-white p-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-950 focus-within:ring-2 focus-within:ring-indigo-500"
+                              title={`${libraryItem.name}: ${libraryItem.description}`}
+                            >
+                              <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-white shadow-sm" style={{ backgroundColor: family.accent, color: family.color }}>
+                                <ArchitectureGlyph familyId={familyId} className="h-7 w-7" />
+                              </span>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-start justify-between gap-2">
+                                  <div className="truncate text-[10px] font-bold leading-tight text-slate-800">{libraryItem.name}</div>
+                                  <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[7px] font-bold uppercase tracking-wide text-slate-500">{family.shortLabel}</span>
+                                </div>
+                                <div className="mt-1 line-clamp-2 text-[9px] leading-4 text-slate-500">{libraryItem.description}</div>
+                                <div className="mt-1.5 flex flex-wrap gap-1">
+                                  {family.ports.slice(0, 3).map((port) => <span key={port.id} className="rounded-full border border-slate-200 bg-white px-1.5 py-0.5 text-[7px] font-bold uppercase text-slate-500">{port.kind}</span>)}
+                                </div>
+                              </div>
+                              <span className="grid h-6 w-6 shrink-0 place-items-center rounded-lg bg-slate-900 text-white opacity-0 transition-opacity group-hover:opacity-100"><Plus className="h-3.5 w-3.5" aria-hidden="true" /></span>
                             </div>
-                            <span className="grid h-5 w-5 shrink-0 place-items-center rounded bg-slate-900 text-white opacity-0 transition-opacity group-hover:opacity-100">
-                              <Plus className="h-3 w-3" aria-hidden="true" />
-                            </span>
-                          </div>
-                        ))}
+                          );
+                        })}
                       </div>
                     )}
                   </div>
@@ -243,9 +229,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
           <div className="flex h-full flex-col items-center justify-center p-5 text-center text-slate-400">
             <Table className="mb-2 h-7 w-7 text-slate-300" aria-hidden="true" />
             <p className="text-[9px] font-bold uppercase tracking-[0.12em] text-slate-500">Work area active</p>
-            <p className="mt-1 max-w-[190px] text-[10px] leading-5 text-slate-500">
-              The block library appears only in the System Blueprint canvas, where blocks can be placed and connected.
-            </p>
+            <p className="mt-1 max-w-[190px] text-[10px] leading-5 text-slate-500">The semantic device library appears only in System Blueprint, where architecture functions and interfaces can be arranged.</p>
           </div>
         )}
       </div>

--- a/src/components/visual/DeviceVisual.tsx
+++ b/src/components/visual/DeviceVisual.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import React, { Suspense, lazy } from 'react';
+import {
+  Box,
+  CameraOff,
+  CircleHelp,
+  FileWarning,
+  ImageOff,
+  Layers3,
+} from 'lucide-react';
+import {
+  getVisualFamily,
+  RepresentationKind,
+  VisualFamilyId,
+} from '../../lib/visual/representationRegistry';
+import type { VisualQualityProfile } from './Lightweight3DPreview';
+
+const LazyLightweight3DPreview = lazy(() =>
+  import('./Lightweight3DPreview').then((module) => ({ default: module.Lightweight3DPreview })),
+);
+
+interface DeviceVisualProps {
+  familyId: VisualFamilyId;
+  kind: RepresentationKind;
+  className?: string;
+  quality?: VisualQualityProfile;
+  compact?: boolean;
+}
+
+interface ArchitectureGlyphProps {
+  familyId: VisualFamilyId;
+  className?: string;
+  title?: string;
+}
+
+const commonStroke = {
+  stroke: 'currentColor',
+  strokeWidth: 2.4,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  fill: 'none',
+};
+
+export const ArchitectureGlyph: React.FC<ArchitectureGlyphProps> = ({ familyId, className = '', title }) => {
+  const family = getVisualFamily(familyId);
+  const glyph = (() => {
+    switch (familyId) {
+      case 'resistor':
+        return <><path d="M5 32h10l5-9 8 18 8-18 8 18 5-9h10" {...commonStroke} /><circle cx="5" cy="32" r="2" fill="currentColor" /><circle cx="59" cy="32" r="2" fill="currentColor" /></>;
+      case 'capacitor':
+        return <><path d="M7 32h18M39 32h18M25 18v28M39 18v28" {...commonStroke} /></>;
+      case 'led':
+        return <><path d="M10 32h14M40 32h14M24 18v28l16-14-16-14Z" {...commonStroke} /><path d="m40 17 8-8m-3 12 8-8" {...commonStroke} /><path d="m46 9 2 7-7-2m6-1 2 7-7-2" {...commonStroke} /></>;
+      case 'push-button':
+        return <><path d="M8 40h16m16 0h16M24 40l16-12M20 18h24M32 18v8" {...commonStroke} /><circle cx="24" cy="40" r="2.5" fill="currentColor" /><circle cx="40" cy="40" r="2.5" fill="currentColor" /></>;
+      case 'microcontroller':
+        return <><rect x="15" y="15" width="34" height="34" rx="4" {...commonStroke} /><rect x="24" y="24" width="16" height="16" rx="2" {...commonStroke} />{[20,28,36,44].map((v) => <React.Fragment key={v}><path d={`M${v} 8v7M${v} 49v7M8 ${v}h7M49 ${v}h7`} {...commonStroke} /></React.Fragment>)}</>;
+      case 'sensor':
+        return <><rect x="11" y="16" width="42" height="32" rx="7" {...commonStroke} /><circle cx="32" cy="32" r="8" {...commonStroke} /><path d="M32 24v16m-8-8h16M6 25h5m-5 14h5m42-14h5m-5 14h5" {...commonStroke} /></>;
+      case 'voltage-regulator':
+        return <><path d="M7 32h12m26 0h12" {...commonStroke} /><rect x="19" y="18" width="26" height="28" rx="4" {...commonStroke} /><path d="M25 35c4-10 10 10 14 0M32 12v6m0 28v6" {...commonStroke} /></>;
+      case 'battery':
+        return <><rect x="10" y="18" width="44" height="30" rx="5" {...commonStroke} /><path d="M54 27h5v12h-5M22 25v16m-8-8h16M38 33h10" {...commonStroke} /></>;
+      case 'usb-c':
+        return <><rect x="7" y="18" width="50" height="28" rx="12" {...commonStroke} /><rect x="15" y="24" width="34" height="16" rx="7" {...commonStroke} /><path d="M23 29v6m6-6v6m6-6v6m6-6v6" {...commonStroke} /></>;
+      case 'motor-actuator':
+        return <><circle cx="29" cy="32" r="18" {...commonStroke} /><path d="M47 32h11M11 32H6M21 40l16-16m-14 0 14 16" {...commonStroke} /><circle cx="29" cy="32" r="4" fill="currentColor" /></>;
+      case 'display':
+        return <><rect x="8" y="12" width="48" height="36" rx="5" {...commonStroke} /><path d="M17 22h30M17 30h21M17 38h26M25 54h14" {...commonStroke} /></>;
+      case 'debug-connector':
+        return <><rect x="10" y="16" width="44" height="32" rx="4" {...commonStroke} />{[20,28,36,44].map((x) => <React.Fragment key={x}><circle cx={x} cy="26" r="2.4" fill="currentColor" /><circle cx={x} cy="38" r="2.4" fill="currentColor" /></React.Fragment>)}<path d="M32 8v8m0 32v8" {...commonStroke} /></>;
+      case 'protection-device':
+        return <><path d="M32 7 52 15v15c0 13-8 22-20 27C20 52 12 43 12 30V15L32 7Z" {...commonStroke} /><path d="m23 32 6 6 13-15" {...commonStroke} /></>;
+      case 'enclosure':
+        return <><path d="m10 20 22-12 22 12v26L32 57 10 46V20Z" {...commonStroke} /><path d="m10 20 22 12 22-12M32 32v25" {...commonStroke} /></>;
+      case 'pcb-assembly':
+        return <><rect x="7" y="12" width="50" height="40" rx="5" {...commonStroke} /><rect x="22" y="22" width="19" height="16" rx="2" {...commonStroke} /><circle cx="14" cy="19" r="2" fill="currentColor" /><circle cx="50" cy="19" r="2" fill="currentColor" /><circle cx="14" cy="45" r="2" fill="currentColor" /><circle cx="50" cy="45" r="2" fill="currentColor" /><path d="M7 31h15m19 0h16M31 12v10m0 16v14" {...commonStroke} /></>;
+      case 'firmware-state':
+        return <><circle cx="24" cy="32" r="13" {...commonStroke} /><circle cx="50" cy="18" r="7" {...commonStroke} /><circle cx="50" cy="46" r="7" {...commonStroke} /><path d="M37 28 45 21m-8 15 8 7M24 19v-8m0 42v-8" {...commonStroke} /></>;
+      case 'software-service':
+        return <><path d="M16 43a12 12 0 0 1 2-24 16 16 0 0 1 29 5 10 10 0 0 1 0 20H16Z" {...commonStroke} /><path d="M23 32h18m-12-7-6 7 6 7m6-14 6 7-6 7" {...commonStroke} /></>;
+      case 'validation':
+        return <><path d="M18 8h28v48H18z" {...commonStroke} /><path d="M25 22h14M25 31h14M25 40h8m5 2 4 4 8-10" {...commonStroke} /><path d="M25 8v8h14V8" {...commonStroke} /></>;
+      case 'product-system':
+        return <><circle cx="32" cy="32" r="23" {...commonStroke} /><circle cx="32" cy="32" r="8" {...commonStroke} /><path d="M32 9v15m0 16v15M9 32h15m16 0h15M16 16l10 10m12 12 10 10m0-32L38 26M26 38 16 48" {...commonStroke} /></>;
+      default:
+        return <><rect x="10" y="14" width="44" height="36" rx="7" {...commonStroke} /><path d="M18 32h28M32 20v24" {...commonStroke} /></>;
+    }
+  })();
+
+  return (
+    <svg viewBox="0 0 64 64" className={className} role="img" aria-label={title ?? family.label}>
+      {glyph}
+    </svg>
+  );
+};
+
+function SchematicVisual({ familyId }: { familyId: VisualFamilyId }) {
+  const family = getVisualFamily(familyId);
+  const terminals = family.ports.slice(0, 6);
+
+  if (family.representations.schematic.status === 'unavailable') {
+    return <UnavailableVisual icon={FileWarning} title="No schematic symbol" detail={family.representations.schematic.description} />;
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-300 bg-[#fffdf7] p-4">
+      <svg viewBox="0 0 520 280" className="h-auto w-full" role="img" aria-label={`${family.label} schematic-symbol preview`}>
+        <defs><pattern id={`grid-${familyId}`} width="20" height="20" patternUnits="userSpaceOnUse"><path d="M20 0H0V20" fill="none" stroke="#e2e8f0" strokeWidth="1" /></pattern></defs>
+        <rect width="520" height="280" fill={`url(#grid-${familyId})`} />
+        <g transform="translate(190 60)" stroke="#0f172a" fill="white" strokeWidth="3">
+          {familyId === 'resistor' ? (
+            <><path d="M-120 80h50l12-24 20 48 20-48 20 48 20-48 12 24h50" fill="none" /><circle cx="-120" cy="80" r="4" fill="#0f172a" /><circle cx="84" cy="80" r="4" fill="#0f172a" /></>
+          ) : familyId === 'capacitor' ? (
+            <><path d="M-100 80h75m50 0h75M-25 35v90M25 35v90" fill="none" /></>
+          ) : familyId === 'led' ? (
+            <><path d="M-100 80h65m70 0h65M-35 30v100L35 80-35 30Z" /><path d="m42 44 35-35m-14 48 35-35" fill="none" /><path d="m77 9 1 22-22-1m42-8 1 22-22-1" fill="none" /></>
+          ) : (
+            <>
+              <rect x="-10" y="0" width="180" height="160" rx="4" />
+              <text x="80" y="76" textAnchor="middle" fill="#0f172a" stroke="none" fontSize="18" fontWeight="700">{family.shortLabel}</text>
+              <text x="80" y="100" textAnchor="middle" fill="#64748b" stroke="none" fontSize="11">family preview</text>
+              {terminals.map((terminal, index) => {
+                const left = terminal.direction === 'input' || (terminal.direction === 'bidirectional' && index % 2 === 0);
+                const y = 24 + index * 23;
+                return <g key={terminal.id}><path d={left ? `M-60 ${y}H-10` : `M170 ${y}h50`} fill="none" /><circle cx={left ? -60 : 220} cy={y} r="3" fill="#0f172a" /><text x={left ? -66 : 226} y={y + 4} textAnchor={left ? 'end' : 'start'} fill="#334155" stroke="none" fontSize="10">{terminal.label}</text></g>;
+              })}
+            </>
+          )}
+        </g>
+        <text x="20" y="255" fill="#64748b" fontSize="12">Vector convention preview · exact pins require a selected component revision</text>
+      </svg>
+    </div>
+  );
+}
+
+function PictorialVisual({ familyId }: { familyId: VisualFamilyId }) {
+  const family = getVisualFamily(familyId);
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-gradient-to-br from-white to-slate-100 p-5">
+      <svg viewBox="0 0 520 280" className="h-auto w-full" role="img" aria-label={`${family.label} educational illustration`}>
+        <defs>
+          <linearGradient id={`surface-${familyId}`} x1="0" x2="1" y1="0" y2="1"><stop stopColor={family.accent} /><stop offset="1" stopColor="#ffffff" /></linearGradient>
+          <filter id={`shadow-${familyId}`} x="-30%" y="-30%" width="160%" height="160%"><feDropShadow dx="0" dy="10" stdDeviation="12" floodColor="#0f172a" floodOpacity="0.16" /></filter>
+        </defs>
+        <rect x="15" y="15" width="490" height="250" rx="26" fill={`url(#surface-${familyId})`} />
+        <g transform="translate(44 35)">
+          <rect x="0" y="0" width="210" height="210" rx="30" fill="white" opacity="0.92" filter={`url(#shadow-${familyId})`} />
+          <g transform="translate(45 45)" style={{ color: family.color }}><ArchitectureGlyph familyId={familyId} className="h-[120px] w-[120px]" /></g>
+        </g>
+        <g transform="translate(290 68)">
+          <text x="0" y="0" fill={family.color} fontSize="14" fontWeight="800" letterSpacing="2">{family.shortLabel}</text>
+          <text x="0" y="34" fill="#0f172a" fontSize="28" fontWeight="800">{family.label}</text>
+          <foreignObject x="0" y="52" width="185" height="84"><div className="text-[14px] leading-6 text-slate-600">{family.description}</div></foreignObject>
+          <g transform="translate(0 150)">{family.ports.slice(0, 3).map((entry, index) => <g key={entry.id} transform={`translate(0 ${index * 25})`}><circle cx="6" cy="-4" r="5" fill={family.color} /><text x="20" y="0" fill="#475569" fontSize="12" fontWeight="600">{entry.label}</text></g>)}</g>
+        </g>
+      </svg>
+      <p className="mt-3 text-xs leading-5 text-slate-500">Internally authored recognition graphic. It teaches the family but does not define exact dimensions, package, pinout, or manufacturer appearance.</p>
+    </div>
+  );
+}
+
+function FootprintVisual({ familyId }: { familyId: VisualFamilyId }) {
+  const family = getVisualFamily(familyId);
+  if (family.representations.footprint.status === 'unresolved') {
+    return <UnavailableVisual icon={Layers3} title="Select a package first" detail={family.representations.footprint.description} />;
+  }
+
+  const padCount = Math.max(2, Math.min(12, family.ports.length * 2));
+  const perSide = Math.ceil(padCount / 2);
+  return (
+    <div className="rounded-xl border border-slate-700 bg-slate-950 p-4">
+      <svg viewBox="0 0 520 280" className="h-auto w-full" role="img" aria-label={`${family.label} footprint-family preview`}>
+        <rect width="520" height="280" rx="18" fill="#020617" />
+        <path d="M55 45H465V235H55Z" fill="none" stroke="#475569" strokeWidth="2" strokeDasharray="8 7" />
+        <rect x="155" y="70" width="210" height="140" rx="8" fill="none" stroke="#facc15" strokeWidth="3" />
+        <circle cx="143" cy="84" r="6" fill="#facc15" />
+        {Array.from({ length: perSide }).map((_, index) => {
+          const y = 90 + (100 * index) / Math.max(1, perSide - 1);
+          return <React.Fragment key={index}><rect x="105" y={y - 8} width="70" height="16" rx="4" fill="#cbd5e1" /><rect x="345" y={y - 8} width="70" height="16" rx="4" fill="#cbd5e1" /><text x="140" y={y + 4} textAnchor="middle" fill="#0f172a" fontSize="10" fontWeight="800">{index + 1}</text><text x="380" y={y + 4} textAnchor="middle" fill="#0f172a" fontSize="10" fontWeight="800">{index + perSide + 1}</text></React.Fragment>;
+        })}
+        <text x="260" y="135" textAnchor="middle" fill="#e2e8f0" fontSize="18" fontWeight="800">{family.shortLabel}</text>
+        <text x="260" y="158" textAnchor="middle" fill="#94a3b8" fontSize="11">package-family preview</text>
+        <text x="24" y="260" fill="#94a3b8" fontSize="12">Exact pads, drills, mask, paste, courtyard, origin, and orientation require the selected footprint revision.</text>
+      </svg>
+    </div>
+  );
+}
+
+function PackageVisual({ familyId }: { familyId: VisualFamilyId }) {
+  const family = getVisualFamily(familyId);
+  if (family.representations.package.status === 'unavailable') {
+    return <UnavailableVisual icon={Box} title="No physical package" detail={family.representations.package.description} />;
+  }
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+      <div className="grid gap-5 md:grid-cols-[220px_minmax(0,1fr)] md:items-center">
+        <svg viewBox="0 0 220 180" className="w-full" role="img" aria-label={`${family.label} unresolved package envelope`}>
+          <path d="m35 55 75-38 75 38v78l-75 34-75-34V55Z" fill="white" stroke="#b45309" strokeWidth="2.5" strokeDasharray="7 6" />
+          <path d="m35 55 75 39 75-39M110 94v73" fill="none" stroke="#d97706" strokeWidth="2" strokeDasharray="5 5" />
+          <path d="M24 31h172M24 150h172M28 26v129M192 26v129" fill="none" stroke="#f59e0b" strokeWidth="1.5" />
+          <text x="110" y="111" textAnchor="middle" fill="#92400e" fontSize="18" fontWeight="800">?</text>
+        </svg>
+        <div>
+          <p className="text-sm font-bold text-amber-950">Exact package geometry is unresolved</p>
+          <p className="mt-2 text-sm leading-6 text-amber-900">{family.representations.package.description}</p>
+          <div className="mt-4 grid grid-cols-2 gap-2 text-xs text-amber-900">
+            {['Width', 'Length', 'Height', 'Origin', 'Tolerance', 'Mounting'].map((entry) => <span key={entry} className="rounded-lg border border-amber-200 bg-white/70 px-2.5 py-2"><strong>{entry}:</strong> missing</span>)}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface UnavailableVisualProps {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  detail: string;
+}
+
+function UnavailableVisual({ icon: Icon, title, detail }: UnavailableVisualProps) {
+  return (
+    <div className="grid min-h-[240px] place-items-center rounded-xl border border-dashed border-slate-300 bg-slate-50 p-6 text-center">
+      <div>
+        <span className="mx-auto grid h-12 w-12 place-items-center rounded-xl border border-slate-200 bg-white text-slate-500"><Icon className="h-5 w-5" /></span>
+        <p className="mt-3 text-sm font-bold text-slate-800">{title}</p>
+        <p className="mx-auto mt-1 max-w-md text-xs leading-5 text-slate-500">{detail}</p>
+      </div>
+    </div>
+  );
+}
+
+export const DeviceVisual: React.FC<DeviceVisualProps> = ({ familyId, kind, className = '', quality = 'balanced', compact = false }) => {
+  const family = getVisualFamily(familyId);
+  const availability = family.representations[kind];
+
+  if (kind === 'architecture') {
+    return (
+      <div className={`grid place-items-center rounded-xl border border-slate-200 ${compact ? 'h-12 w-12' : 'min-h-[240px]'} ${className}`} style={{ backgroundColor: family.accent, color: family.color }}>
+        <ArchitectureGlyph familyId={familyId} className={compact ? 'h-8 w-8' : 'h-32 w-32'} />
+      </div>
+    );
+  }
+  if (kind === 'schematic') return <div className={className}><SchematicVisual familyId={familyId} /></div>;
+  if (kind === 'pictorial') return <div className={className}><PictorialVisual familyId={familyId} /></div>;
+  if (kind === 'footprint') return <div className={className}><FootprintVisual familyId={familyId} /></div>;
+  if (kind === 'package') return <div className={className}><PackageVisual familyId={familyId} /></div>;
+  if (kind === 'render3d') {
+    if (availability.status === 'unavailable') return <UnavailableVisual icon={CameraOff} title="3D not applicable" detail={availability.description} />;
+    return (
+      <Suspense fallback={<div className="grid min-h-[260px] place-items-center rounded-xl border border-slate-700 bg-slate-950 text-xs font-semibold text-slate-300">Loading lightweight 3D only when requested…</div>}>
+        <LazyLightweight3DPreview familyId={familyId} quality={quality} className={className} />
+      </Suspense>
+    );
+  }
+  if (kind === 'exact3d') return <UnavailableVisual icon={Layers3} title={availability.label} detail={availability.description} />;
+  if (kind === 'photo') return <UnavailableVisual icon={ImageOff} title={availability.label} detail={availability.description} />;
+  return <UnavailableVisual icon={CircleHelp} title="Representation unavailable" detail={availability.description} />;
+};

--- a/src/components/visual/Lightweight3DPreview.tsx
+++ b/src/components/visual/Lightweight3DPreview.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import type { VisualFamilyId } from '../../lib/visual/representationRegistry';
+
+export type VisualQualityProfile = 'low' | 'balanced' | 'high';
+
+interface Lightweight3DPreviewProps {
+  familyId: VisualFamilyId;
+  quality?: VisualQualityProfile;
+  className?: string;
+}
+
+const qualityPixelRatio: Record<VisualQualityProfile, number> = {
+  low: 1,
+  balanced: 1.35,
+  high: 1.8,
+};
+
+function material(color: number, options: Partial<THREE.MeshStandardMaterialParameters> = {}) {
+  return new THREE.MeshStandardMaterial({ color, roughness: 0.55, metalness: 0.08, ...options });
+}
+
+function addBox(
+  group: THREE.Group,
+  size: [number, number, number],
+  position: [number, number, number],
+  color: number,
+  options?: Partial<THREE.MeshStandardMaterialParameters>,
+) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material(color, options));
+  mesh.position.set(...position);
+  group.add(mesh);
+  return mesh;
+}
+
+function addCylinder(
+  group: THREE.Group,
+  radius: number,
+  height: number,
+  position: [number, number, number],
+  color: number,
+  rotation: [number, number, number] = [0, 0, 0],
+) {
+  const mesh = new THREE.Mesh(new THREE.CylinderGeometry(radius, radius, height, 24), material(color));
+  mesh.position.set(...position);
+  mesh.rotation.set(...rotation);
+  group.add(mesh);
+  return mesh;
+}
+
+function addPins(group: THREE.Group, count: number, axis: 'x' | 'z', extent: number) {
+  const pinGeometry = new THREE.BoxGeometry(0.18, 0.12, 0.7);
+  const pinMaterial = material(0xcbd5e1, { metalness: 0.75, roughness: 0.22 });
+  const pairCount = Math.max(2, Math.ceil(count / 2));
+  for (let index = 0; index < pairCount; index += 1) {
+    const offset = pairCount === 1 ? 0 : -extent / 2 + (extent * index) / (pairCount - 1);
+    for (const side of [-1, 1]) {
+      const pin = new THREE.Mesh(pinGeometry, pinMaterial);
+      if (axis === 'x') {
+        pin.position.set(side * 2.2, 0, offset);
+        pin.rotation.y = Math.PI / 2;
+      } else {
+        pin.position.set(offset, 0, side * 2.2);
+      }
+      group.add(pin);
+    }
+  }
+}
+
+function buildFamilyModel(familyId: VisualFamilyId): THREE.Group {
+  const group = new THREE.Group();
+
+  switch (familyId) {
+    case 'resistor': {
+      addCylinder(group, 0.65, 3.2, [0, 0, 0], 0xd6a85f, [0, 0, Math.PI / 2]);
+      addCylinder(group, 0.11, 2.2, [-2.65, 0, 0], 0xb8c2cc, [0, 0, Math.PI / 2]);
+      addCylinder(group, 0.11, 2.2, [2.65, 0, 0], 0xb8c2cc, [0, 0, Math.PI / 2]);
+      [0x7c2d12, 0x111827, 0xdc2626, 0xd97706].forEach((color, index) => {
+        const band = addCylinder(group, 0.69, 0.18, [-0.75 + index * 0.5, 0, 0], color, [0, 0, Math.PI / 2]);
+        band.material = material(color, { roughness: 0.35 });
+      });
+      break;
+    }
+    case 'capacitor': {
+      addCylinder(group, 1.25, 3.1, [0, 0.4, 0], 0x1d4ed8);
+      addCylinder(group, 1.28, 0.18, [0, 1.98, 0], 0xcbd5e1);
+      addCylinder(group, 0.1, 1.8, [-0.4, -1.9, 0], 0xcbd5e1);
+      addCylinder(group, 0.1, 1.8, [0.4, -1.9, 0], 0xcbd5e1);
+      break;
+    }
+    case 'led': {
+      addCylinder(group, 1.1, 2.1, [0, 0.45, 0], 0xef4444);
+      const dome = new THREE.Mesh(new THREE.SphereGeometry(1.1, 24, 12, 0, Math.PI * 2, 0, Math.PI / 2), material(0xf87171, { transparent: true, opacity: 0.75 }));
+      dome.position.y = 1.5;
+      group.add(dome);
+      addCylinder(group, 0.09, 2.4, [-0.35, -1.75, 0], 0xcbd5e1);
+      addCylinder(group, 0.09, 2.8, [0.35, -1.95, 0], 0xcbd5e1);
+      break;
+    }
+    case 'push-button': {
+      addBox(group, [4.6, 1.5, 4.2], [0, 0, 0], 0x475569);
+      addBox(group, [2.2, 0.9, 2.2], [0, 1.2, 0], 0x94a3b8);
+      addPins(group, 4, 'x', 2.5);
+      break;
+    }
+    case 'microcontroller': {
+      addBox(group, [5.3, 0.9, 5.3], [0, 0, 0], 0x111827, { roughness: 0.38 });
+      addPins(group, 16, 'x', 4.4);
+      addPins(group, 16, 'z', 4.4);
+      addBox(group, [1.4, 0.05, 0.35], [0, 0.48, 0], 0x334155);
+      break;
+    }
+    case 'sensor': {
+      addBox(group, [6.2, 0.45, 4.2], [0, -0.25, 0], 0x047857);
+      addBox(group, [2.5, 0.75, 2.5], [0, 0.35, 0], 0x1f2937);
+      addBox(group, [0.8, 0.35, 0.8], [-2.1, 0.18, 1.15], 0xd1d5db, { metalness: 0.55 });
+      for (let index = 0; index < 4; index += 1) addCylinder(group, 0.17, 0.3, [-2.2 + index * 1.45, -0.25, 1.7], 0xd4af37, [Math.PI / 2, 0, 0]);
+      break;
+    }
+    case 'voltage-regulator': {
+      addBox(group, [4.6, 0.8, 3.6], [0, 0, 0], 0x1f2937);
+      addPins(group, 6, 'x', 2.4);
+      addBox(group, [1.7, 0.12, 1.5], [0, 0.46, 0], 0x334155);
+      break;
+    }
+    case 'battery': {
+      addBox(group, [6.4, 2.2, 4.4], [0, 0, 0], 0x94a3b8, { metalness: 0.35, roughness: 0.4 });
+      addBox(group, [0.8, 0.3, 0.8], [-1.15, 1.25, 0], 0xdc2626, { metalness: 0.6 });
+      addBox(group, [0.8, 0.3, 0.8], [1.15, 1.25, 0], 0x111827, { metalness: 0.6 });
+      break;
+    }
+    case 'usb-c': {
+      addBox(group, [6.3, 2.3, 4.6], [0, 0, 0], 0x94a3b8, { metalness: 0.8, roughness: 0.2 });
+      addBox(group, [4.9, 1.25, 3.8], [0, 0, 0.45], 0x111827);
+      addBox(group, [3.7, 0.45, 2.5], [0, 0, 1.5], 0xd1d5db, { metalness: 0.55 });
+      break;
+    }
+    case 'motor-actuator': {
+      addCylinder(group, 2.4, 2.2, [0, 0, 0], 0x64748b, [Math.PI / 2, 0, 0]);
+      addCylinder(group, 0.45, 4.2, [0, 0, 3.1], 0xcbd5e1, [Math.PI / 2, 0, 0]);
+      addBox(group, [1.1, 0.3, 0.7], [-0.75, -1.3, -0.5], 0xdc2626);
+      addBox(group, [1.1, 0.3, 0.7], [0.75, -1.3, -0.5], 0x111827);
+      break;
+    }
+    case 'display': {
+      addBox(group, [7.4, 0.75, 5.2], [0, 0, 0], 0x111827);
+      addBox(group, [6.4, 0.08, 4.2], [0, 0.43, 0], 0x0ea5e9, { emissive: 0x082f49, emissiveIntensity: 0.45 });
+      addBox(group, [3.2, 0.18, 1.1], [0, -0.48, -3.05], 0xd97706, { metalness: 0.65 });
+      break;
+    }
+    case 'debug-connector': {
+      addBox(group, [6.2, 0.45, 3.2], [0, -0.25, 0], 0x1f2937);
+      for (let row = 0; row < 2; row += 1) {
+        for (let column = 0; column < 5; column += 1) {
+          addBox(group, [0.34, 2.2, 0.34], [-2.2 + column * 1.1, 0.95, -0.65 + row * 1.3], 0xd4af37, { metalness: 0.8, roughness: 0.2 });
+        }
+      }
+      break;
+    }
+    case 'protection-device': {
+      addBox(group, [3.4, 0.7, 2.5], [0, 0, 0], 0x1f2937);
+      addPins(group, 4, 'x', 1.4);
+      addBox(group, [1.1, 0.05, 0.18], [0, 0.38, 0], 0xef4444);
+      break;
+    }
+    case 'enclosure': {
+      const outer = addBox(group, [8.5, 4.6, 6.2], [0, 0, 0], 0x64748b, { transparent: true, opacity: 0.35, side: THREE.DoubleSide });
+      outer.material.depthWrite = false;
+      const edges = new THREE.LineSegments(new THREE.EdgesGeometry(outer.geometry), new THREE.LineBasicMaterial({ color: 0xcbd5e1 }));
+      edges.position.copy(outer.position);
+      group.add(edges);
+      addBox(group, [6.7, 0.4, 4.5], [0, -1.1, 0], 0x047857);
+      break;
+    }
+    case 'pcb-assembly': {
+      addBox(group, [9.2, 0.45, 6.2], [0, -0.3, 0], 0x047857);
+      addBox(group, [3.2, 0.85, 3.2], [-1.1, 0.35, 0.3], 0x111827);
+      addBox(group, [2.3, 1.25, 1.7], [2.7, 0.55, -1.4], 0x334155);
+      addCylinder(group, 0.75, 1.3, [2.8, 0.45, 1.6], 0x1d4ed8);
+      for (const x of [-3.8, 3.8]) for (const z of [-2.3, 2.3]) addCylinder(group, 0.22, 0.55, [x, -0.3, z], 0xd4af37, [Math.PI / 2, 0, 0]);
+      break;
+    }
+    case 'product-system': {
+      const outer = addBox(group, [8, 4.8, 6], [0, 0, 0], 0x334155, { transparent: true, opacity: 0.3, side: THREE.DoubleSide });
+      outer.material.depthWrite = false;
+      addBox(group, [5.8, 0.4, 3.8], [0, -1, 0], 0x047857);
+      addBox(group, [2.4, 1, 2.4], [0, -0.2, 0], 0x111827);
+      break;
+    }
+    default:
+      addBox(group, [5.2, 2.2, 4.2], [0, 0, 0], 0x64748b);
+      break;
+  }
+
+  const bounds = new THREE.Box3().setFromObject(group);
+  const center = bounds.getCenter(new THREE.Vector3());
+  group.position.sub(center);
+  group.rotation.x = -0.2;
+  group.rotation.y = 0.45;
+  return group;
+}
+
+export const Lightweight3DPreview: React.FC<Lightweight3DPreviewProps> = ({
+  familyId,
+  quality = 'balanced',
+  className = '',
+}) => {
+  const mountRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        antialias: quality !== 'low',
+        alpha: true,
+        powerPreference: 'low-power',
+        preserveDrawingBuffer: false,
+      });
+    } catch {
+      setError('WebGL is unavailable on this device or browser session.');
+      return;
+    }
+
+    setError(null);
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 100);
+    camera.position.set(10, 8, 12);
+    camera.lookAt(0, 0, 0);
+
+    renderer.setClearColor(0x0f172a, 0);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, qualityPixelRatio[quality]));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.domElement.setAttribute('aria-label', 'Interactive visualization-only 3D family preview');
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
+    renderer.domElement.style.display = 'block';
+    mount.replaceChildren(renderer.domElement);
+
+    scene.add(new THREE.HemisphereLight(0xf8fafc, 0x1e293b, 2.2));
+    const keyLight = new THREE.DirectionalLight(0xffffff, 3.1);
+    keyLight.position.set(8, 12, 10);
+    scene.add(keyLight);
+    const fillLight = new THREE.DirectionalLight(0x93c5fd, 1.3);
+    fillLight.position.set(-10, 5, -6);
+    scene.add(fillLight);
+
+    const model = buildFamilyModel(familyId);
+    scene.add(model);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = false;
+    controls.enablePan = false;
+    controls.minDistance = 7;
+    controls.maxDistance = 28;
+    controls.autoRotate = false;
+    controls.target.set(0, 0, 0);
+
+    let animationFrame: number | null = null;
+    let isVisible = true;
+
+    const render = () => {
+      animationFrame = null;
+      if (!isVisible) return;
+      renderer.render(scene, camera);
+    };
+
+    const scheduleRender = () => {
+      if (animationFrame !== null) return;
+      animationFrame = window.requestAnimationFrame(render);
+    };
+
+    controls.addEventListener('change', scheduleRender);
+
+    const resize = () => {
+      const width = Math.max(1, mount.clientWidth);
+      const height = Math.max(1, mount.clientHeight);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height, false);
+      scheduleRender();
+    };
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(mount);
+
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      isVisible = entries[0]?.isIntersecting ?? true;
+      if (isVisible) scheduleRender();
+    });
+    intersectionObserver.observe(mount);
+
+    resize();
+    scheduleRender();
+
+    return () => {
+      if (animationFrame !== null) window.cancelAnimationFrame(animationFrame);
+      controls.removeEventListener('change', scheduleRender);
+      controls.dispose();
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      scene.traverse((object) => {
+        if (!(object instanceof THREE.Mesh)) return;
+        object.geometry.dispose();
+        const materials = Array.isArray(object.material) ? object.material : [object.material];
+        materials.forEach((entry) => entry.dispose());
+      });
+      renderer.dispose();
+      renderer.forceContextLoss();
+      renderer.domElement.remove();
+    };
+  }, [familyId, quality]);
+
+  return (
+    <div className={`relative min-h-[260px] overflow-hidden rounded-xl border border-slate-700 bg-slate-950 ${className}`}>
+      <div ref={mountRef} className="absolute inset-0" />
+      {error && (
+        <div className="absolute inset-0 grid place-items-center p-6 text-center text-sm text-slate-300">
+          {error}
+        </div>
+      )}
+      <div className="pointer-events-none absolute bottom-2 left-2 rounded-md border border-slate-700 bg-slate-950/85 px-2 py-1 text-[10px] font-semibold text-slate-300 backdrop-blur-sm">
+        Visualization only · drag to orbit · wheel to zoom · no continuous animation
+      </div>
+    </div>
+  );
+};

--- a/src/components/visual/Lightweight3DPreview.tsx
+++ b/src/components/visual/Lightweight3DPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import type { VisualFamilyId } from '../../lib/visual/representationRegistry';
@@ -93,7 +93,10 @@ function buildFamilyModel(familyId: VisualFamilyId): THREE.Group {
     }
     case 'led': {
       addCylinder(group, 1.1, 2.1, [0, 0.45, 0], 0xef4444);
-      const dome = new THREE.Mesh(new THREE.SphereGeometry(1.1, 24, 12, 0, Math.PI * 2, 0, Math.PI / 2), material(0xf87171, { transparent: true, opacity: 0.75 }));
+      const dome = new THREE.Mesh(
+        new THREE.SphereGeometry(1.1, 24, 12, 0, Math.PI * 2, 0, Math.PI / 2),
+        material(0xf87171, { transparent: true, opacity: 0.75 }),
+      );
       dome.position.y = 1.5;
       group.add(dome);
       addCylinder(group, 0.09, 2.4, [-0.35, -1.75, 0], 0xcbd5e1);
@@ -117,7 +120,9 @@ function buildFamilyModel(familyId: VisualFamilyId): THREE.Group {
       addBox(group, [6.2, 0.45, 4.2], [0, -0.25, 0], 0x047857);
       addBox(group, [2.5, 0.75, 2.5], [0, 0.35, 0], 0x1f2937);
       addBox(group, [0.8, 0.35, 0.8], [-2.1, 0.18, 1.15], 0xd1d5db, { metalness: 0.55 });
-      for (let index = 0; index < 4; index += 1) addCylinder(group, 0.17, 0.3, [-2.2 + index * 1.45, -0.25, 1.7], 0xd4af37, [Math.PI / 2, 0, 0]);
+      for (let index = 0; index < 4; index += 1) {
+        addCylinder(group, 0.17, 0.3, [-2.2 + index * 1.45, -0.25, 1.7], 0xd4af37, [Math.PI / 2, 0, 0]);
+      }
       break;
     }
     case 'voltage-regulator': {
@@ -167,9 +172,16 @@ function buildFamilyModel(familyId: VisualFamilyId): THREE.Group {
       break;
     }
     case 'enclosure': {
-      const outer = addBox(group, [8.5, 4.6, 6.2], [0, 0, 0], 0x64748b, { transparent: true, opacity: 0.35, side: THREE.DoubleSide });
+      const outer = addBox(group, [8.5, 4.6, 6.2], [0, 0, 0], 0x64748b, {
+        transparent: true,
+        opacity: 0.35,
+        side: THREE.DoubleSide,
+      });
       outer.material.depthWrite = false;
-      const edges = new THREE.LineSegments(new THREE.EdgesGeometry(outer.geometry), new THREE.LineBasicMaterial({ color: 0xcbd5e1 }));
+      const edges = new THREE.LineSegments(
+        new THREE.EdgesGeometry(outer.geometry),
+        new THREE.LineBasicMaterial({ color: 0xcbd5e1 }),
+      );
       edges.position.copy(outer.position);
       group.add(edges);
       addBox(group, [6.7, 0.4, 4.5], [0, -1.1, 0], 0x047857);
@@ -180,11 +192,19 @@ function buildFamilyModel(familyId: VisualFamilyId): THREE.Group {
       addBox(group, [3.2, 0.85, 3.2], [-1.1, 0.35, 0.3], 0x111827);
       addBox(group, [2.3, 1.25, 1.7], [2.7, 0.55, -1.4], 0x334155);
       addCylinder(group, 0.75, 1.3, [2.8, 0.45, 1.6], 0x1d4ed8);
-      for (const x of [-3.8, 3.8]) for (const z of [-2.3, 2.3]) addCylinder(group, 0.22, 0.55, [x, -0.3, z], 0xd4af37, [Math.PI / 2, 0, 0]);
+      for (const x of [-3.8, 3.8]) {
+        for (const z of [-2.3, 2.3]) {
+          addCylinder(group, 0.22, 0.55, [x, -0.3, z], 0xd4af37, [Math.PI / 2, 0, 0]);
+        }
+      }
       break;
     }
     case 'product-system': {
-      const outer = addBox(group, [8, 4.8, 6], [0, 0, 0], 0x334155, { transparent: true, opacity: 0.3, side: THREE.DoubleSide });
+      const outer = addBox(group, [8, 4.8, 6], [0, 0, 0], 0x334155, {
+        transparent: true,
+        opacity: 0.3,
+        side: THREE.DoubleSide,
+      });
       outer.material.depthWrite = false;
       addBox(group, [5.8, 0.4, 3.8], [0, -1, 0], 0x047857);
       addBox(group, [2.4, 1, 2.4], [0, -0.2, 0], 0x111827);
@@ -203,13 +223,19 @@ function buildFamilyModel(familyId: VisualFamilyId): THREE.Group {
   return group;
 }
 
+function renderWebGLUnavailable(mount: HTMLDivElement) {
+  const message = document.createElement('div');
+  message.className = 'absolute inset-0 grid place-items-center p-6 text-center text-sm text-slate-300';
+  message.textContent = 'WebGL is unavailable on this device or browser session.';
+  mount.replaceChildren(message);
+}
+
 export const Lightweight3DPreview: React.FC<Lightweight3DPreviewProps> = ({
   familyId,
   quality = 'balanced',
   className = '',
 }) => {
   const mountRef = useRef<HTMLDivElement>(null);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -224,11 +250,10 @@ export const Lightweight3DPreview: React.FC<Lightweight3DPreviewProps> = ({
         preserveDrawingBuffer: false,
       });
     } catch {
-      setError('WebGL is unavailable on this device or browser session.');
+      renderWebGLUnavailable(mount);
       return;
     }
 
-    setError(null);
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 100);
     camera.position.set(10, 8, 12);
@@ -320,11 +345,6 @@ export const Lightweight3DPreview: React.FC<Lightweight3DPreviewProps> = ({
   return (
     <div className={`relative min-h-[260px] overflow-hidden rounded-xl border border-slate-700 bg-slate-950 ${className}`}>
       <div ref={mountRef} className="absolute inset-0" />
-      {error && (
-        <div className="absolute inset-0 grid place-items-center p-6 text-center text-sm text-slate-300">
-          {error}
-        </div>
-      )}
       <div className="pointer-events-none absolute bottom-2 left-2 rounded-md border border-slate-700 bg-slate-950/85 px-2 py-1 text-[10px] font-semibold text-slate-300 backdrop-blur-sm">
         Visualization only · drag to orbit · wheel to zoom · no continuous animation
       </div>

--- a/src/components/visual/RepresentationInspector.tsx
+++ b/src/components/visual/RepresentationInspector.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import * as Tabs from '@radix-ui/react-tabs';
+import {
+  ArrowRight,
+  BookOpen,
+  Box,
+  CheckCircle2,
+  CircuitBoard,
+  Cpu,
+  ExternalLink,
+  FileCode2,
+  Image,
+  Layers3,
+  PackageSearch,
+  ShieldAlert,
+  TriangleAlert,
+  X,
+} from 'lucide-react';
+import type { NodeData } from '../../types';
+import {
+  getVisualFamily,
+  REPRESENTATION_KINDS,
+  RepresentationKind,
+  representationStatusCounts,
+  resolveVisualFamilyId,
+} from '../../lib/visual/representationRegistry';
+import { useProjectStore } from '../../store/projectStore';
+import { useKnowledge } from '../knowledge/KnowledgeProvider';
+import { DeviceVisual } from './DeviceVisual';
+import type { VisualQualityProfile } from './Lightweight3DPreview';
+
+interface RepresentationInspectorProps {
+  nodeData: NodeData | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const representationIcon: Record<RepresentationKind, React.ComponentType<{ className?: string }>> = {
+  architecture: Cpu,
+  schematic: FileCode2,
+  pictorial: Image,
+  footprint: CircuitBoard,
+  package: Box,
+  render3d: Layers3,
+  exact3d: PackageSearch,
+  photo: ExternalLink,
+};
+
+const statusClasses = {
+  available: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+  provisional: 'border-sky-200 bg-sky-50 text-sky-800',
+  unresolved: 'border-amber-200 bg-amber-50 text-amber-900',
+  unavailable: 'border-slate-200 bg-slate-100 text-slate-600',
+};
+
+const trustClasses = {
+  semantic: 'bg-violet-50 text-violet-700 border-violet-200',
+  educational: 'bg-blue-50 text-blue-700 border-blue-200',
+  preview: 'bg-amber-50 text-amber-800 border-amber-200',
+  authoritative: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+};
+
+export const RepresentationInspector: React.FC<RepresentationInspectorProps> = ({ nodeData, open, onOpenChange }) => {
+  const familyId = useMemo(() => resolveVisualFamilyId(nodeData ?? {}), [nodeData]);
+  const family = getVisualFamily(familyId);
+  const [activeKind, setActiveKind] = useState<RepresentationKind>('architecture');
+  const [quality, setQuality] = useState<VisualQualityProfile>('balanced');
+  const setActiveView = useProjectStore((state) => state.setActiveView);
+  const { openKnowledge } = useKnowledge();
+  const statusCounts = representationStatusCounts(family);
+  const current = family.representations[activeKind];
+
+  const openWorkbench = (viewId: string) => {
+    setActiveView(viewId);
+    onOpenChange(false);
+  };
+
+  const openGuide = () => {
+    if (!family.knowledgeId) return;
+    onOpenChange(false);
+    openKnowledge(family.knowledgeId);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[100] bg-slate-950/45 backdrop-blur-[2px]" />
+        <Dialog.Content
+          aria-describedby="representation-inspector-description"
+          className="fixed inset-y-0 right-0 z-[110] flex w-full max-w-[1120px] flex-col overflow-hidden border-l border-slate-200 bg-slate-50 shadow-2xl outline-none sm:w-[94vw]"
+        >
+          <header className="flex shrink-0 items-start justify-between gap-4 border-b border-slate-200 bg-white px-4 py-4 sm:px-6">
+            <div className="flex min-w-0 items-start gap-3">
+              <DeviceVisual familyId={familyId} kind="architecture" compact />
+              <div className="min-w-0">
+                <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-indigo-700">Multi-representation inspector</p>
+                <Dialog.Title className="mt-0.5 truncate text-lg font-bold text-slate-950">{nodeData?.name || family.label}</Dialog.Title>
+                <Dialog.Description id="representation-inspector-description" className="mt-1 max-w-2xl text-xs leading-5 text-slate-500">
+                  One project identity can expose different visuals for architecture, learning, electrical, PCB, mechanical, and 3D work. Their trust levels remain separate.
+                </Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close asChild>
+              <button type="button" aria-label="Close representation inspector" className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </Dialog.Close>
+          </header>
+
+          <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)]">
+            <aside className="min-h-0 overflow-y-auto border-b border-slate-200 bg-white p-4 lg:border-b-0 lg:border-r">
+              <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                <p className="text-xs font-bold text-slate-900">{family.label}</p>
+                <p className="mt-1 text-xs leading-5 text-slate-500">{family.description}</p>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-center text-[10px] font-bold uppercase tracking-wide">
+                  <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-2 py-2 text-emerald-800"><span className="block text-lg">{statusCounts.available}</span>Available</div>
+                  <div className="rounded-lg border border-sky-200 bg-sky-50 px-2 py-2 text-sky-800"><span className="block text-lg">{statusCounts.provisional}</span>Preview</div>
+                  <div className="rounded-lg border border-amber-200 bg-amber-50 px-2 py-2 text-amber-900"><span className="block text-lg">{statusCounts.unresolved}</span>Unresolved</div>
+                  <div className="rounded-lg border border-slate-200 bg-white px-2 py-2 text-slate-600"><span className="block text-lg">{statusCounts.unavailable}</span>N/A</div>
+                </div>
+              </section>
+
+              <section className="mt-4">
+                <h2 className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Typed architecture ports</h2>
+                <div className="mt-2 space-y-2">
+                  {family.ports.map((port) => (
+                    <div key={port.id} className="rounded-lg border border-slate-200 bg-white p-2.5">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs font-bold text-slate-900">{port.label}</span>
+                        <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[9px] font-bold uppercase text-slate-600">{port.kind} · {port.direction}</span>
+                      </div>
+                      <p className="mt-1 text-[11px] leading-4 text-slate-500">{port.description}</p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              <section className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs leading-5 text-amber-950">
+                <div className="flex gap-2"><TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /><p><strong>Recognition is not qualification.</strong> A recognizable visual never supplies missing pin, package, dimensional, or CAD data.</p></div>
+              </section>
+            </aside>
+
+            <main className="min-h-0 overflow-y-auto p-4 sm:p-6">
+              <Tabs.Root value={activeKind} onValueChange={(value) => setActiveKind(value as RepresentationKind)}>
+                <Tabs.List aria-label="Representations" className="flex gap-1.5 overflow-x-auto rounded-xl border border-slate-200 bg-white p-1.5 shadow-sm">
+                  {REPRESENTATION_KINDS.map((kind) => {
+                    const entry = family.representations[kind];
+                    const Icon = representationIcon[kind];
+                    return (
+                      <Tabs.Trigger key={kind} value={kind} className="group flex min-w-[110px] shrink-0 items-center gap-2 rounded-lg border border-transparent px-3 py-2 text-left text-xs font-semibold text-slate-600 outline-none transition hover:bg-slate-50 data-[state=active]:border-indigo-200 data-[state=active]:bg-indigo-50 data-[state=active]:text-indigo-800 focus-visible:ring-2 focus-visible:ring-indigo-500">
+                        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                        <span className="min-w-0"><span className="block capitalize">{kind === 'render3d' ? 'Light 3D' : kind === 'exact3d' ? 'Exact 3D' : kind}</span><span className={`mt-0.5 block text-[8px] font-bold uppercase tracking-wide ${entry.status === 'available' ? 'text-emerald-700' : entry.status === 'provisional' ? 'text-sky-700' : entry.status === 'unresolved' ? 'text-amber-700' : 'text-slate-400'}`}>{entry.status}</span></span>
+                      </Tabs.Trigger>
+                    );
+                  })}
+                </Tabs.List>
+
+                <section className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="flex flex-wrap gap-2">
+                        <span className={`rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide ${statusClasses[current.status]}`}>{current.status}</span>
+                        <span className={`rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide ${trustClasses[current.trust]}`}>{current.trust}</span>
+                      </div>
+                      <h2 className="mt-2 text-lg font-bold text-slate-950">{current.label}</h2>
+                      <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-600">{current.description}</p>
+                    </div>
+                    {activeKind === 'render3d' && current.status !== 'unavailable' && (
+                      <label className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700">
+                        Quality
+                        <select value={quality} onChange={(event) => setQuality(event.target.value as VisualQualityProfile)} className="rounded border border-slate-300 bg-white px-2 py-1 text-xs outline-none focus:ring-2 focus:ring-indigo-500">
+                          <option value="low">Low power</option><option value="balanced">Balanced</option><option value="high">High detail</option>
+                        </select>
+                      </label>
+                    )}
+                  </div>
+
+                  <div className="mt-4">
+                    <DeviceVisual familyId={familyId} kind={activeKind} quality={quality} />
+                  </div>
+
+                  <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4 md:grid-cols-3">
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3"><p className="text-[10px] font-bold uppercase tracking-wide text-slate-500">Source</p><p className="mt-1 text-xs leading-5 text-slate-700">{current.source}</p></div>
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3"><p className="text-[10px] font-bold uppercase tracking-wide text-slate-500">License</p><p className="mt-1 text-xs leading-5 text-slate-700">{current.license}</p></div>
+                    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3"><p className="text-[10px] font-bold uppercase tracking-wide text-slate-500">Qualification</p><p className="mt-1 text-xs leading-5 text-slate-700">{current.qualification}</p></div>
+                  </div>
+
+                  {current.authoritativeFor.length > 0 && (
+                    <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900"><div className="flex gap-2"><CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" /><p><strong>Authoritative only for:</strong> {current.authoritativeFor.join(', ')}.</p></div></div>
+                  )}
+                </section>
+              </Tabs.Root>
+
+              <section className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+                <div className="flex items-center gap-2"><ShieldAlert className="h-4 w-4 text-slate-500" aria-hidden="true" /><h2 className="text-xs font-extrabold uppercase tracking-[0.13em] text-slate-600">Continue with the correct workbench</h2></div>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+                  {family.knowledgeId && <button type="button" onClick={openGuide} className="group rounded-xl border border-slate-200 bg-slate-50 p-3 text-left hover:border-indigo-200 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="flex items-center justify-between text-sm font-bold text-slate-900"><span className="flex items-center gap-2"><BookOpen className="h-4 w-4 text-indigo-600" />Learn</span><ArrowRight className="h-4 w-4 text-slate-400 group-hover:text-indigo-700" /></span><span className="mt-1 block text-xs leading-5 text-slate-500">Understand use, connections, mistakes, and validation.</span></button>}
+                  <button type="button" onClick={() => openWorkbench('component-library')} className="group rounded-xl border border-slate-200 bg-slate-50 p-3 text-left hover:border-indigo-200 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="flex items-center justify-between text-sm font-bold text-slate-900"><span className="flex items-center gap-2"><PackageSearch className="h-4 w-4 text-indigo-600" />Component</span><ArrowRight className="h-4 w-4 text-slate-400 group-hover:text-indigo-700" /></span><span className="mt-1 block text-xs leading-5 text-slate-500">Choose a real definition, package, pins, and footprint.</span></button>
+                  <button type="button" onClick={() => openWorkbench('schematic-editor')} className="group rounded-xl border border-slate-200 bg-slate-50 p-3 text-left hover:border-indigo-200 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="flex items-center justify-between text-sm font-bold text-slate-900"><span className="flex items-center gap-2"><FileCode2 className="h-4 w-4 text-indigo-600" />Schematic</span><ArrowRight className="h-4 w-4 text-slate-400 group-hover:text-indigo-700" /></span><span className="mt-1 block text-xs leading-5 text-slate-500">Use exact symbols and electrical connectivity.</span></button>
+                  <button type="button" onClick={() => openWorkbench('board-designer')} className="group rounded-xl border border-slate-200 bg-slate-50 p-3 text-left hover:border-indigo-200 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="flex items-center justify-between text-sm font-bold text-slate-900"><span className="flex items-center gap-2"><CircuitBoard className="h-4 w-4 text-indigo-600" />PCB</span><ArrowRight className="h-4 w-4 text-slate-400 group-hover:text-indigo-700" /></span><span className="mt-1 block text-xs leading-5 text-slate-500">Place only the selected exact footprint revision.</span></button>
+                </div>
+              </section>
+            </main>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/lib/visual/representationRegistry.ts
+++ b/src/lib/visual/representationRegistry.ts
@@ -1,0 +1,462 @@
+export const REPRESENTATION_KINDS = [
+  'architecture',
+  'schematic',
+  'pictorial',
+  'footprint',
+  'package',
+  'render3d',
+  'exact3d',
+  'photo',
+] as const;
+
+export type RepresentationKind = (typeof REPRESENTATION_KINDS)[number];
+
+export type RepresentationStatus = 'available' | 'provisional' | 'unresolved' | 'unavailable';
+export type RepresentationTrust = 'semantic' | 'educational' | 'preview' | 'authoritative';
+export type ArchitecturePortKind =
+  | 'power'
+  | 'ground'
+  | 'data'
+  | 'control'
+  | 'analog'
+  | 'wireless'
+  | 'mechanical'
+  | 'thermal'
+  | 'dependency';
+
+export type ArchitecturePortDirection = 'input' | 'output' | 'bidirectional';
+
+export type VisualFamilyId =
+  | 'resistor'
+  | 'capacitor'
+  | 'led'
+  | 'push-button'
+  | 'microcontroller'
+  | 'sensor'
+  | 'voltage-regulator'
+  | 'battery'
+  | 'usb-c'
+  | 'motor-actuator'
+  | 'display'
+  | 'debug-connector'
+  | 'protection-device'
+  | 'enclosure'
+  | 'pcb-assembly'
+  | 'firmware-state'
+  | 'software-service'
+  | 'validation'
+  | 'product-system'
+  | 'generic-function';
+
+export interface ArchitecturePort {
+  id: string;
+  label: string;
+  kind: ArchitecturePortKind;
+  direction: ArchitecturePortDirection;
+  description: string;
+}
+
+export interface RepresentationAvailability {
+  kind: RepresentationKind;
+  status: RepresentationStatus;
+  trust: RepresentationTrust;
+  label: string;
+  description: string;
+  authoritativeFor: string[];
+  source: string;
+  license: string;
+  qualification: string;
+}
+
+export interface VisualFamilyDefinition {
+  id: VisualFamilyId;
+  label: string;
+  shortLabel: string;
+  description: string;
+  color: string;
+  accent: string;
+  knowledgeId?: string;
+  keywords: string[];
+  ports: ArchitecturePort[];
+  representations: Record<RepresentationKind, RepresentationAvailability>;
+}
+
+export interface VisualNodeLike {
+  name?: string;
+  category?: string;
+  description?: string;
+  candidateComponents?: string;
+  tags?: string[];
+}
+
+const internalSource = 'Hardware Studio authored semantic vector system';
+const internalLicense = 'Repository license; no third-party raster asset embedded';
+
+function representation(
+  kind: RepresentationKind,
+  status: RepresentationStatus,
+  trust: RepresentationTrust,
+  label: string,
+  description: string,
+  authoritativeFor: string[] = [],
+): RepresentationAvailability {
+  return {
+    kind,
+    status,
+    trust,
+    label,
+    description,
+    authoritativeFor,
+    source: internalSource,
+    license: internalLicense,
+    qualification:
+      status === 'available'
+        ? 'Reviewed internal representation contract'
+        : status === 'provisional'
+          ? 'Visualization only; exact selected-part data is still required'
+          : status === 'unresolved'
+            ? 'Required source data is missing and no guessed engineering geometry is substituted'
+            : 'This representation is not applicable or has not been licensed/qualified',
+  };
+}
+
+function representationSet(options: {
+  schematic?: boolean;
+  footprint?: boolean;
+  physical?: boolean;
+  pictorial?: boolean;
+  render3d?: boolean;
+}): Record<RepresentationKind, RepresentationAvailability> {
+  return {
+    architecture: representation(
+      'architecture',
+      'available',
+      'semantic',
+      'Architecture visual',
+      'Recognizable functional silhouette with typed connection ports. It communicates system intent, not exact electrical or physical geometry.',
+      ['system architecture communication'],
+    ),
+    schematic: options.schematic
+      ? representation(
+          'schematic',
+          'provisional',
+          'preview',
+          'Schematic-symbol preview',
+          'Vector convention preview. A selected component revision must provide the exact symbol pins, numbers, units, and electrical roles.',
+        )
+      : representation(
+          'schematic',
+          'unavailable',
+          'semantic',
+          'No schematic symbol',
+          'This family is not itself an electrical schematic component.',
+        ),
+    pictorial: options.pictorial === false
+      ? representation(
+          'pictorial',
+          'unavailable',
+          'educational',
+          'No pictorial asset',
+          'No licensed or internally authored educational illustration is attached.',
+        )
+      : representation(
+          'pictorial',
+          'available',
+          'educational',
+          'Educational illustration',
+          'Internally authored recognizable illustration for onboarding and identification. It is not dimensionally authoritative.',
+          ['recognition and learning'],
+        ),
+    footprint: options.footprint
+      ? representation(
+          'footprint',
+          'provisional',
+          'preview',
+          'Footprint-family preview',
+          'Vector pad-layout preview for recognition. The exact package footprint, pads, drills, courtyard, paste, mask, and origin come from the selected component revision.',
+        )
+      : representation(
+          'footprint',
+          'unresolved',
+          'preview',
+          'Footprint not selected',
+          'No exact PCB footprint is available for this concept. Choose a real component/package before PCB placement.',
+        ),
+    package: options.physical
+      ? representation(
+          'package',
+          'unresolved',
+          'preview',
+          'Mechanical package unresolved',
+          'The family has a physical form, but exact dimensions, tolerances, mounting features, origin, and height require the selected part.',
+        )
+      : representation(
+          'package',
+          'unavailable',
+          'preview',
+          'No physical package',
+          'This concept does not have a direct physical package representation.',
+        ),
+    render3d: options.render3d || options.physical
+      ? representation(
+          'render3d',
+          'provisional',
+          'preview',
+          'Lightweight 3D silhouette',
+          'On-demand low-power Three.js visualization. It is intentionally simple and cannot be used for clearance, interference, mass, or manufacturing checks.',
+        )
+      : representation(
+          'render3d',
+          'unavailable',
+          'preview',
+          'No 3D visualization',
+          'A 3D visualization is not applicable to this non-physical concept.',
+        ),
+    exact3d: options.physical
+      ? representation(
+          'exact3d',
+          'unresolved',
+          'authoritative',
+          'Exact CAD model missing',
+          'Attach and qualify STEP/B-Rep geometry with units, origin, orientation, version, hash, and provenance before authoritative assembly checks.',
+          ['assembly and interference only after qualification'],
+        )
+      : representation(
+          'exact3d',
+          'unavailable',
+          'authoritative',
+          'Exact CAD not applicable',
+          'This non-physical concept has no exact CAD representation.',
+        ),
+    photo: representation(
+      'photo',
+      'unavailable',
+      'educational',
+      'Licensed photo not attached',
+      'Hardware Studio does not ship random web images. A manufacturer or project image needs explicit source and usage rights.',
+    ),
+  };
+}
+
+const port = (
+  id: string,
+  label: string,
+  kind: ArchitecturePortKind,
+  direction: ArchitecturePortDirection,
+  description: string,
+): ArchitecturePort => ({ id, label, kind, direction, description });
+
+export const visualFamilyRegistry: readonly VisualFamilyDefinition[] = [
+  {
+    id: 'resistor', label: 'Resistor', shortLabel: 'R', description: 'Current limiting, bias, sensing, division, or termination.',
+    color: '#b45309', accent: '#fef3c7', knowledgeId: 'resistor', keywords: ['resistor', 'ohm', 'pull-up', 'pull down', 'termination'],
+    ports: [port('a', 'A', 'analog', 'bidirectional', 'First passive terminal'), port('b', 'B', 'analog', 'bidirectional', 'Second passive terminal')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'capacitor', label: 'Capacitor', shortLabel: 'C', description: 'Decoupling, filtering, timing, coupling, or energy buffering.',
+    color: '#0369a1', accent: '#e0f2fe', knowledgeId: 'capacitor', keywords: ['capacitor', 'decoupling', 'bypass', 'filter', 'bulk'],
+    ports: [port('a', 'A', 'analog', 'bidirectional', 'First terminal'), port('b', 'B', 'analog', 'bidirectional', 'Second terminal')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'led', label: 'LED Indicator', shortLabel: 'LED', description: 'Visible product status or illumination output.',
+    color: '#be123c', accent: '#ffe4e6', knowledgeId: 'led', keywords: ['led', 'indicator', 'rgb', 'light', 'status light'],
+    ports: [port('anode', 'Anode', 'power', 'input', 'Positive LED terminal'), port('cathode', 'Cathode', 'ground', 'output', 'Return terminal'), port('control', 'PWM', 'control', 'input', 'Optional brightness or color control')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'push-button', label: 'Push Button', shortLabel: 'SW', description: 'Physical momentary or maintained user input.',
+    color: '#7c3aed', accent: '#ede9fe', knowledgeId: 'push-button', keywords: ['button', 'switch', 'push', 'touch', 'momentary'],
+    ports: [port('contact-a', 'Contact A', 'control', 'bidirectional', 'First switch contact'), port('contact-b', 'Contact B', 'control', 'bidirectional', 'Second switch contact'), port('mechanical', 'Press', 'mechanical', 'input', 'Human mechanical actuation')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'microcontroller', label: 'Microcontroller', shortLabel: 'MCU', description: 'Programmable controller coordinating product behavior and peripherals.',
+    color: '#0f766e', accent: '#ccfbf1', knowledgeId: 'microcontroller', keywords: ['mcu', 'microcontroller', 'controller', 'processor', 'esp32', 'nrf', 'stm32', 'ble'],
+    ports: [port('power', 'Power', 'power', 'input', 'Controller supply domain'), port('ground', 'Ground', 'ground', 'input', 'Electrical reference'), port('gpio', 'GPIO', 'control', 'bidirectional', 'General-purpose control and status'), port('bus', 'Data buses', 'data', 'bidirectional', 'I2C, SPI, UART, USB, or similar'), port('debug', 'Debug', 'dependency', 'bidirectional', 'Programming and debug access'), port('wireless', 'Wireless', 'wireless', 'bidirectional', 'Optional RF interface')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'sensor', label: 'Sensor', shortLabel: 'SNS', description: 'Converts a physical condition into electrical or digital information.',
+    color: '#047857', accent: '#d1fae5', knowledgeId: 'environmental-sensor', keywords: ['sensor', 'imu', 'temperature', 'humidity', 'pressure', 'microphone', 'motion', 'i2c'],
+    ports: [port('power', 'Power', 'power', 'input', 'Sensor supply'), port('ground', 'Ground', 'ground', 'input', 'Electrical reference'), port('environment', 'Physical input', 'mechanical', 'input', 'Measured physical phenomenon'), port('data', 'Measurement', 'data', 'output', 'Digital bus or measured signal'), port('interrupt', 'Interrupt', 'control', 'output', 'Optional event or data-ready output')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'voltage-regulator', label: 'Voltage Regulator', shortLabel: 'PWR', description: 'Converts and controls a product power rail.',
+    color: '#a16207', accent: '#fef9c3', knowledgeId: 'voltage-regulator', keywords: ['regulator', 'ldo', 'buck', 'boost', 'dc-dc', 'power converter'],
+    ports: [port('vin', 'VIN', 'power', 'input', 'Input power rail'), port('ground', 'Ground', 'ground', 'input', 'Electrical reference'), port('enable', 'Enable', 'control', 'input', 'Optional rail control'), port('vout', 'VOUT', 'power', 'output', 'Controlled output rail'), port('status', 'Power good', 'control', 'output', 'Optional rail-status output')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'battery', label: 'Battery', shortLabel: 'BAT', description: 'Stored energy source with chemistry, protection, and charging constraints.',
+    color: '#15803d', accent: '#dcfce7', knowledgeId: 'battery', keywords: ['battery', 'cell', 'lipo', 'li-ion', 'power source'],
+    ports: [port('positive', 'Positive', 'power', 'output', 'Battery positive terminal'), port('negative', 'Negative', 'ground', 'output', 'Battery return terminal'), port('temperature', 'Temperature', 'analog', 'output', 'Optional pack-temperature sensing'), port('mechanical', 'Envelope', 'mechanical', 'bidirectional', 'Retention, swelling, and service interface')],
+    representations: representationSet({ schematic: true, footprint: false, physical: true }),
+  },
+  {
+    id: 'usb-c', label: 'USB-C Connector', shortLabel: 'USB-C', description: 'Reversible external power and/or data interface.',
+    color: '#1d4ed8', accent: '#dbeafe', knowledgeId: 'usb-c-connector', keywords: ['usb', 'usb-c', 'type-c', 'connector', 'vbus', 'cc1', 'cc2'],
+    ports: [port('cable', 'Cable', 'mechanical', 'bidirectional', 'External plug interface'), port('vbus', 'VBUS', 'power', 'bidirectional', 'USB power path'), port('usb-data', 'USB data', 'data', 'bidirectional', 'D+/D− or high-speed pairs'), port('cc', 'CC', 'control', 'bidirectional', 'Role and current configuration'), port('shield', 'Shield', 'ground', 'bidirectional', 'Shield or chassis connection')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'motor-actuator', label: 'Motor / Actuator', shortLabel: 'ACT', description: 'Electrical-to-mechanical motion, force, vibration, or airflow.',
+    color: '#c2410c', accent: '#ffedd5', knowledgeId: 'motor-actuator', keywords: ['motor', 'haptic', 'actuator', 'vibration', 'fan', 'solenoid'],
+    ports: [port('power', 'Drive power', 'power', 'input', 'Actuator power path'), port('control', 'Drive control', 'control', 'input', 'PWM, phase, or driver control'), port('feedback', 'Feedback', 'data', 'output', 'Optional position, current, or fault feedback'), port('motion', 'Motion', 'mechanical', 'output', 'Mechanical output')],
+    representations: representationSet({ schematic: true, footprint: false, physical: true }),
+  },
+  {
+    id: 'display', label: 'Display', shortLabel: 'DSP', description: 'Visual information output with electrical, optical, and mechanical interfaces.',
+    color: '#4338ca', accent: '#e0e7ff', knowledgeId: 'display', keywords: ['display', 'oled', 'lcd', 'screen', 'panel'],
+    ports: [port('power', 'Power', 'power', 'input', 'Panel and optional backlight power'), port('data', 'Display data', 'data', 'input', 'SPI, I2C, parallel, MIPI, or other interface'), port('control', 'Control', 'control', 'input', 'Reset, chip select, command, and backlight control'), port('visual', 'Visual output', 'mechanical', 'output', 'Visible active-area output')],
+    representations: representationSet({ schematic: true, footprint: false, physical: true }),
+  },
+  {
+    id: 'debug-connector', label: 'Programming / Debug', shortLabel: 'DBG', description: 'Programming, recovery, debug, logging, or factory-test access.',
+    color: '#475569', accent: '#e2e8f0', knowledgeId: 'debug-connector', keywords: ['debug', 'swd', 'jtag', 'uart header', 'programming', 'test pads', 'pogo'],
+    ports: [port('target-power', 'Target voltage', 'power', 'input', 'Target voltage reference'), port('ground', 'Ground', 'ground', 'bidirectional', 'Common reference'), port('debug-data', 'Debug data', 'data', 'bidirectional', 'SWDIO, JTAG data, UART, or protocol data'), port('debug-clock', 'Clock', 'control', 'input', 'Debug/programming clock'), port('reset', 'Reset', 'control', 'bidirectional', 'Optional target reset')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'protection-device', label: 'Protection Device', shortLabel: 'PROT', description: 'Limits damage from abnormal voltage, current, polarity, or transients.',
+    color: '#b91c1c', accent: '#fee2e2', knowledgeId: 'protection-device', keywords: ['protection', 'esd', 'tvs', 'fuse', 'reverse polarity', 'surge', 'flyback'],
+    ports: [port('exposed', 'Exposed side', 'power', 'bidirectional', 'Connector or fault-facing node'), port('protected', 'Protected side', 'power', 'bidirectional', 'Protected circuit node'), port('return', 'Return', 'ground', 'output', 'Transient or fault-current return')],
+    representations: representationSet({ schematic: true, footprint: true, physical: true }),
+  },
+  {
+    id: 'enclosure', label: 'Enclosure', shortLabel: 'ENC', description: 'Physical shell, openings, mounting, protection, and product touch surfaces.',
+    color: '#57534e', accent: '#e7e5e4', keywords: ['enclosure', 'casing', 'shell', 'housing', 'mechanical', 'outer body'],
+    ports: [port('assembly', 'Assembly', 'mechanical', 'bidirectional', 'Internal mounting and mating interfaces'), port('environment', 'Environment', 'mechanical', 'bidirectional', 'External physical environment'), port('thermal', 'Thermal path', 'thermal', 'bidirectional', 'Heat flow through or around the enclosure'), port('user', 'User interface', 'mechanical', 'bidirectional', 'Buttons, displays, openings, and touch surfaces')],
+    representations: representationSet({ schematic: false, footprint: false, physical: true }),
+  },
+  {
+    id: 'pcb-assembly', label: 'PCB Assembly', shortLabel: 'PCBA', description: 'Board, stackup, footprints, copper, and placed component assembly.',
+    color: '#047857', accent: '#d1fae5', keywords: ['pcb', 'board', 'pcba', 'circuit board', 'assembly'],
+    ports: [port('power', 'Power', 'power', 'bidirectional', 'Board power interfaces'), port('data', 'Data', 'data', 'bidirectional', 'Board communication interfaces'), port('mechanical', 'Mounting', 'mechanical', 'bidirectional', 'Board mounting and connector geometry'), port('thermal', 'Thermal', 'thermal', 'bidirectional', 'Board and component heat paths')],
+    representations: representationSet({ schematic: false, footprint: false, physical: true, render3d: true }),
+  },
+  {
+    id: 'firmware-state', label: 'Firmware State', shortLabel: 'STATE', description: 'A software mode with events, transitions, and actions.',
+    color: '#6d28d9', accent: '#ede9fe', keywords: ['firmware', 'state', 'boot', 'idle', 'sleep', 'handler', 'driver', 'watchdog'],
+    ports: [port('events', 'Events', 'control', 'input', 'Events that enter or affect the state'), port('actions', 'Actions', 'control', 'output', 'Commands and effects produced by the state'), port('dependencies', 'Dependencies', 'dependency', 'bidirectional', 'Required modules, hardware, and services')],
+    representations: representationSet({ schematic: false, footprint: false, physical: false, pictorial: true }),
+  },
+  {
+    id: 'software-service', label: 'Software Service', shortLabel: 'SVC', description: 'Application, cloud, host, or external software capability.',
+    color: '#0369a1', accent: '#e0f2fe', keywords: ['software', 'app', 'cloud', 'api', 'service', 'host'],
+    ports: [port('api', 'API', 'data', 'bidirectional', 'Structured software interface'), port('events', 'Events', 'control', 'bidirectional', 'Commands, notifications, and lifecycle events'), port('dependency', 'Dependency', 'dependency', 'bidirectional', 'Required or provided software dependency')],
+    representations: representationSet({ schematic: false, footprint: false, physical: false }),
+  },
+  {
+    id: 'validation', label: 'Validation Activity', shortLabel: 'TEST', description: 'Test, inspection, evidence, or acceptance activity.',
+    color: '#be123c', accent: '#ffe4e6', keywords: ['test', 'testing', 'validation', 'verification', 'qa', 'review'],
+    ports: [port('subject', 'Subject', 'dependency', 'input', 'Design, requirement, build, or device under test'), port('evidence', 'Evidence', 'data', 'output', 'Measurements, observations, logs, or reports'), port('decision', 'Result', 'control', 'output', 'Pass, fail, blocker, or review outcome')],
+    representations: representationSet({ schematic: false, footprint: false, physical: false }),
+  },
+  {
+    id: 'product-system', label: 'Product / System', shortLabel: 'SYS', description: 'Top-level product or subsystem boundary and intent.',
+    color: '#0f172a', accent: '#e2e8f0', keywords: ['product', 'system', 'container', 'subsystem', 'architecture'],
+    ports: [port('interfaces', 'Interfaces', 'data', 'bidirectional', 'External and internal product interfaces'), port('power', 'Power', 'power', 'input', 'Product power boundary'), port('mechanical', 'Physical', 'mechanical', 'bidirectional', 'Physical boundary and environment'), port('requirements', 'Requirements', 'dependency', 'input', 'Intent, constraints, and acceptance criteria')],
+    representations: representationSet({ schematic: false, footprint: false, physical: true }),
+  },
+  {
+    id: 'generic-function', label: 'Functional Block', shortLabel: 'FUNC', description: 'A semantic product function without a qualified device representation.',
+    color: '#334155', accent: '#f1f5f9', keywords: [],
+    ports: [port('inputs', 'Inputs', 'data', 'input', 'Information, energy, or dependencies consumed by the function'), port('outputs', 'Outputs', 'data', 'output', 'Information, energy, or effects produced by the function')],
+    representations: representationSet({ schematic: false, footprint: false, physical: false }),
+  },
+] as const;
+
+const familyById = new Map<VisualFamilyId, VisualFamilyDefinition>(
+  visualFamilyRegistry.map((family) => [family.id, family]),
+);
+
+export function getVisualFamily(id: VisualFamilyId): VisualFamilyDefinition {
+  return familyById.get(id) ?? familyById.get('generic-function')!;
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9+.#-]+/g, ' ').trim();
+}
+
+export function resolveVisualFamilyId(node: VisualNodeLike): VisualFamilyId {
+  const text = normalize([
+    node.name,
+    node.category,
+    node.description,
+    node.candidateComponents,
+    ...(node.tags ?? []),
+  ].filter(Boolean).join(' '));
+
+  const exactPriority: Array<[VisualFamilyId, string[]]> = [
+    ['usb-c', ['usb-c', 'usb c', 'type-c', 'type c']],
+    ['debug-connector', ['debug', 'swd', 'jtag', 'programming', 'uart header', 'test pad', 'pogo']],
+    ['voltage-regulator', ['regulator', 'ldo', 'buck converter', 'boost converter', 'dc-dc']],
+    ['protection-device', ['protection', 'esd', 'tvs', 'fuse', 'flyback', 'reverse polarity']],
+    ['microcontroller', ['microcontroller', 'mcu', 'esp32', 'nrf52', 'nrf', 'stm32', 'controller', 'processor']],
+    ['motor-actuator', ['motor', 'haptic', 'actuator', 'vibration', 'solenoid', 'fan']],
+    ['push-button', ['push button', 'pushbutton', 'button', 'momentary switch', 'touch surface']],
+    ['display', ['display', 'oled', 'lcd', 'screen', 'panel']],
+    ['battery', ['battery', 'lipo', 'li-ion', 'cell', 'energy source']],
+    ['sensor', ['sensor', 'imu', 'temperature', 'humidity', 'pressure', 'microphone', 'motion']],
+    ['resistor', ['resistor', 'pull-up', 'pull down', 'ohm']],
+    ['capacitor', ['capacitor', 'decoupling', 'bypass', 'bulk cap']],
+    ['led', ['rgb led', 'led indicator', 'light indicator', 'status light']],
+    ['pcb-assembly', ['pcb assembly', 'pcba', 'circuit board', 'board assembly', 'pcb zone']],
+    ['enclosure', ['enclosure', 'casing', 'housing', 'outer shell', 'outer body', 'mechanical shell']],
+    ['validation', ['validation', 'verification', 'testing', 'test activity', 'factory qa']],
+    ['software-service', ['software', 'cloud', 'api', 'service', 'mobile app', 'host app']],
+    ['firmware-state', ['firmware', 'boot state', 'idle state', 'sleep state', 'handler', 'watchdog', 'driver']],
+    ['product-system', ['product container', 'hardware product', 'system boundary', 'subsystem']],
+  ];
+
+  for (const [familyId, terms] of exactPriority) {
+    if (terms.some((term) => text.includes(term))) return familyId;
+  }
+
+  const category = normalize(node.category ?? '');
+  if (category.includes('firmware')) return 'firmware-state';
+  if (category.includes('mechanical')) return 'enclosure';
+  if (category.includes('testing')) return 'validation';
+  if (category.includes('software')) return 'software-service';
+  if (category.includes('product')) return 'product-system';
+  return 'generic-function';
+}
+
+export function resolveVisualFamily(node: VisualNodeLike): VisualFamilyDefinition {
+  return getVisualFamily(resolveVisualFamilyId(node));
+}
+
+export const portKindStyles: Record<ArchitecturePortKind, { color: string; label: string; dash?: string }> = {
+  power: { color: '#dc2626', label: 'Power' },
+  ground: { color: '#475569', label: 'Ground' },
+  data: { color: '#2563eb', label: 'Data' },
+  control: { color: '#7c3aed', label: 'Control' },
+  analog: { color: '#ea580c', label: 'Analog' },
+  wireless: { color: '#0891b2', label: 'Wireless', dash: '5 4' },
+  mechanical: { color: '#78716c', label: 'Mechanical', dash: '8 4' },
+  thermal: { color: '#d97706', label: 'Thermal', dash: '2 4' },
+  dependency: { color: '#64748b', label: 'Dependency', dash: '3 3' },
+};
+
+export function portHandleId(port: ArchitecturePort): string {
+  return `visual-port:${port.kind}:${port.id}`;
+}
+
+export function portKindFromHandleId(handleId?: string | null): ArchitecturePortKind | undefined {
+  if (!handleId?.startsWith('visual-port:')) return undefined;
+  const kind = handleId.split(':')[1] as ArchitecturePortKind;
+  return kind in portKindStyles ? kind : undefined;
+}
+
+export function representationStatusCounts(family: VisualFamilyDefinition): Record<RepresentationStatus, number> {
+  return REPRESENTATION_KINDS.reduce<Record<RepresentationStatus, number>>(
+    (counts, kind) => {
+      counts[family.representations[kind].status] += 1;
+      return counts;
+    },
+    { available: 0, provisional: 0, unresolved: 0, unavailable: 0 },
+  );
+}


### PR DESCRIPTION
## Summary

Closes #61
Contributes to #60 without claiming completion of the broader imported-asset and exact-CAD program.

This replaces the first generic Blueprint visual layer with a connected, truthful multi-representation system.

## User workflow

A user can now:

1. open the System Blueprint and recognize mapped device/function families visually;
2. understand typed ports for power, ground, data, control, analog, wireless, mechanical, thermal, and dependency relationships;
3. connect ports and receive type-specific edge color, dash, direction, and wireless behavior;
4. zoom out to compact silhouettes or zoom in for purpose, status, interfaces, and candidate hardware;
5. drag or click semantic visual items from the same family-aware Blueprint library;
6. inspect architecture, schematic, educational, footprint, package, lightweight 3D, exact-CAD, and photo representations;
7. see the status, trust, source, license, qualification, and authority boundary of each representation;
8. open Learn, Component Library, Schematic, or PCB from the inspector;
9. view an on-demand WebGL 3D silhouette without continuous animation or false engineering authority.

## Representation architecture

- 20 typed visual families, including all bounded starter physical/electronic families plus firmware, software, validation, product, and generic fallbacks;
- eight distinct representation categories with independent status/trust contracts;
- deterministic mapping from existing node content, so no project migration or duplicate identity catalog is introduced;
- unresolved exact footprint/package/STEP/photo states remain unresolved instead of receiving guessed authoritative geometry;
- no copied screenshots, random web images, or unlicensed raster assets.

## Blueprint changes

- semantic authored SVG glyphs replace uniform generic block visuals;
- typed React Flow handles and connection styling;
- progressive detail at low, medium, and normal zoom;
- family-aware MiniMap colors;
- architecture-specific explanatory UI;
- direct representation inspection from every node;
- semantic visual thumbnails and port summaries in the Blueprint library.

## Lightweight 3D

- lazy imported only when the Lightweight 3D tab is selected;
- Three.js low-power renderer preference;
- low/balanced/high pixel-ratio caps;
- no auto-rotation and no permanent animation loop;
- event-driven rendering on initial display, resize, visibility return, orbit, and zoom;
- pauses when hidden;
- disposes controls, observers, geometry, materials, renderer, and WebGL context on close;
- explicitly labeled visualization-only.

## Verification contracts

Tests cover:

- unique family IDs;
- all eight representation records per family;
- source/license/qualification completeness;
- bounded starter mappings;
- safe generic fallback;
- exact-CAD versus preview trust boundaries;
- no available unlicensed photos;
- typed port handle encoding/decoding.

## Required before merge

- clean install;
- lint;
- TypeScript typecheck;
- full Vitest suite;
- production Next.js build;
- successful Vercel deployment.

## Deliberate non-goals

- qualified KiCad/LibrePCB import adapters;
- exact manufacturer footprints, packages, STEP models, or photos;
- CAD-kernel completion;
- closing parent #60.