### PR TITLE
Build adaptive workflows and guided project navigation

### DIFF
--- a/docs/research/ADAPTIVE_WORKFLOWS.md
+++ b/docs/research/ADAPTIVE_WORKFLOWS.md
@@ -1,0 +1,135 @@
+# Adaptive workflows and capability-based navigation
+
+Status: implementation decision for issue #59.
+
+## Product problem
+
+Hardware Studio spans product intent, mechanical design, electronics, PCB, firmware, validation, and release outputs. Showing every workbench to every user makes the product appear comprehensive but makes ordinary tasks harder to understand.
+
+The product must therefore support both:
+
+- **connected work**, where multiple domains share one project graph; and
+- **standalone work**, where a user can focus on one domain without being forced through unrelated upstream or downstream modules.
+
+Progressive disclosure changes what the shell shows. It does not delete engineering records or create a second project model.
+
+## Research patterns
+
+### KiCad
+
+KiCad intentionally connects schematic and PCB editors while still allowing standalone editor workflows. The PCB editor can maintain board-local nets in standalone use, while richer synchronization comes from the associated schematic.
+
+Sources:
+
+- https://docs.kicad.org/9.0/en/eeschema/eeschema.html
+- https://docs.kicad.org/10.0/en/pcbnew/pcbnew.pdf
+
+Hardware Studio decision: Electronics and PCB can be enabled independently. When PCB is shown without Electronics, the product must state that schematic synchronization and component-definition context are unavailable rather than blocking the user.
+
+### Autodesk Fusion
+
+Fusion groups capabilities into purpose-driven workspaces. The active workspace controls the commands and data most relevant to the current task.
+
+Source:
+
+- https://help.autodesk.com/view/NINVFUS/ENU/?guid=GS-WORKSPACES
+
+Hardware Studio decision: workflow profiles are task-oriented starting points, not permanent product editions. Every non-overview domain remains independently configurable.
+
+### Blender
+
+Blender workspaces are task-oriented arrangements of editors. They reduce visible complexity without creating separate copies of the underlying scene.
+
+Source:
+
+- https://docs.blender.org/manual/en/4.2/interface/window_system/workspaces.html
+
+Hardware Studio decision: workflow preferences affect navigation and guidance only. Canonical project engineering data remains shared and unchanged.
+
+### Onshape
+
+Onshape documents can hold multiple linked artifact types as tabs, and larger or reusable areas can be split into linked documents for performance and ownership.
+
+Sources:
+
+- https://cad.onshape.com/help/Content/Document/documents.htm
+- https://cad.onshape.com/help/Content/Document/linking_documents.htm
+
+Hardware Studio decision: keep one connected local project graph now, while preserving the architectural option to split large domain data behind stable references later. The adaptive shell must not require that split.
+
+## Implemented workflow model
+
+The shell supports these profiles:
+
+- Complete Product
+- Electronics + PCB
+- Mechanical + Assembly
+- Firmware + Device
+- Validation + Handoff
+- Custom
+
+Profiles select initial capabilities. They do not lock the user. Product, Mechanical, Electronics, PCB, Firmware, Validation, and Outputs can each be shown or hidden independently. Overview is always available.
+
+## Persistence boundary
+
+Workflow preferences are stored under a dedicated local-storage key:
+
+`hardware-studio:workflow-preferences:v1`
+
+They are not included in canonical project serialization and do not call project-store mutation actions. Hiding a domain therefore cannot remove its requirements, geometry, components, nets, firmware, tests, revisions, or output records.
+
+Malformed or unknown preference data normalizes to safe values. Unknown domain IDs are discarded. If storage is blocked, preferences remain usable in memory.
+
+## Active-view safety
+
+If a user hides the domain containing the currently open workbench:
+
+- the workbench stays open;
+- the domain remains temporarily visible in navigation;
+- a banner explains that it is hidden from the configured workflow;
+- the user can show the domain again or leave the workbench;
+- no silent redirect occurs.
+
+## Guided home
+
+The previous dashboard assumed one universal linear pipeline and exposed generation or repair actions that could mutate the project before the user understood the design.
+
+The guided home instead shows:
+
+- selected workflow;
+- visible and hidden domains;
+- current canonical project-data counts;
+- connected versus standalone limitations;
+- one next action per visible domain;
+- evidence explaining why each action is suggested;
+- a direct route to workflow configuration.
+
+Actions are derived from existing project data. No fake completion percentage is used as primary guidance, and showing a domain does not imply its work is complete.
+
+## Lightweight 3D versus CAD kernel
+
+Workflow configuration and lightweight visualization are separate concerns.
+
+The lightweight Three.js representation introduced by issue #61 is:
+
+- visualization-only;
+- lazy-loaded;
+- event-driven;
+- capped by a quality profile;
+- non-authoritative for dimensions, interference, mass, manufacturing, or release.
+
+The future CAD kernel in issue #17 remains responsible for exact solids, STEP/B-Rep processing, dimensional authority, interference, manufacturing geometry, and qualified exports.
+
+Adaptive workflows can hide or show Mechanical and 3D entry points, but they do not change this trust boundary.
+
+## Non-goals
+
+This implementation does not:
+
+- create separate product editions;
+- delete data for hidden domains;
+- force domain dependencies;
+- claim parity with KiCad, Fusion, Blender, or Onshape;
+- turn Three.js previews into CAD;
+- replace the canonical product graph;
+- complete the broader shell redesign in issue #9.

--- a/src/__tests__/workflowProfiles.test.ts
+++ b/src/__tests__/workflowProfiles.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import { navigationDomains } from '../lib/navigationRegistry';
+import {
+  createPreferenceFromProfile,
+  deriveGuidedWorkflowActions,
+  getHiddenDomainCount,
+  getVisibleNavigationDomains,
+  getWorkflowConnectionNotices,
+  inferProfileId,
+  normalizeWorkflowPreference,
+  toggleWorkflowDomain,
+  workflowProfiles,
+  WORKFLOW_DOMAIN_IDS,
+  type WorkflowProjectSnapshot,
+} from '../lib/workflowProfiles';
+
+const emptySnapshot: WorkflowProjectSnapshot = {
+  requirements: 0,
+  architectureNodes: 0,
+  risks: 0,
+  mechanicalObjects: 0,
+  assemblyLayers: 0,
+  components: 0,
+  circuitBlocks: 0,
+  nets: 0,
+  boards: 0,
+  traces: 0,
+  firmwareModules: 0,
+  firmwareStates: 0,
+  validationTests: 0,
+  validationRuns: 0,
+  revisions: 0,
+  factoryPackageStatus: 'Draft',
+};
+
+describe('adaptive workflow profiles', () => {
+  it('ships unique bounded profiles and every configurable domain', () => {
+    expect(new Set(workflowProfiles.map((profile) => profile.id)).size).toBe(workflowProfiles.length);
+    expect(WORKFLOW_DOMAIN_IDS).toEqual([
+      'product',
+      'mechanical',
+      'electronics',
+      'pcb',
+      'firmware',
+      'validation',
+      'outputs',
+    ]);
+
+    workflowProfiles.forEach((profile) => {
+      expect(profile.name.trim(), profile.id).not.toBe('');
+      expect(profile.summary.trim(), profile.id).not.toBe('');
+      expect(profile.bestFor.trim(), profile.id).not.toBe('');
+      expect(profile.enabledDomains.every((domainId) => WORKFLOW_DOMAIN_IDS.includes(domainId))).toBe(true);
+    });
+  });
+
+  it('creates exact preferences from standard profiles and infers custom combinations', () => {
+    const electronics = createPreferenceFromProfile('electronics-pcb');
+    expect(electronics.enabledDomains).toEqual(['product', 'electronics', 'pcb', 'validation', 'outputs']);
+    expect(inferProfileId(electronics.enabledDomains)).toBe('electronics-pcb');
+
+    expect(inferProfileId(['mechanical', 'firmware'])).toBe('custom');
+  });
+
+  it('normalizes malformed storage without admitting unknown domains', () => {
+    expect(normalizeWorkflowPreference(null).enabledDomains).toEqual([...WORKFLOW_DOMAIN_IDS]);
+
+    const normalized = normalizeWorkflowPreference({
+      version: 999,
+      profileId: 'not-real',
+      enabledDomains: ['pcb', 'pcb', 'unknown', 'firmware'],
+      showAllDomains: 'yes',
+      hasCompletedSetup: true,
+    });
+
+    expect(normalized).toEqual({
+      version: 1,
+      profileId: 'custom',
+      enabledDomains: ['pcb', 'firmware'],
+      showAllDomains: false,
+      hasCompletedSetup: true,
+    });
+  });
+
+  it('toggles domains in canonical order and reports the hidden count', () => {
+    const withoutMechanical = toggleWorkflowDomain(WORKFLOW_DOMAIN_IDS, 'mechanical');
+    expect(withoutMechanical).not.toContain('mechanical');
+    expect(getHiddenDomainCount(withoutMechanical)).toBe(1);
+
+    const restored = toggleWorkflowDomain(withoutMechanical, 'mechanical');
+    expect(restored).toEqual([...WORKFLOW_DOMAIN_IDS]);
+  });
+});
+
+describe('capability-based navigation', () => {
+  it('always preserves Overview while filtering other domains', () => {
+    const visible = getVisibleNavigationDomains(['electronics'], 'dashboard', false);
+    expect(visible.map((domain) => domain.id)).toEqual(['overview', 'electronics']);
+    expect(visible[0]).toEqual(navigationDomains[0]);
+  });
+
+  it('preserves a currently active hidden workbench until the user leaves it', () => {
+    const visible = getVisibleNavigationDomains(['electronics'], 'mechanical-studio', false);
+    expect(visible.map((domain) => domain.id)).toEqual(['overview', 'mechanical', 'electronics']);
+  });
+
+  it('returns the full registry only for temporary Show all', () => {
+    const visible = getVisibleNavigationDomains([], 'dashboard', true);
+    expect(visible).toEqual(navigationDomains);
+  });
+});
+
+describe('truthful standalone guidance', () => {
+  it('explains PCB and firmware limitations when electronics is hidden', () => {
+    const notices = getWorkflowConnectionNotices(['pcb', 'firmware']);
+    expect(notices.map((notice) => notice.id)).toEqual([
+      'pcb-without-electronics',
+      'firmware-without-electronics',
+    ]);
+  });
+
+  it('describes useful mechanical and PCB connectivity without forcing a dependency', () => {
+    const notices = getWorkflowConnectionNotices(['mechanical', 'pcb']);
+    expect(notices.some((notice) => notice.id === 'pcb-without-electronics')).toBe(true);
+    expect(notices.some((notice) => notice.id === 'mechanical-pcb-connected')).toBe(true);
+  });
+
+  it('does not invent warnings for a complete connected workflow', () => {
+    expect(getWorkflowConnectionNotices(WORKFLOW_DOMAIN_IDS)).toEqual([
+      expect.objectContaining({ id: 'mechanical-pcb-connected', tone: 'info' }),
+    ]);
+  });
+});
+
+describe('guided project actions', () => {
+  it('derives exactly one honest action for each enabled domain', () => {
+    const enabled = ['product', 'electronics', 'pcb', 'firmware', 'validation', 'outputs'] as const;
+    const actions = deriveGuidedWorkflowActions(enabled, emptySnapshot);
+    expect(actions.map((action) => action.domainId)).toEqual(enabled);
+    expect(new Set(actions.map((action) => action.domainId)).size).toBe(enabled.length);
+    expect(actions.every((action) => action.status === 'start')).toBe(true);
+  });
+
+  it('moves from creation to review based on actual project evidence', () => {
+    const populated: WorkflowProjectSnapshot = {
+      ...emptySnapshot,
+      requirements: 5,
+      architectureNodes: 8,
+      components: 12,
+      circuitBlocks: 4,
+      nets: 18,
+      boards: 1,
+      traces: 30,
+      firmwareModules: 6,
+      firmwareStates: 4,
+      validationTests: 9,
+      validationRuns: 3,
+      revisions: 2,
+      factoryPackageStatus: 'Review',
+    };
+
+    const actions = deriveGuidedWorkflowActions(
+      ['product', 'electronics', 'pcb', 'firmware', 'validation', 'outputs'],
+      populated,
+    );
+
+    expect(actions.every((action) => action.status === 'review')).toBe(true);
+    expect(actions.find((action) => action.domainId === 'pcb')?.viewId).toBe('pcb-constraints');
+    expect(actions.find((action) => action.domainId === 'validation')?.viewId).toBe('requirement-coverage');
+  });
+
+  it('returns no domain action for an overview-only workspace', () => {
+    expect(deriveGuidedWorkflowActions([], emptySnapshot)).toEqual([]);
+  });
+});

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertTriangle, ArrowLeft } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, EyeOff, Settings2 } from 'lucide-react';
 import { useProjectStore } from '../store/projectStore';
 import { useStorageHealthStore } from '../store/storageHealthStore';
+import { useWorkflowPreferencesStore } from '../store/workflowPreferencesStore';
 import { getNavigationItem, isCanvasNavigationItem, NavigationSurface } from '../lib/navigationRegistry';
+import { getDomainIdForView, type WorkflowDomainId } from '../lib/workflowProfiles';
 import { useFeedback } from './feedback/FeedbackProvider';
 import { RECOVER_TO_DASHBOARD_KEY } from '../lib/reliability';
 import { TopBar } from './TopBar';
@@ -64,23 +66,13 @@ const UnavailableWorkspace: React.FC<{ viewId: string; onReturn: () => void }> =
   <section className="flex h-full min-h-0 flex-1 items-center justify-center bg-slate-50 px-6 py-10">
     <div className="w-full max-w-xl rounded-2xl border border-amber-200 bg-white p-6 shadow-sm">
       <div className="flex items-start gap-3">
-        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-amber-50 text-amber-700">
-          <AlertTriangle className="h-5 w-5" aria-hidden="true" />
-        </span>
+        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-amber-50 text-amber-700"><AlertTriangle className="h-5 w-5" aria-hidden="true" /></span>
         <div className="min-w-0">
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-700">Workspace unavailable</p>
           <h1 className="mt-1 text-xl font-semibold tracking-tight text-slate-950">This view is not registered.</h1>
-          <p className="mt-2 text-sm leading-6 text-slate-600">
-            The saved view ID <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-800">{viewId}</code>{' '}
-            does not match a current Hardware Studio workbench. No project data was changed and no unrelated editor was opened.
-          </p>
-          <button
-            type="button"
-            onClick={onReturn}
-            className="mt-5 inline-flex items-center gap-2 rounded-lg bg-slate-950 px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
-          >
-            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            Return to project dashboard
+          <p className="mt-2 text-sm leading-6 text-slate-600">The saved view ID <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-800">{viewId}</code> does not match a current Hardware Studio workbench. No project data was changed and no unrelated editor was opened.</p>
+          <button type="button" onClick={onReturn} className="mt-5 inline-flex items-center gap-2 rounded-lg bg-slate-950 px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" /> Return to project dashboard
           </button>
         </div>
       </div>
@@ -91,6 +83,7 @@ const UnavailableWorkspace: React.FC<{ viewId: string; onReturn: () => void }> =
 export const AppShell: React.FC = () => {
   const { activeView, loadProjectFromLocalStorage, setActiveView } = useProjectStore();
   const storageHealth = useStorageHealthStore((state) => state.health);
+  const { enabledDomains, showAllDomains, toggleDomain, openSetup } = useWorkflowPreferencesStore();
   const retrySave = useCallback(() => {
     useProjectStore.getState().saveActiveProject();
   }, []);
@@ -131,12 +124,16 @@ export const AppShell: React.FC = () => {
   const activeNavigationItem = getNavigationItem(activeView);
   const isCanvasView = isCanvasNavigationItem(activeNavigationItem);
   const showVisualizer = Boolean(activeNavigationItem?.showVisualizer);
+  const activeDomain = getDomainIdForView(activeView);
+  const activeHiddenDomain = activeDomain && activeDomain !== 'overview'
+    && !enabledDomains.includes(activeDomain as WorkflowDomainId)
+    && !showAllDomains
+    ? activeDomain as WorkflowDomainId
+    : undefined;
 
   if (!mounted) {
     return (
-      <div className="flex h-screen w-screen select-none items-center justify-center bg-slate-50 font-mono text-[10px] uppercase tracking-widest text-slate-500">
-        Initializing workspace...
-      </div>
+      <div className="flex h-screen w-screen select-none items-center justify-center bg-slate-50 font-mono text-[10px] uppercase tracking-widest text-slate-500">Initializing workspace...</div>
     );
   }
 
@@ -146,6 +143,18 @@ export const AppShell: React.FC = () => {
       <div className="relative flex min-h-0 flex-1">
         <Sidebar />
         <main className="relative flex h-full min-w-0 flex-1 flex-col overflow-hidden">
+          {activeHiddenDomain && (
+            <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-amber-950">
+              <div className="flex min-w-0 items-center gap-2">
+                <EyeOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+                <p className="text-xs leading-5"><strong>This workbench is hidden from your current workflow.</strong> It remains open until you leave, and its project data has not been changed.</p>
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <button type="button" onClick={() => toggleDomain(activeHiddenDomain)} className="rounded-lg border border-amber-300 bg-white px-2.5 py-1.5 text-xs font-semibold hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-500">Show this domain</button>
+                <button type="button" onClick={openSetup} className="inline-flex items-center gap-1.5 rounded-lg bg-amber-900 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-amber-800 focus:outline-none focus:ring-2 focus:ring-amber-600 focus:ring-offset-1"><Settings2 className="h-3.5 w-3.5" aria-hidden="true" /> Configure</button>
+              </div>
+            </div>
+          )}
           <div className="relative flex min-h-0 flex-1">
             {showVisualizer && <ProductVisualizer />}
             <div className="relative flex h-full min-w-0 flex-1 flex-col">

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,580 +1,236 @@
-import React, { useState, useEffect } from 'react';
-import { useProjectStore } from '../store/projectStore';
-import { calculateReadinessScore } from '../lib/readinessScore';
-import { Button } from '../ui/Button';
-import { Card, CardHeader, CardContent, CardTitle } from '../ui/Card';
-import { Badge } from '../ui/Badge';
-import { 
-  RefreshCw, 
-  CheckCircle,
-  Download,
+'use client';
+
+import React, { useMemo } from 'react';
+import {
   AlertTriangle,
-  Play,
-  Hammer,
-  ShieldCheck,
-  ChevronRight,
-  Check,
-  Package
+  ArrowRight,
+  CheckCircle2,
+  CircleHelp,
+  EyeOff,
+  Link2,
+  Settings2,
+  Unlink,
 } from 'lucide-react';
+import { navigationDomains } from '../lib/navigationRegistry';
+import {
+  deriveGuidedWorkflowActions,
+  getHiddenDomainCount,
+  getWorkflowConnectionNotices,
+  getWorkflowProfile,
+  type WorkflowDomainId,
+  type WorkflowProjectSnapshot,
+} from '../lib/workflowProfiles';
+import { useProjectStore } from '../store/projectStore';
+import { useWorkflowPreferencesStore } from '../store/workflowPreferencesStore';
+
+function arrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value : fallback;
+}
+
+const domainById = new Map(
+  navigationDomains
+    .filter((domain) => domain.id !== 'overview')
+    .map((domain) => [domain.id as WorkflowDomainId, domain]),
+);
+
+const statusStyles = {
+  start: 'border-indigo-200 bg-indigo-50 text-indigo-800',
+  continue: 'border-sky-200 bg-sky-50 text-sky-800',
+  review: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+} as const;
 
 export const ProjectDashboard: React.FC = () => {
   const store = useProjectStore();
-  const { 
-    projectName, 
-    description, 
-    templateName, 
-    version,
-    nodes = [], 
-    firmwareTasks = [], 
-    testing = [], 
-    boards = [], 
-    circuitBlocks = [], 
-    boardComponents = [], 
-    nets = [], 
-    factoryFiles = {},
-    editorLayouts = {},
-    traces = [],
-    drillHoles = [],
-    mechanicalZones = [],
-    assemblyLayers = [],
-    factoryPackageStatus = "Draft",
-    factoryReviewChecks = {},
-    reviewResults = [],
-    requirements = [],
-    architectureNodes = [],
-    mechanicalObjects = [],
-    firmwareModules = [],
-    validationTests = [],
-    setActiveView,
-    generateFullProductPlan,
-    runFullDesignReview,
-    generateEditorLayouts,
-    addGndNet,
-    addI2cPullupResistor,
-    addFlybackDiode,
-    addDebugTestPad,
-    fixMissingDimensionsWithPlaceholder,
-    autoPlaceComponents
-  } = store;
+  const { projectName, description, setActiveView } = store;
+  const project = store as unknown as Record<string, unknown>;
+  const { enabledDomains, profileId, openSetup } = useWorkflowPreferencesStore();
 
-  // Run design review on render mount
-  useEffect(() => {
-    runFullDesignReview();
-  }, [runFullDesignReview]);
+  const profile = getWorkflowProfile(profileId);
+  const hiddenDomainCount = getHiddenDomainCount(enabledDomains);
 
-  const report = calculateReadinessScore(store);
-  const [toastMessage, setToastMessage] = useState<string | null>(null);
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [activeTab, setActiveTab] = useState<'all' | 'blockers' | 'warnings'>('all');
+  const snapshot = useMemo<WorkflowProjectSnapshot>(() => ({
+    requirements: arrayLength(project.requirements),
+    architectureNodes: Math.max(arrayLength(project.architectureNodes), arrayLength(project.nodes)),
+    risks: Math.max(arrayLength(project.productRisks), arrayLength(project.risks)),
+    mechanicalObjects: arrayLength(project.mechanicalObjects),
+    assemblyLayers: arrayLength(project.assemblyLayers),
+    components: arrayLength(project.boardComponents),
+    circuitBlocks: arrayLength(project.circuitBlocks),
+    nets: arrayLength(project.nets),
+    boards: arrayLength(project.boards),
+    traces: arrayLength(project.traces),
+    firmwareModules: arrayLength(project.firmwareModules),
+    firmwareStates: arrayLength(project.firmwareStates),
+    validationTests: arrayLength(project.validationTests),
+    validationRuns: arrayLength(project.validationRuns),
+    revisions: arrayLength(project.revisions),
+    factoryPackageStatus: stringValue(project.factoryPackageStatus, 'Draft'),
+  }), [project]);
 
-  const handleGenerateAll = () => {
-    setIsGenerating(true);
-    setTimeout(() => {
-      const res = generateFullProductPlan();
-      setToastMessage(res.summary);
-      setIsGenerating(false);
-      runFullDesignReview();
-      setTimeout(() => setToastMessage(null), 5000);
-    }, 600);
-  };
+  const guidedActions = useMemo(
+    () => deriveGuidedWorkflowActions(enabledDomains, snapshot),
+    [enabledDomains, snapshot],
+  );
+  const connectionNotices = useMemo(
+    () => getWorkflowConnectionNotices(enabledDomains),
+    [enabledDomains],
+  );
 
-  const handleGenerateLayouts = () => {
-    generateEditorLayouts();
-    setToastMessage("Editor Layouts generated dynamically. View them in Blueprint Editor.");
-    runFullDesignReview();
-    setTimeout(() => setToastMessage(null), 5000);
-  };
-
-  // Determine stage info
-  const getProjectStageInfo = () => {
-    if (report.canMoveToFabrication) {
-      return { stage: "Factory Released", action: "Export Handoff Package", nextView: "factory-builder" };
-    }
-    if (report.canMoveToFactoryHandoff) {
-      return { stage: "Manufacturing Audit", action: "Verify Factory release files", nextView: "factory-builder" };
-    }
-    if (report.canMoveToPrototype) {
-      return { stage: "Prototype Testing", action: "Execute bring-up checklist", nextView: "testing" };
-    }
-    if (report.isEditorLayoutReady) {
-      return { stage: "CAD Layout Routing", action: "Draw copper trace paths", nextView: "blueprint-editor" };
-    }
-    if (report.isBlueprintPackReady) {
-      return { stage: "Drawing Generation", action: "Review engineering sheets", nextView: "blueprint-sheets" };
-    }
-    return { stage: "Architecture & Planning", action: "Generate Full Product Plan", nextView: "dashboard" };
-  };
-
-  const stageInfo = getProjectStageInfo();
-
-  // Design review severity breakdown
-  const reviewSummary = {
-    blockers: reviewResults.filter(r => r.severity === 'Blocker').length,
-    errors: reviewResults.filter(r => r.severity === 'Error').length,
-    warnings: reviewResults.filter(r => r.severity === 'Warning').length,
-    infos: reviewResults.filter(r => r.severity === 'Info').length,
-  };
-
-  // Dynamic next recommended actions
-  const nextActionsList: { label: string; action: () => void; buttonLabel: string }[] = [];
-
-  if (boards.length === 0) {
-    nextActionsList.push({
-      label: "Active board outline dimensions not configured in database.",
-      buttonLabel: "Configure Board",
-      action: () => setActiveView("board-studio")
-    });
-  }
-
-  const unplaced = boardComponents.filter(c => !c.placementX || !c.placementY);
-  if (unplaced.length > 0) {
-    nextActionsList.push({
-      label: `${unplaced.length} components footprints lack placement coordinates.`,
-      buttonLabel: "Auto-Place Layout",
-      action: () => {
-        autoPlaceComponents();
-        setToastMessage("Auto-placed SMT components layout coordinates.");
-        runFullDesignReview();
-      }
-    });
-  }
-
-  if (!nets.some(n => n.netName.toUpperCase() === 'GND')) {
-    nextActionsList.push({
-      label: "Logical GND ground connection path reference net is missing.",
-      buttonLabel: "Add GND Net",
-      action: () => {
-        addGndNet();
-        setToastMessage("Created missing logical GND net.");
-        runFullDesignReview();
-      }
-    });
-  }
-
-  const totalLayoutObjs = Object.values(editorLayouts).reduce((sum, arr) => sum + (arr?.length || 0), 0);
-  if (totalLayoutObjs === 0) {
-    nextActionsList.push({
-      label: "Blueprint Editor layout canvas outlines have not been initialized.",
-      buttonLabel: "Generate Layouts",
-      action: () => handleGenerateLayouts()
-    });
-  }
-
-  if (drillHoles.length === 0) {
-    nextActionsList.push({
-      label: "Micro drill holes coordinate list is empty.",
-      buttonLabel: "Seed Template Drills",
-      action: () => setActiveView("board-studio")
-    });
-  }
-
-  if (factoryPackageStatus === 'Draft') {
-    nextActionsList.push({
-      label: "Draft manufacturing stencils package has not been generated.",
-      buttonLabel: "Compile Package",
-      action: () => setActiveView("factory-builder")
-    });
-  }
-
-  const checklistItemsCount = 10;
-  const checkedCount = Object.values(factoryReviewChecks).filter(Boolean).length;
-  if (checkedCount < checklistItemsCount && factoryPackageStatus !== 'Draft') {
-    nextActionsList.push({
-      label: `${checklistItemsCount - checkedCount} checklist review verifications are pending.`,
-      buttonLabel: "Complete Review",
-      action: () => setActiveView("factory-builder")
-    });
-  }
-
-  const mainNextActionLabel = nextActionsList[0]?.label || "Engineering review passed. Export your fabrication release manifest.";
-  const mainNextActionTrigger = nextActionsList[0]?.action || (() => setActiveView("factory-builder"));
-  const mainNextActionButton = nextActionsList[0]?.buttonLabel || "Open Builder";
-
-  // Category warnings extractor helper
-  const getCategoryIssuesCount = (cat: string) => {
-    return reviewResults.filter(r => r.category === cat && r.severity !== 'Info').length;
-  };
-
-  // 10 Pipeline Stages Configuration
-  const pipelineStages = [
-    { step: "Idea", label: "Template pick", active: true, count: 1, unit: "selected", warnings: 0, view: "dashboard" },
-    { step: "Architecture", label: "Subsystems map", active: architectureNodes.length > 0 || nodes.length > 0, count: architectureNodes.length || nodes.length, unit: "nodes", warnings: getCategoryIssuesCount("Architecture"), view: "electronics" },
-    { step: "Mechanical", label: "Enclosure outline", active: mechanicalObjects.length > 0 || mechanicalZones.length > 0, count: mechanicalObjects.length || mechanicalZones.length, unit: "zones", warnings: getCategoryIssuesCount("Mechanical"), view: "mechanical-studio" },
-    { step: "Assembly", label: "Stackup stack", active: assemblyLayers.length > 0, count: assemblyLayers.length, unit: "layers", warnings: getCategoryIssuesCount("Assembly"), view: "assembly-stack" },
-    { step: "Schematic", label: "Logical modules", active: circuitBlocks.length > 0, count: circuitBlocks.length, unit: "circuits", warnings: getCategoryIssuesCount("Schematic ERC"), view: "schematic-editor" },
-    { step: "PCB Layout", label: "Substrates contours", active: boards.length > 0, count: boards.length, unit: "PCBs", warnings: getCategoryIssuesCount("PCB DRC"), view: "board-designer" },
-    { step: "Routing", label: "Trace track path", active: traces.length > 0, count: traces.length, unit: "traces", warnings: getCategoryIssuesCount("Routing"), view: "board-designer" },
-    { step: "Firmware", label: "Code driver loops", active: firmwareModules.length > 0 || firmwareTasks.length > 0, count: firmwareModules.length || firmwareTasks.length, unit: "modules", warnings: getCategoryIssuesCount("Firmware"), view: "firmware-studio" },
-    { step: "Testing", label: "QA diagnostic plan", active: validationTests.length > 0 || testing.length > 0, count: validationTests.length || testing.length, unit: "tests", warnings: getCategoryIssuesCount("Testing"), view: "validation-studio" },
-    { step: "Factory Package", label: "Gerbers drill release", active: factoryPackageStatus !== 'Draft', count: Object.values(factoryFiles).filter(f => f && f.status !== 'Not Generated').length, unit: "files", warnings: getCategoryIssuesCount("Factory Package"), view: "factory-builder" }
-  ];
-
-  const getActionResolver = (resId: string) => {
-    switch (resId) {
-      case 'rev_erc_gnd':
-        return { label: "Add GND Net", run: () => addGndNet() };
-      case 'rev_arch_input':
-      case 'rev_arch_power':
-      case 'rev_arch_feedback':
-        return { label: "Generate Blueprint Pack", run: () => handleGenerateAll() };
-      case 'rev_erc_i2c_pullups':
-        return { label: "Add pull-ups (4.7k)", run: () => addI2cPullupResistor() };
-      case 'rev_erc_motor_protection':
-        return { label: "Add flyback protection", run: () => addFlybackDiode() };
-      case 'rev_erc_mcu_debug':
-        return { label: "Add SWD programming pads", run: () => addDebugTestPad() };
-      case 'rev_drc_dim_board_main':
-      case 'rev_drc_dim_board_ring':
-        return { label: "Fix board bounds", run: () => fixMissingDimensionsWithPlaceholder() };
-      case 'rev_bom_footprint_led':
-      case 'rev_bom_footprint_mcu':
-        return { label: "Auto-place layout", run: () => autoPlaceComponents() };
-      default:
-        return null;
-    }
-  };
-
-  const filteredReviews = reviewResults.filter(res => {
-    if (activeTab === 'blockers') return res.severity === 'Blocker' || res.severity === 'Error';
-    if (activeTab === 'warnings') return res.severity === 'Warning';
-    return true;
-  });
+  const dataSummary = [
+    ['Requirements', snapshot.requirements],
+    ['Architecture', snapshot.architectureNodes],
+    ['Mechanical objects', snapshot.mechanicalObjects],
+    ['Components', snapshot.components],
+    ['Boards', snapshot.boards],
+    ['Firmware modules', snapshot.firmwareModules],
+    ['Validation tests', snapshot.validationTests],
+    ['Revisions', snapshot.revisions],
+  ] as const;
 
   return (
-    <div className="flex-1 bg-slate-50 overflow-y-auto p-6 space-y-6 select-none font-sans text-slate-800 h-full">
-      {/* Toast Notification */}
-      {toastMessage && (
-        <div className="fixed bottom-6 right-6 z-50 bg-white border border-slate-200 text-slate-900 rounded-lg px-4 py-3.5 shadow-xl max-w-md flex items-start space-x-3">
-          <CheckCircle className="w-5 h-5 text-emerald-600 shrink-0 mt-0.5" />
-          <div className="space-y-1">
-            <span className="text-[10px] font-bold uppercase tracking-wider block font-mono text-emerald-700">Store Action Confirmed</span>
-            <p className="text-[11px] font-sans font-medium text-slate-600 leading-relaxed">{toastMessage}</p>
-          </div>
-        </div>
-      )}
-
-      {/* Hero Header */}
-      <div className="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm relative overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,_var(--tw-gradient-stops))] from-indigo-50/50 via-transparent to-transparent pointer-events-none" />
-        
-        <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-6 relative z-10">
-          <div className="space-y-2">
-            <div className="flex items-center space-x-2">
-              <Badge className="bg-indigo-50 text-indigo-700 border border-indigo-200/50 uppercase text-[9px] tracking-widest font-mono font-bold py-0.5">
-                {templateName || 'Custom Blueprint'}
-              </Badge>
-              <span className="text-slate-400 font-mono text-[10px]">V{version || "3.0"}</span>
-            </div>
-            <h1 className="text-2xl font-black text-slate-900 uppercase tracking-tight font-mono">{projectName}</h1>
-            <p className="text-xs text-slate-500 max-w-2xl">{description || 'No project description mapped.'}</p>
-            
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 pt-2 text-[10.5px]">
-              <div className="flex items-center space-x-1.5 bg-slate-50 px-2.5 py-1 rounded border border-slate-200">
-                <span className="text-slate-450">Pipeline Stage:</span>
-                <span className="text-indigo-650 font-bold uppercase font-mono">{stageInfo.stage}</span>
-              </div>
-              <div className="flex items-center space-x-1.5 bg-slate-50 px-2.5 py-1 rounded border border-slate-200">
-                <span className="text-slate-455">Readiness Score:</span>
-                <span className="text-emerald-600 font-black font-mono">{report.overallScore}%</span>
-              </div>
-              <div className="flex items-center space-x-1.5 bg-slate-50 px-2.5 py-1 rounded border border-slate-200">
-                <span className="text-slate-455">Package Status:</span>
-                <span className="text-emerald-600 font-bold font-mono">{factoryPackageStatus}</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="shrink-0 flex flex-wrap gap-2 lg:max-w-md">
-            <Button onClick={handleGenerateAll} disabled={isGenerating} className="h-8 text-[10.5px] uppercase font-bold bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer shadow-sm">
-              <RefreshCw className={`w-3.5 h-3.5 mr-1 ${isGenerating ? 'animate-spin' : ''}`} />
-              Generate Product Plan
-            </Button>
-            <Button onClick={handleGenerateLayouts} variant="outline" className="h-8 text-[10.5px] border-slate-250 bg-white hover:bg-slate-50 text-slate-700 cursor-pointer shadow-sm">
-              <Hammer className="w-3.5 h-3.5 mr-1" />
-              Generate Layouts
-            </Button>
-            <Button onClick={() => store.runFullDesignReview()} variant="outline" className="h-8 text-[10.5px] border-slate-250 bg-white hover:bg-slate-50 text-slate-700 cursor-pointer shadow-sm">
-              <ShieldCheck className="w-3.5 h-3.5 mr-1" />
-              Run Design Review
-            </Button>
-            <Button onClick={() => setActiveView('blueprint-editor')} className="h-8 text-[10.5px] uppercase font-bold bg-emerald-600 hover:bg-emerald-555 text-white cursor-pointer shadow-sm">
-              <Play className="w-3.5 h-3.5 mr-1 fill-current" />
-              Open Canvas
-            </Button>
-            <Button onClick={() => setActiveView('factory-builder')} variant="outline" className="h-8 text-[10.5px] border-slate-250 bg-white hover:bg-slate-50 text-slate-700 cursor-pointer shadow-sm">
-              <Download className="w-3.5 h-3.5 mr-1" />
-              Export Factory Package
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      {/* Main Recommended Action Callout */}
-      <div className="bg-amber-50 border border-amber-250/60 rounded-xl p-4 flex items-center justify-between gap-4 shadow-sm">
-        <div className="flex items-start space-x-3 text-amber-850">
-          <AlertTriangle className="w-4.5 h-4.5 text-amber-600 shrink-0 mt-0.5" />
-          <div>
-            <div className="text-[10px] uppercase font-black tracking-wider text-slate-500 font-mono">Next Recommended Action</div>
-            <p className="text-[11px] leading-relaxed mt-0.5">{mainNextActionLabel}</p>
-          </div>
-        </div>
-        <Button onClick={mainNextActionTrigger} className="shrink-0 h-7 text-[10px] bg-amber-600 hover:bg-amber-700 text-white font-bold border-none shadow-sm">
-          {mainNextActionButton}
-        </Button>
-      </div>
-
-      {/* End-to-End Pipeline visual flowchart */}
-      <div className="bg-white border border-slate-200 rounded-xl p-4 shadow-sm">
-        <h2 className="text-[10px] font-black uppercase tracking-wider text-slate-600 mb-3 px-1 font-mono">
-          Engineering Flow Pipeline
-        </h2>
-        <div className="flex flex-col md:flex-row items-stretch md:items-center justify-between gap-2 overflow-x-auto pb-1 scrollbar-thin">
-          {pipelineStages.map((stage, idx) => {
-            const isCompleted = stage.active;
-            const wCount = stage.warnings;
-            return (
-              <React.Fragment key={idx}>
-                <div 
-                  onClick={() => setActiveView(stage.view)}
-                  className={`flex-1 min-w-[125px] border rounded-lg p-2.5 flex flex-col justify-between text-left transition-all cursor-pointer relative hover:border-slate-350 ${
-                    isCompleted 
-                      ? 'border-indigo-200 bg-indigo-50/40 text-slate-900 hover:bg-indigo-50/70' 
-                      : 'border-slate-150 bg-slate-50/50 text-slate-400'
-                  }`}
-                >
-                  {isCompleted && (
-                    <div className="absolute top-1.5 right-1.5 bg-emerald-500 text-white rounded-full p-0.5 shadow">
-                      <Check className="w-2.5 h-2.5 stroke-[3]" />
-                    </div>
-                  )}
-                  
-                  <div>
-                    <span className="text-[9.5px] font-bold uppercase tracking-wider font-mono block">{stage.step}</span>
-                    <span className="text-[7.5px] text-slate-450 mt-0.5 leading-none block font-sans truncate">{stage.label}</span>
-                  </div>
-
-                  <div className="flex items-center justify-between mt-2.5 pt-1 border-t border-slate-100 text-[9px] font-mono">
-                    <span className="text-slate-655 font-bold">{stage.count} {stage.unit}</span>
-                    {wCount > 0 && (
-                      <span className="text-amber-700 font-bold bg-amber-50 px-1 rounded">
-                        {wCount} ⚠️
-                      </span>
-                    )}
-                  </div>
-                </div>
-                {idx < 9 && (
-                  <ChevronRight className={`w-3.5 h-3.5 hidden md:block shrink-0 ${isCompleted ? 'text-indigo-300' : 'text-slate-200'}`} />
+    <div className="h-full overflow-y-auto bg-slate-50 p-4 text-slate-900 sm:p-5 lg:p-6">
+      <div className="mx-auto max-w-7xl space-y-5">
+        <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="grid gap-5 p-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:p-6">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-indigo-200 bg-indigo-50 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-[0.12em] text-indigo-700">{profile.name}</span>
+                <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[10px] font-bold text-slate-600">{enabledDomains.length} domains visible</span>
+                {hiddenDomainCount > 0 && (
+                  <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[10px] font-bold text-slate-600">
+                    <EyeOff className="h-3 w-3" aria-hidden="true" /> {hiddenDomainCount} hidden
+                  </span>
                 )}
-              </React.Fragment>
-            );
-          })}
-        </div>
-      </div>
+              </div>
+              <h1 className="mt-3 text-2xl font-bold tracking-tight text-slate-950 sm:text-3xl">{projectName}</h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">{description || 'Build only the parts of the product you need, while keeping shared engineering data connected when multiple domains are enabled.'}</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {enabledDomains.map((domainId) => {
+                  const domain = domainById.get(domainId);
+                  return domain ? (
+                    <span key={domainId} className="rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-slate-700 shadow-sm">{domain.label}</span>
+                  ) : null;
+                })}
+                {enabledDomains.length === 0 && (
+                  <span className="rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-xs font-semibold text-amber-800">Overview-only workflow</span>
+                )}
+              </div>
+            </div>
 
-      {/* Grid: Design Review & Factory Package Summary */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        {/* Design Review (7 columns) */}
-        <div className="lg:col-span-7 space-y-4">
-          <Card className="bg-white border border-slate-200 shadow-sm">
-            <CardHeader className="bg-slate-50/60 border-b border-slate-150 p-4">
-              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                <div className="flex items-center space-x-2">
-                  <ShieldCheck className="w-4.5 h-4.5 text-emerald-600" />
-                  <CardTitle className="text-xs font-black text-slate-900 uppercase tracking-wider font-mono">
-                    Design Review Summary
-                  </CardTitle>
-                </div>
-                <div className="flex space-x-2">
-                  <div className="flex space-x-1 bg-slate-50 p-0.5 rounded border border-slate-150 self-start">
-                    {(['all', 'blockers', 'warnings'] as const).map(tab => (
-                      <button
-                        key={tab}
-                        onClick={() => setActiveTab(tab)}
-                        className={`px-2.5 py-1 rounded text-[8.5px] uppercase font-bold tracking-wider font-mono transition-all cursor-pointer ${
-                          activeTab === tab 
-                            ? 'bg-white text-slate-900 font-bold shadow-sm border border-slate-200/50' 
-                            : 'text-slate-500 hover:text-slate-705'
-                        }`}
-                      >
-                        {tab}
-                      </button>
-                    ))}
-                  </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              <div className="flex items-start gap-3">
+                <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-white text-indigo-700 shadow-sm"><Settings2 className="h-4 w-4" aria-hidden="true" /></span>
+                <div>
+                  <h2 className="text-sm font-bold text-slate-950">Your studio adapts to the work</h2>
+                  <p className="mt-1 text-xs leading-5 text-slate-600">Hiding a domain changes navigation only. Existing project data remains untouched and can be shown again at any time.</p>
                 </div>
               </div>
-            </CardHeader>
-            <CardContent className="p-4 space-y-3 max-h-[350px] overflow-y-auto scrollbar-thin">
-              
-              {/* Severity Summary Counter */}
-              <div className="grid grid-cols-4 gap-2 mb-2 text-center text-[10px] font-mono">
-                <div className="bg-slate-50 p-2 rounded border border-slate-150">
-                  <div className="text-rose-600 font-bold text-sm">{reviewSummary.blockers}</div>
-                  <div className="text-slate-500 uppercase tracking-widest text-[7px] mt-0.5">Blockers</div>
-                </div>
-                <div className="bg-slate-50 p-2 rounded border border-slate-150">
-                  <div className="text-rose-500 font-bold text-sm">{reviewSummary.errors}</div>
-                  <div className="text-slate-500 uppercase tracking-widest text-[7px] mt-0.5">Errors</div>
-                </div>
-                <div className="bg-slate-50 p-2 rounded border border-slate-150">
-                  <div className="text-amber-600 font-bold text-sm">{reviewSummary.warnings}</div>
-                  <div className="text-slate-500 uppercase tracking-widest text-[7px] mt-0.5">Warnings</div>
-                </div>
-                <div className="bg-slate-50 p-2 rounded border border-slate-150">
-                  <div className="text-indigo-600 font-bold text-sm">{reviewSummary.infos}</div>
-                  <div className="text-slate-500 uppercase tracking-widest text-[7px] mt-0.5">Info</div>
-                </div>
-              </div>
+              <button
+                type="button"
+                onClick={openSetup}
+                className="mt-4 inline-flex h-9 w-full items-center justify-center gap-2 rounded-lg bg-slate-950 px-3 text-sm font-semibold text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+              >
+                Configure workflow
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </section>
 
-              {filteredReviews.length === 0 ? (
-                <div className="text-center py-6 text-slate-500 space-y-2">
-                  <CheckCircle className="w-8 h-8 text-emerald-500 mx-auto opacity-70" />
-                  <p className="text-[10px] uppercase font-bold tracking-wider font-mono">0 review violations flagged</p>
-                  <p className="text-[10px] font-sans text-slate-500">ERC parameters and layout DRC paths look safe.</p>
-                </div>
-              ) : (
-                filteredReviews.slice(0, 5).map((action, idx) => {
-                  const resolver = getActionResolver(action.id);
-                  const isError = action.severity === 'Error' || action.severity === 'Blocker';
-                  
-                  return (
-                    <div key={action.id || idx} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 bg-slate-50/50 p-3 rounded border border-slate-150 hover:bg-slate-50 transition-all">
-                      <div className="space-y-1">
-                        <div className="flex items-center space-x-2">
-                          <span className={`px-1.5 py-0.25 rounded text-[8px] font-extrabold font-mono border uppercase tracking-wider ${
-                            isError
-                              ? 'bg-rose-50 text-rose-700 border-rose-200'
-                              : 'bg-amber-50 text-amber-700 border-amber-200'
-                          }`}>
-                            {action.severity}
-                          </span>
-                          <span className="text-[10.5px] font-bold text-slate-800 font-mono block">
-                            {action.title}
-                          </span>
-                        </div>
-                        <p className="text-[10px] text-slate-500 leading-relaxed font-sans max-w-xl">
-                          {action.description}
-                        </p>
+        <section aria-labelledby="next-actions-title">
+          <div>
+            <p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">Guided next actions</p>
+            <h2 id="next-actions-title" className="mt-1 text-xl font-bold tracking-tight text-slate-950">What should happen next</h2>
+            <p className="mt-1 text-sm text-slate-600">One honest action per visible domain, derived from the project data that actually exists.</p>
+          </div>
+
+          {guidedActions.length > 0 ? (
+            <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {guidedActions.map((action) => {
+                const domain = domainById.get(action.domainId);
+                return (
+                  <button
+                    key={action.domainId}
+                    type="button"
+                    onClick={() => setActiveView(action.viewId)}
+                    className="group rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-[10px] font-extrabold uppercase tracking-[0.12em] text-slate-500">{domain?.label ?? action.domainId}</p>
+                        <h3 className="mt-1 text-sm font-bold leading-5 text-slate-950">{action.title}</h3>
                       </div>
+                      <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[9px] font-extrabold uppercase tracking-wide ${statusStyles[action.status]}`}>{action.status}</span>
+                    </div>
+                    <p className="mt-2 text-xs leading-5 text-slate-600">{action.description}</p>
+                    <div className="mt-4 flex items-center justify-between gap-3 border-t border-slate-100 pt-3">
+                      <span className="text-[10px] font-semibold text-slate-500">{action.evidence}</span>
+                      <ArrowRight className="h-4 w-4 text-slate-400 transition group-hover:translate-x-0.5 group-hover:text-indigo-700" aria-hidden="true" />
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="mt-4 rounded-2xl border border-dashed border-slate-300 bg-white p-6 text-center">
+              <CheckCircle2 className="mx-auto h-6 w-6 text-slate-400" aria-hidden="true" />
+              <h3 className="mt-2 text-sm font-bold text-slate-900">Overview-only workspace</h3>
+              <p className="mt-1 text-xs leading-5 text-slate-500">Enable a domain to receive a guided next action. No project data has been deleted.</p>
+              <button type="button" onClick={openSetup} className="mt-4 rounded-lg border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500">Choose domains</button>
+            </div>
+          )}
+        </section>
 
-                      <div className="shrink-0 flex items-center space-x-1.5 self-end sm:self-center">
-                        <button
-                          onClick={() => {
-                            if (action.linkedObjectType) {
-                              const viewMap: Record<string, string> = {
-                                "node": "blueprint-editor",
-                                "mechanical-zone": "blueprint-editor",
-                                "assembly-layer": "blueprint-editor",
-                                "board": "board-studio",
-                                "component": "board-components",
-                                "circuit": "circuit-planner",
-                                "net": "netlist-planner",
-                                "pin": "pin-map",
-                                "power": "power-budget",
-                                "firmware": "firmware-plan",
-                                "test": "testing",
-                                "checklist": "mfg-pack",
-                                "factory-file": "factory-builder",
-                                "trace": "netlist-planner"
-                              };
-                              setActiveView(viewMap[action.linkedObjectType] || "blueprint-editor");
-                            } else {
-                              setActiveView("blueprint-editor");
-                            }
-                          }}
-                          className="flex items-center space-x-1 px-2.5 py-1 bg-white hover:bg-slate-50 border border-slate-200 text-slate-655 hover:text-slate-800 rounded text-[9px] font-bold transition-all cursor-pointer font-mono"
-                        >
-                          <span>Inspect</span>
-                          <ChevronRight className="w-3 h-3" />
-                        </button>
-                        
-                        {resolver && (
-                          <button
-                            onClick={() => {
-                              resolver.run();
-                              setToastMessage(`Auto-fix applied successfully: ${resolver.label}`);
-                              runFullDesignReview();
-                            }}
-                            className="flex items-center space-x-1 px-2.5 py-1 bg-emerald-50 hover:bg-emerald-100 border border-emerald-250 text-emerald-700 rounded text-[9px] font-bold transition-all cursor-pointer font-mono"
-                          >
-                            <span>Fix</span>
-                          </button>
-                        )}
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
+          <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5" aria-labelledby="project-data-title">
+            <div>
+              <p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Current project data</p>
+              <h2 id="project-data-title" className="mt-1 text-lg font-bold text-slate-950">What already exists</h2>
+            </div>
+            <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {dataSummary.map(([label, count]) => (
+                <div key={label} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                  <p className="text-2xl font-bold tracking-tight text-slate-950">{count}</p>
+                  <p className="mt-1 text-[10px] font-bold uppercase tracking-wide text-slate-500">{label}</p>
+                </div>
+              ))}
+            </div>
+            <p className="mt-4 text-xs leading-5 text-slate-500">These counts come from canonical project state. Workflow preferences are stored separately and cannot erase these records.</p>
+          </section>
+
+          <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5" aria-labelledby="connection-notices-title">
+            <div className="flex items-center gap-2">
+              {connectionNotices.some((notice) => notice.tone === 'warning') ? <Unlink className="h-4 w-4 text-amber-700" aria-hidden="true" /> : <Link2 className="h-4 w-4 text-emerald-700" aria-hidden="true" />}
+              <h2 id="connection-notices-title" className="text-sm font-bold text-slate-950">Connected and standalone behavior</h2>
+            </div>
+
+            {connectionNotices.length > 0 ? (
+              <div className="mt-3 space-y-2">
+                {connectionNotices.map((notice) => (
+                  <div key={notice.id} className={`rounded-xl border p-3 ${notice.tone === 'warning' ? 'border-amber-200 bg-amber-50 text-amber-950' : 'border-sky-200 bg-sky-50 text-sky-950'}`}>
+                    <div className="flex gap-2">
+                      {notice.tone === 'warning' ? <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /> : <CircleHelp className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />}
+                      <div>
+                        <p className="text-xs font-bold">{notice.title}</p>
+                        <p className="mt-1 text-xs leading-5 opacity-80">{notice.description}</p>
                       </div>
                     </div>
-                  );
-                })
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Factory Package Summary (5 columns) */}
-        <div className="lg:col-span-5 space-y-4">
-          <Card className="bg-white border border-slate-200 shadow-sm">
-            <CardHeader className="bg-slate-50/60 border-b border-slate-150 p-4">
-              <div className="flex items-center space-x-2">
-                <Package className="w-4.5 h-4.5 text-indigo-650" />
-                <CardTitle className="text-xs font-black text-slate-900 uppercase tracking-wider font-mono">
-                  Factory Package Summary
-                </CardTitle>
+                  </div>
+                ))}
               </div>
-            </CardHeader>
-            <CardContent className="p-4 space-y-3.5 text-[10.5px]">
-              
-              <div className="space-y-2 bg-slate-50 p-3 rounded border border-slate-150 font-mono text-[9.5px]">
-                <div className="flex justify-between border-b border-slate-200/60 pb-1">
-                  <span className="text-slate-450">Gerbers status:</span>
-                  <span className={factoryFiles.gerberZip?.status === 'Verified' ? "text-emerald-600 font-bold" : "text-slate-500"}>
-                    {factoryFiles.gerberZip?.status || 'Not Generated'}
-                  </span>
-                </div>
-                <div className="flex justify-between border-b border-slate-200/60 pb-1 mt-1">
-                  <span className="text-slate-455">Drill status:</span>
-                  <span className={factoryFiles.drillFiles?.status === 'Verified' ? "text-emerald-600 font-bold" : "text-slate-500"}>
-                    {factoryFiles.drillFiles?.status || 'Not Generated'}
-                  </span>
-                </div>
-                <div className="flex justify-between border-b border-slate-200/60 pb-1 mt-1">
-                  <span className="text-slate-455">BOM status:</span>
-                  <span className={factoryFiles.bomCsv?.status === 'Verified' ? "text-emerald-600 font-bold" : "text-slate-500"}>
-                    {factoryFiles.bomCsv?.status || 'Not Generated'}
-                  </span>
-                </div>
-                <div className="flex justify-between border-b border-slate-200/60 pb-1 mt-1">
-                  <span className="text-slate-455">CPL status:</span>
-                  <span className={factoryFiles.cplCsv?.status === 'Verified' ? "text-emerald-600 font-bold" : "text-slate-500"}>
-                    {factoryFiles.cplCsv?.status || 'Not Generated'}
-                  </span>
-                </div>
-                <div className="flex justify-between border-b border-slate-200/60 pb-1 mt-1">
-                  <span className="text-slate-455">Handoff Manifest:</span>
-                  <span className={checkedCount === checklistItemsCount ? "text-emerald-600 font-bold" : "text-slate-500"}>
-                    {factoryPackageStatus}
-                  </span>
-                </div>
-                <div className="flex justify-between mt-1">
-                  <span className="text-slate-455">FABRICATION RELEASE:</span>
-                  <span className={report.canMoveToFabrication ? "text-emerald-600 font-black animate-pulse" : "text-slate-450 font-bold"}>
-                    {report.canMoveToFabrication ? "RELEASE READY" : "LOCKED"}
-                  </span>
+            ) : (
+              <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-emerald-950">
+                <div className="flex gap-2">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                  <p className="text-xs leading-5">The visible domains can share project context without a special standalone limitation. Workbench-specific engineering boundaries still apply.</p>
                 </div>
               </div>
-
-              <div className="border-t border-slate-150 pt-3 space-y-1 text-slate-500 leading-normal">
-                <span className="font-extrabold text-slate-800 uppercase text-[9px] tracking-wider block font-mono">⚠️ Verification Status Notice:</span>
-                <p className="text-[10px] text-slate-400 font-sans">
-                  The package is configured as <strong>{factoryPackageStatus}</strong>. It requires checking off the 10 manual verification guidelines inside the Factory Package Builder before release confirmation is unlocked.
-                </p>
-              </div>
-
-              <button
-                onClick={() => setActiveView("factory-builder")}
-                className="w-full py-1.5 mt-1 bg-indigo-600 hover:bg-indigo-500 text-white rounded text-[10px] font-bold uppercase tracking-wider transition-all cursor-pointer text-center font-mono shadow-md"
-              >
-                Go to Factory Package Builder
-              </button>
-            </CardContent>
-          </Card>
+            )}
+          </section>
         </div>
       </div>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Binary,
   Blocks,
@@ -10,6 +10,8 @@ import {
   CircuitBoard,
   Cpu,
   Download,
+  Eye,
+  EyeOff,
   FileCheck2,
   FileText,
   GitBranch,
@@ -20,6 +22,7 @@ import {
   Palette,
   Plus,
   Ruler,
+  Settings2,
   ShieldAlert,
   Table,
   Tags,
@@ -32,11 +35,16 @@ import { blockLibrary, BlockLibraryItem } from '../data/blockLibrary';
 import {
   getNavigationItem,
   isCanvasNavigationItem,
-  navigationDomains,
   NavigationIconKey,
 } from '../lib/navigationRegistry';
+import {
+  getHiddenDomainCount,
+  getVisibleNavigationDomains,
+  getWorkflowProfile,
+} from '../lib/workflowProfiles';
 import { getVisualFamily, resolveVisualFamilyId } from '../lib/visual/representationRegistry';
 import { useProjectStore } from '../store/projectStore';
+import { useWorkflowPreferencesStore } from '../store/workflowPreferencesStore';
 import { ArchitectureGlyph } from './visual/DeviceVisual';
 
 interface SidebarProps {
@@ -78,6 +86,13 @@ const iconByKey: Record<NavigationIconKey, LucideIcon> = {
 
 export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
   const { activeView, setActiveView, addNode } = useProjectStore();
+  const {
+    enabledDomains,
+    showAllDomains,
+    setShowAllDomains,
+    openSetup,
+    profileId,
+  } = useWorkflowPreferencesStore();
   const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({
     Interaction: true,
     Electronics: true,
@@ -85,6 +100,12 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
 
   const activeNavigationItem = getNavigationItem(activeView);
   const isCanvasView = isCanvasNavigationItem(activeNavigationItem);
+  const visibleDomains = useMemo(
+    () => getVisibleNavigationDomains(enabledDomains, activeView, showAllDomains),
+    [activeView, enabledDomains, showAllDomains],
+  );
+  const hiddenDomainCount = getHiddenDomainCount(enabledDomains);
+  const profile = getWorkflowProfile(profileId);
 
   const toggleCategory = (category: string) => {
     setExpandedCategories((previous) => ({ ...previous, [category]: !previous[category] }));
@@ -123,41 +144,86 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
 
   return (
     <aside className="z-20 flex h-full w-[272px] shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white shadow-sm">
-      <div className="max-h-[72vh] shrink-0 select-none overflow-y-auto border-b border-slate-100 px-3 py-3">
-        <nav className="space-y-4" aria-label="Engineering workbenches">
-          {navigationDomains.map((domain) => (
-            <section key={domain.id} aria-labelledby={`nav-${domain.id}`}>
-              <div className="mb-1.5 px-2">
-                <h2 id={`nav-${domain.id}`} className="text-[9px] font-extrabold uppercase tracking-[0.16em] text-slate-500">{domain.label}</h2>
-                <p className="mt-0.5 text-[9px] leading-4 text-slate-400">{domain.purpose}</p>
-              </div>
+      <div className="shrink-0 border-b border-slate-200 bg-slate-50 p-3">
+        <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[8px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">Active workflow</p>
+              <p className="mt-1 truncate text-[11px] font-bold text-slate-950">{profile.name}</p>
+              <p className="mt-1 text-[9px] leading-4 text-slate-500">
+                {enabledDomains.length} visible · {hiddenDomainCount} hidden
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={openSetup}
+              className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              aria-label="Configure workflow"
+              title="Configure workflow"
+            >
+              <Settings2 className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
 
-              <div className="space-y-1">
-                {domain.items.map((item) => {
-                  const Icon = iconByKey[item.icon];
-                  const isActive = activeView === item.id;
-                  return (
-                    <button
-                      key={item.id}
-                      type="button"
-                      onClick={() => setActiveView(item.id)}
-                      aria-current={isActive ? 'page' : undefined}
-                      className={`group flex w-full items-start gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1 ${isActive ? 'border-slate-950 bg-slate-900 text-white shadow-sm' : 'border-transparent text-slate-700 hover:border-slate-200 hover:bg-slate-50 hover:text-slate-950'}`}
-                    >
-                      <Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${isActive ? 'text-emerald-300' : 'text-slate-400 group-hover:text-slate-600'}`} aria-hidden="true" />
-                      <span className="min-w-0 flex-1">
-                        <span className="flex items-center justify-between gap-2">
-                          <span className="truncate text-[11px] font-semibold leading-4">{item.label}</span>
-                          <span className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[7px] font-bold uppercase tracking-[0.08em] ${isActive ? 'bg-slate-800 text-slate-300' : 'bg-slate-100 text-slate-500'}`}>{item.badge}</span>
+          {hiddenDomainCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowAllDomains(!showAllDomains)}
+              aria-pressed={showAllDomains}
+              className="mt-3 flex w-full items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-2 text-left text-[9px] font-semibold text-slate-600 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <span>{showAllDomains ? 'Return to focused navigation' : `Temporarily show ${hiddenDomainCount} hidden modules`}</span>
+              {showAllDomains ? <EyeOff className="h-3.5 w-3.5" aria-hidden="true" /> : <Eye className="h-3.5 w-3.5" aria-hidden="true" />}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="max-h-[64vh] shrink-0 select-none overflow-y-auto border-b border-slate-100 px-3 py-3">
+        <nav className="space-y-4" aria-label="Engineering workbenches">
+          {visibleDomains.map((domain) => {
+            const domainIsActiveButHidden = domain.id !== 'overview'
+              && !enabledDomains.includes(domain.id as never)
+              && !showAllDomains;
+            return (
+              <section key={domain.id} aria-labelledby={`nav-${domain.id}`}>
+                <div className="mb-1.5 px-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <h2 id={`nav-${domain.id}`} className="text-[9px] font-extrabold uppercase tracking-[0.16em] text-slate-500">{domain.label}</h2>
+                    {domainIsActiveButHidden && (
+                      <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[7px] font-bold uppercase tracking-wide text-amber-700">Active hidden</span>
+                    )}
+                  </div>
+                  <p className="mt-0.5 text-[9px] leading-4 text-slate-400">{domain.purpose}</p>
+                </div>
+
+                <div className="space-y-1">
+                  {domain.items.map((item) => {
+                    const Icon = iconByKey[item.icon];
+                    const isActive = activeView === item.id;
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => setActiveView(item.id)}
+                        aria-current={isActive ? 'page' : undefined}
+                        className={`group flex w-full items-start gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1 ${isActive ? 'border-slate-950 bg-slate-900 text-white shadow-sm' : 'border-transparent text-slate-700 hover:border-slate-200 hover:bg-slate-50 hover:text-slate-950'}`}
+                      >
+                        <Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${isActive ? 'text-emerald-300' : 'text-slate-400 group-hover:text-slate-600'}`} aria-hidden="true" />
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="truncate text-[11px] font-semibold leading-4">{item.label}</span>
+                            <span className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[7px] font-bold uppercase tracking-[0.08em] ${isActive ? 'bg-slate-800 text-slate-300' : 'bg-slate-100 text-slate-500'}`}>{item.badge}</span>
+                          </span>
+                          <span className={`mt-0.5 block text-[9px] leading-4 ${isActive ? 'text-slate-300' : 'text-slate-450'}`}>{item.purpose}</span>
                         </span>
-                        <span className={`mt-0.5 block text-[9px] leading-4 ${isActive ? 'text-slate-300' : 'text-slate-450'}`}>{item.purpose}</span>
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </section>
-          ))}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
         </nav>
       </div>
 
@@ -198,7 +264,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ onAddBlock }) => {
                               draggable
                               onDragStart={(event) => handleDragStart(event, libraryItem)}
                               onClick={() => handleAddBlock(libraryItem)}
-                              className="group flex cursor-grab items-center gap-2.5 rounded-xl border border-slate-100 bg-white p-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-950 focus-within:ring-2 focus-within:ring-indigo-500"
+                              className="group flex cursor-grab items-center gap-2.5 rounded-xl border border-slate-100 bg-white p-2 text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-950"
                               title={`${libraryItem.name}: ${libraryItem.description}`}
                             >
                               <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-white shadow-sm" style={{ backgroundColor: family.accent, color: family.color }}>

--- a/src/components/reliability/StudioRoot.tsx
+++ b/src/components/reliability/StudioRoot.tsx
@@ -3,8 +3,10 @@
 import React, { useEffect, useState } from 'react';
 import { RECOVER_TO_DASHBOARD_KEY } from '../../lib/reliability';
 import { prepareStorageReliability } from '../../store/storageHealthStore';
+import { useWorkflowPreferencesStore } from '../../store/workflowPreferencesStore';
 import { FeedbackProvider } from '../feedback/FeedbackProvider';
 import { KnowledgeProvider } from '../knowledge/KnowledgeProvider';
+import { WorkflowSetupDialog } from '../workflow/WorkflowSetupDialog';
 import { AppErrorBoundary } from './AppErrorBoundary';
 
 type ShellComponent = React.ComponentType;
@@ -12,13 +14,15 @@ type ShellComponent = React.ComponentType;
 const StudioApplicationLoader: React.FC = () => {
   const [Shell, setShell] = useState<ShellComponent | null>(null);
   const [loadError, setLoadError] = useState<Error | null>(null);
+  const hydrateWorkflowPreferences = useWorkflowPreferencesStore((state) => state.hydrate);
 
   useEffect(() => {
     prepareStorageReliability();
+    hydrateWorkflowPreferences();
     import('../AppShell')
       .then((module) => setShell(() => module.AppShell))
       .catch((error: unknown) => setLoadError(error instanceof Error ? error : new Error(String(error))));
-  }, []);
+  }, [hydrateWorkflowPreferences]);
 
   if (loadError) throw loadError;
   if (!Shell) {
@@ -28,7 +32,13 @@ const StudioApplicationLoader: React.FC = () => {
       </div>
     );
   }
-  return <Shell />;
+
+  return (
+    <>
+      <Shell />
+      <WorkflowSetupDialog />
+    </>
+  );
 };
 
 export const StudioRoot: React.FC = () => (

--- a/src/components/workflow/WorkflowSetupDialog.tsx
+++ b/src/components/workflow/WorkflowSetupDialog.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  CircleHelp,
+  Link2,
+  Settings2,
+  Unlink,
+  X,
+} from 'lucide-react';
+import {
+  getWorkflowConnectionNotices,
+  getWorkflowProfile,
+  inferProfileId,
+  toggleWorkflowDomain,
+  workflowProfiles,
+  WORKFLOW_DOMAIN_IDS,
+  type WorkflowDomainId,
+  type WorkflowProfileId,
+} from '../../lib/workflowProfiles';
+import { navigationDomains } from '../../lib/navigationRegistry';
+import { useWorkflowPreferencesStore } from '../../store/workflowPreferencesStore';
+
+const domainDetail = new Map(
+  navigationDomains
+    .filter((domain) => domain.id !== 'overview')
+    .map((domain) => [domain.id as WorkflowDomainId, domain]),
+);
+
+interface WorkflowSetupSessionProps {
+  initialDomains: readonly WorkflowDomainId[];
+  initialProfileId: WorkflowProfileId;
+  onCancel: () => void;
+  onApply: (domains: readonly WorkflowDomainId[]) => void;
+}
+
+const WorkflowSetupSession: React.FC<WorkflowSetupSessionProps> = ({
+  initialDomains,
+  initialProfileId,
+  onCancel,
+  onApply,
+}) => {
+  const [draftDomains, setDraftDomains] = useState<WorkflowDomainId[]>([...initialDomains]);
+  const [selectedProfileId, setSelectedProfileId] = useState<WorkflowProfileId>(initialProfileId);
+
+  const notices = useMemo(() => getWorkflowConnectionNotices(draftDomains), [draftDomains]);
+  const selectedProfile = getWorkflowProfile(selectedProfileId);
+
+  const selectProfile = (profileId: WorkflowProfileId) => {
+    const profile = getWorkflowProfile(profileId);
+    setSelectedProfileId(profileId);
+    if (profileId !== 'custom') setDraftDomains([...profile.enabledDomains]);
+  };
+
+  const toggleDomain = (domainId: WorkflowDomainId) => {
+    const nextDomains = toggleWorkflowDomain(draftDomains, domainId);
+    setDraftDomains(nextDomains);
+    setSelectedProfileId(inferProfileId(nextDomains));
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[330px_minmax(0,1fr)]">
+        <aside className="border-b border-slate-200 bg-slate-50 p-4 lg:border-b-0 lg:border-r lg:p-5">
+          <p className="text-[11px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Start from a workflow</p>
+          <div className="mt-3 space-y-2">
+            {workflowProfiles.map((profile) => {
+              const active = selectedProfileId === profile.id;
+              return (
+                <button
+                  key={profile.id}
+                  type="button"
+                  onClick={() => selectProfile(profile.id)}
+                  aria-pressed={active}
+                  className={`w-full rounded-xl border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 ${active ? 'border-indigo-300 bg-white shadow-sm' : 'border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white'}`}
+                >
+                  <span className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-bold text-slate-950">{profile.name}</span>
+                    {active ? <Check className="h-4 w-4 shrink-0 text-indigo-700" aria-hidden="true" /> : <ChevronRight className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />}
+                  </span>
+                  <span className="mt-1.5 block text-xs leading-5 text-slate-500">{profile.summary}</span>
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+
+        <main className="min-h-0 overflow-y-auto bg-white p-4 sm:p-5 lg:p-6">
+          <div className="max-w-3xl">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-[11px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">{selectedProfile.name}</p>
+                <h3 className="mt-1 text-xl font-bold tracking-tight text-slate-950">Choose what appears in your studio</h3>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">{selectedProfile.bestFor}</p>
+              </div>
+              <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-600">
+                {draftDomains.length} of {WORKFLOW_DOMAIN_IDS.length} domains visible
+              </span>
+            </div>
+
+            <div className="mt-5 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-xs leading-5 text-emerald-900">
+              <div className="flex gap-2">
+                <Link2 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                <p><strong>Connected when useful, independent when needed.</strong> Showing multiple domains lets them share the same project state. Hiding a domain only changes navigation—it does not delete engineering data.</p>
+              </div>
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2">
+              {WORKFLOW_DOMAIN_IDS.map((domainId) => {
+                const domain = domainDetail.get(domainId);
+                const enabled = draftDomains.includes(domainId);
+                if (!domain) return null;
+                return (
+                  <button
+                    key={domainId}
+                    type="button"
+                    onClick={() => toggleDomain(domainId)}
+                    aria-pressed={enabled}
+                    className={`rounded-xl border p-4 text-left transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 ${enabled ? 'border-indigo-200 bg-indigo-50' : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50'}`}
+                  >
+                    <span className="flex items-start justify-between gap-3">
+                      <span>
+                        <span className="block text-sm font-bold text-slate-950">{domain.label}</span>
+                        <span className="mt-1 block text-xs leading-5 text-slate-500">{domain.purpose}</span>
+                      </span>
+                      <span className={`grid h-6 w-6 shrink-0 place-items-center rounded-md border ${enabled ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-slate-300 bg-white text-transparent'}`}>
+                        <Check className="h-4 w-4" aria-hidden="true" />
+                      </span>
+                    </span>
+                    <span className="mt-3 block text-[11px] font-semibold text-slate-500">{domain.items.length} {domain.items.length === 1 ? 'workbench' : 'workbenches'}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <section className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <div className="flex items-center gap-2">
+                <Unlink className="h-4 w-4 text-slate-600" aria-hidden="true" />
+                <h4 className="text-sm font-bold text-slate-900">Standalone and connection notes</h4>
+              </div>
+              {notices.length > 0 ? (
+                <div className="mt-3 space-y-2">
+                  {notices.map((notice) => (
+                    <div key={notice.id} className={`rounded-lg border p-3 ${notice.tone === 'warning' ? 'border-amber-200 bg-amber-50 text-amber-950' : 'border-sky-200 bg-sky-50 text-sky-950'}`}>
+                      <div className="flex gap-2">
+                        {notice.tone === 'warning' ? <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /> : <CircleHelp className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />}
+                        <div>
+                          <p className="text-xs font-bold">{notice.title}</p>
+                          <p className="mt-1 text-xs leading-5 opacity-80">{notice.description}</p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-2 text-xs leading-5 text-slate-600">This selection has no special standalone limitations. Individual workbenches still show their own readiness and engineering boundaries.</p>
+              )}
+            </section>
+          </div>
+        </main>
+      </div>
+
+      <footer className="flex flex-col-reverse gap-2 border-t border-slate-200 bg-white px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+        <p className="text-xs leading-5 text-slate-500">Overview is always available. You can change this workflow later without losing project data.</p>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="h-9 rounded-lg border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500">Cancel</button>
+          <button type="button" onClick={() => onApply(draftDomains)} className="inline-flex h-9 items-center gap-2 rounded-lg bg-slate-950 px-4 text-sm font-semibold text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2">
+            <Check className="h-4 w-4" aria-hidden="true" /> Use this workflow
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export const WorkflowSetupDialog: React.FC = () => {
+  const { isSetupOpen, enabledDomains, profileId, closeSetup, replaceDomains, completeSetup } = useWorkflowPreferencesStore();
+
+  const apply = (domains: readonly WorkflowDomainId[]) => {
+    replaceDomains(domains);
+    completeSetup();
+  };
+
+  return (
+    <Dialog.Root open={isSetupOpen} onOpenChange={(open) => { if (!open) closeSetup(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[120] bg-slate-950/50 backdrop-blur-sm" />
+        <Dialog.Content
+          aria-describedby="workflow-setup-description"
+          className="fixed left-1/2 top-1/2 z-[130] flex max-h-[92vh] w-[calc(100vw-1.5rem)] max-w-5xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl outline-none"
+        >
+          <header className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3 sm:px-5 sm:py-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-indigo-50 text-indigo-700"><Settings2 className="h-5 w-5" aria-hidden="true" /></span>
+              <div className="min-w-0">
+                <Dialog.Title className="text-base font-bold text-slate-950">Configure your Hardware Studio workflow</Dialog.Title>
+                <Dialog.Description id="workflow-setup-description" className="mt-1 text-xs leading-5 text-slate-500">Show only the domains you need now. Re-enable anything later without deleting its project data.</Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close asChild>
+              <button type="button" className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-slate-200 bg-white text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="Close workflow setup">
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </Dialog.Close>
+          </header>
+
+          {isSetupOpen && (
+            <WorkflowSetupSession
+              key={`${profileId}:${enabledDomains.join(',')}`}
+              initialDomains={enabledDomains}
+              initialProfileId={profileId}
+              onCancel={closeSetup}
+              onApply={apply}
+            />
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/lib/workflowProfiles.ts
+++ b/src/lib/workflowProfiles.ts
@@ -1,0 +1,375 @@
+import {
+  getNavigationItem,
+  navigationDomains,
+  type NavigationDomain,
+  type NavigationDomainId,
+} from './navigationRegistry';
+
+export const WORKFLOW_DOMAIN_IDS = [
+  'product',
+  'mechanical',
+  'electronics',
+  'pcb',
+  'firmware',
+  'validation',
+  'outputs',
+] as const satisfies readonly NavigationDomainId[];
+
+export type WorkflowDomainId = (typeof WORKFLOW_DOMAIN_IDS)[number];
+
+export const WORKFLOW_PROFILE_IDS = [
+  'complete-product',
+  'electronics-pcb',
+  'mechanical-assembly',
+  'firmware-device',
+  'validation-handoff',
+  'custom',
+] as const;
+
+export type WorkflowProfileId = (typeof WORKFLOW_PROFILE_IDS)[number];
+
+export interface WorkflowProfile {
+  id: WorkflowProfileId;
+  name: string;
+  summary: string;
+  bestFor: string;
+  enabledDomains: readonly WorkflowDomainId[];
+  startingView: string;
+}
+
+export interface WorkflowPreference {
+  version: 1;
+  profileId: WorkflowProfileId;
+  enabledDomains: WorkflowDomainId[];
+  showAllDomains: boolean;
+  hasCompletedSetup: boolean;
+}
+
+export interface WorkflowConnectionNotice {
+  id: string;
+  tone: 'info' | 'warning';
+  title: string;
+  description: string;
+  relatedDomains: WorkflowDomainId[];
+}
+
+export interface WorkflowProjectSnapshot {
+  requirements: number;
+  architectureNodes: number;
+  risks: number;
+  mechanicalObjects: number;
+  assemblyLayers: number;
+  components: number;
+  circuitBlocks: number;
+  nets: number;
+  boards: number;
+  traces: number;
+  firmwareModules: number;
+  firmwareStates: number;
+  validationTests: number;
+  validationRuns: number;
+  revisions: number;
+  factoryPackageStatus: string;
+}
+
+export interface GuidedWorkflowAction {
+  domainId: WorkflowDomainId;
+  title: string;
+  description: string;
+  viewId: string;
+  status: 'start' | 'continue' | 'review';
+  evidence: string;
+}
+
+const ALL_DOMAINS = [...WORKFLOW_DOMAIN_IDS];
+
+export const workflowProfiles: readonly WorkflowProfile[] = [
+  {
+    id: 'complete-product',
+    name: 'Complete Product',
+    summary: 'Keep the full product lifecycle visible from intent through release outputs.',
+    bestFor: 'Teams or individuals building electronics, mechanical, firmware, validation, and handoff together.',
+    enabledDomains: ALL_DOMAINS,
+    startingView: 'dashboard',
+  },
+  {
+    id: 'electronics-pcb',
+    name: 'Electronics + PCB',
+    summary: 'Focus on components, schematic, power, board layout, checks, and engineering outputs.',
+    bestFor: 'PCB design, electronics prototypes, modules, controller boards, and hardware revisions.',
+    enabledDomains: ['product', 'electronics', 'pcb', 'validation', 'outputs'],
+    startingView: 'component-library',
+  },
+  {
+    id: 'mechanical-assembly',
+    name: 'Mechanical + Assembly',
+    summary: 'Focus on product intent, enclosure/layout work, assembly structure, validation, and outputs.',
+    bestFor: 'Enclosures, fixtures, physical packaging, assembly planning, and mechanical coordination.',
+    enabledDomains: ['product', 'mechanical', 'validation', 'outputs'],
+    startingView: 'mechanical-studio',
+  },
+  {
+    id: 'firmware-device',
+    name: 'Firmware + Device',
+    summary: 'Focus on hardware-aware firmware planning, mappings, behavior, tests, and release records.',
+    bestFor: 'Firmware built around existing boards, embedded behavior, bring-up, and device validation.',
+    enabledDomains: ['product', 'electronics', 'firmware', 'validation', 'outputs'],
+    startingView: 'firmware-studio',
+  },
+  {
+    id: 'validation-handoff',
+    name: 'Validation + Handoff',
+    summary: 'Focus on requirements, tests, evidence, coverage, revisions, and delivery outputs.',
+    bestFor: 'Test planning, verification, factory QA preparation, audits, and controlled handoff.',
+    enabledDomains: ['product', 'validation', 'outputs'],
+    startingView: 'validation-studio',
+  },
+  {
+    id: 'custom',
+    name: 'Custom Workflow',
+    summary: 'Choose exactly which engineering domains should appear in your workspace.',
+    bestFor: 'Standalone work, unusual processes, imported designs, or intentionally narrow projects.',
+    enabledDomains: [],
+    startingView: 'dashboard',
+  },
+] as const;
+
+export const DEFAULT_WORKFLOW_PREFERENCE: WorkflowPreference = {
+  version: 1,
+  profileId: 'complete-product',
+  enabledDomains: [...ALL_DOMAINS],
+  showAllDomains: false,
+  hasCompletedSetup: false,
+};
+
+const profileById = new Map(workflowProfiles.map((profile) => [profile.id, profile]));
+const validDomainIds = new Set<WorkflowDomainId>(WORKFLOW_DOMAIN_IDS);
+
+export function getWorkflowProfile(profileId: WorkflowProfileId): WorkflowProfile {
+  return profileById.get(profileId) ?? workflowProfiles[0];
+}
+
+export function createPreferenceFromProfile(
+  profileId: WorkflowProfileId,
+  previous: Partial<WorkflowPreference> = {},
+): WorkflowPreference {
+  const profile = getWorkflowProfile(profileId);
+  return {
+    version: 1,
+    profileId,
+    enabledDomains: [...profile.enabledDomains],
+    showAllDomains: previous.showAllDomains ?? false,
+    hasCompletedSetup: previous.hasCompletedSetup ?? false,
+  };
+}
+
+export function inferProfileId(enabledDomains: readonly WorkflowDomainId[]): WorkflowProfileId {
+  const normalized = [...new Set(enabledDomains)].sort();
+  const matching = workflowProfiles.find((profile) => {
+    if (profile.id === 'custom') return false;
+    const profileDomains = [...profile.enabledDomains].sort();
+    return profileDomains.length === normalized.length
+      && profileDomains.every((domainId, index) => domainId === normalized[index]);
+  });
+  return matching?.id ?? 'custom';
+}
+
+export function normalizeWorkflowPreference(input: unknown): WorkflowPreference {
+  if (!input || typeof input !== 'object') {
+    return { ...DEFAULT_WORKFLOW_PREFERENCE, enabledDomains: [...ALL_DOMAINS] };
+  }
+
+  const candidate = input as Partial<WorkflowPreference>;
+  const enabledDomains = Array.isArray(candidate.enabledDomains)
+    ? [...new Set(candidate.enabledDomains.filter((domainId): domainId is WorkflowDomainId => validDomainIds.has(domainId as WorkflowDomainId)))]
+    : [...ALL_DOMAINS];
+
+  return {
+    version: 1,
+    profileId: inferProfileId(enabledDomains),
+    enabledDomains,
+    showAllDomains: candidate.showAllDomains === true,
+    hasCompletedSetup: candidate.hasCompletedSetup === true,
+  };
+}
+
+export function toggleWorkflowDomain(
+  enabledDomains: readonly WorkflowDomainId[],
+  domainId: WorkflowDomainId,
+): WorkflowDomainId[] {
+  const current = new Set(enabledDomains);
+  if (current.has(domainId)) current.delete(domainId);
+  else current.add(domainId);
+  return WORKFLOW_DOMAIN_IDS.filter((candidate) => current.has(candidate));
+}
+
+export function getDomainIdForView(viewId: string): NavigationDomainId | undefined {
+  const visibleDomain = navigationDomains.find((domain) => domain.items.some((item) => item.id === viewId));
+  if (visibleDomain) return visibleDomain.id;
+
+  const item = getNavigationItem(viewId);
+  if (!item) return undefined;
+  return navigationDomains.find((domain) => domain.items.some((candidate) => candidate.surface === item.surface))?.id;
+}
+
+export function getVisibleNavigationDomains(
+  enabledDomains: readonly WorkflowDomainId[],
+  activeView: string,
+  showAllDomains: boolean,
+): readonly NavigationDomain[] {
+  if (showAllDomains) return navigationDomains;
+
+  const enabled = new Set<NavigationDomainId>(['overview', ...enabledDomains]);
+  const activeDomain = getDomainIdForView(activeView);
+  if (activeDomain) enabled.add(activeDomain);
+  return navigationDomains.filter((domain) => enabled.has(domain.id));
+}
+
+export function getHiddenDomainCount(enabledDomains: readonly WorkflowDomainId[]): number {
+  return WORKFLOW_DOMAIN_IDS.length - new Set(enabledDomains).size;
+}
+
+export function getWorkflowConnectionNotices(
+  enabledDomains: readonly WorkflowDomainId[],
+): WorkflowConnectionNotice[] {
+  const enabled = new Set(enabledDomains);
+  const notices: WorkflowConnectionNotice[] = [];
+
+  if (enabled.has('pcb') && !enabled.has('electronics')) {
+    notices.push({
+      id: 'pcb-without-electronics',
+      tone: 'warning',
+      title: 'PCB is shown as a standalone workspace',
+      description: 'Board planning remains available, but schematic synchronization, linked nets, and component-definition context require the Electronics domain.',
+      relatedDomains: ['pcb', 'electronics'],
+    });
+  }
+
+  if (enabled.has('firmware') && !enabled.has('electronics')) {
+    notices.push({
+      id: 'firmware-without-electronics',
+      tone: 'warning',
+      title: 'Firmware is shown without hardware context',
+      description: 'Firmware planning remains available, but pin, bus, component, and board mappings require Electronics data.',
+      relatedDomains: ['firmware', 'electronics'],
+    });
+  }
+
+  if (enabled.has('mechanical') && enabled.has('pcb')) {
+    notices.push({
+      id: 'mechanical-pcb-connected',
+      tone: 'info',
+      title: 'Mechanical and PCB work can share placement context',
+      description: 'Keep both domains visible when coordinating board outline, mounting, connector openings, package height, and enclosure clearances.',
+      relatedDomains: ['mechanical', 'pcb'],
+    });
+  }
+
+  if (enabled.has('validation') && enabledDomains.length === 1) {
+    notices.push({
+      id: 'validation-standalone',
+      tone: 'info',
+      title: 'Validation is operating independently',
+      description: 'Generic tests can be planned alone. Requirement coverage and automatic impact context become richer when source engineering domains are also visible.',
+      relatedDomains: ['validation'],
+    });
+  }
+
+  if (enabled.has('outputs') && !enabledDomains.some((domainId) => domainId !== 'outputs')) {
+    notices.push({
+      id: 'outputs-only',
+      tone: 'warning',
+      title: 'Outputs has no visible source domain',
+      description: 'Exports and release records can only package engineering data that already exists in the project. Showing Outputs does not generate missing source work.',
+      relatedDomains: ['outputs'],
+    });
+  }
+
+  return notices;
+}
+
+function evidence(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function deriveGuidedWorkflowActions(
+  enabledDomains: readonly WorkflowDomainId[],
+  snapshot: WorkflowProjectSnapshot,
+): GuidedWorkflowAction[] {
+  const actions: GuidedWorkflowAction[] = [];
+  const enabled = new Set(enabledDomains);
+
+  if (enabled.has('product')) {
+    if (snapshot.requirements === 0) {
+      actions.push({ domainId: 'product', title: 'Define the first measurable requirement', description: 'Start with what the product must achieve and how success will be checked.', viewId: 'requirements', status: 'start', evidence: evidence(snapshot.requirements, 'requirement') });
+    } else if (snapshot.architectureNodes === 0) {
+      actions.push({ domainId: 'product', title: 'Turn requirements into product architecture', description: 'Create functions, interfaces, and system relationships without jumping directly into implementation.', viewId: 'product-architecture', status: 'continue', evidence: evidence(snapshot.requirements, 'requirement') });
+    } else {
+      actions.push({ domainId: 'product', title: 'Review risks and cross-domain interfaces', description: 'Confirm that architecture decisions, assumptions, and interfaces are explicit before downstream work expands.', viewId: 'risks-interfaces', status: 'review', evidence: `${evidence(snapshot.requirements, 'requirement')} · ${evidence(snapshot.architectureNodes, 'architecture node')}` });
+    }
+  }
+
+  if (enabled.has('mechanical')) {
+    if (snapshot.mechanicalObjects === 0) {
+      actions.push({ domainId: 'mechanical', title: 'Create the first mechanical layout object', description: 'Define the physical envelope or a meaningful reference before planning the assembly.', viewId: 'mechanical-studio', status: 'start', evidence: evidence(snapshot.mechanicalObjects, 'mechanical object') });
+    } else if (snapshot.assemblyLayers === 0) {
+      actions.push({ domainId: 'mechanical', title: 'Describe the assembly stack', description: 'Organize physical layers, materials, thicknesses, and order around the existing layout.', viewId: 'assembly-stack', status: 'continue', evidence: evidence(snapshot.mechanicalObjects, 'mechanical object') });
+    } else {
+      actions.push({ domainId: 'mechanical', title: 'Review layout and assembly assumptions', description: 'Check that dimensions, materials, and clearances are explicit before treating the model as engineering evidence.', viewId: 'mechanical-studio', status: 'review', evidence: `${evidence(snapshot.mechanicalObjects, 'mechanical object')} · ${evidence(snapshot.assemblyLayers, 'assembly layer')}` });
+    }
+  }
+
+  if (enabled.has('electronics')) {
+    if (snapshot.components === 0) {
+      actions.push({ domainId: 'electronics', title: 'Choose the first component definition', description: 'Understand the device family, inspect its pins and footprint, then register one project instance.', viewId: 'component-library', status: 'start', evidence: evidence(snapshot.components, 'component') });
+    } else if (snapshot.circuitBlocks === 0 || snapshot.nets === 0) {
+      actions.push({ domainId: 'electronics', title: 'Build electrical structure and connectivity', description: 'Organize component responsibilities and create explicit electrical connections before PCB placement.', viewId: 'schematic-editor', status: 'continue', evidence: `${evidence(snapshot.components, 'component')} · ${evidence(snapshot.nets, 'net')}` });
+    } else {
+      actions.push({ domainId: 'electronics', title: 'Review power, pins, and sourcing together', description: 'Confirm that connectivity, power assumptions, pin ownership, and BOM records describe the same design.', viewId: 'power-tree', status: 'review', evidence: `${evidence(snapshot.components, 'component')} · ${evidence(snapshot.nets, 'net')}` });
+    }
+  }
+
+  if (enabled.has('pcb')) {
+    if (snapshot.boards === 0) {
+      actions.push({ domainId: 'pcb', title: 'Create or configure a board', description: 'Define the board identity and outline before placing footprints or routing nets.', viewId: 'board-settings', status: 'start', evidence: evidence(snapshot.boards, 'board') });
+    } else if (snapshot.components === 0) {
+      actions.push({ domainId: 'pcb', title: 'Add board components before placement', description: 'A board can exist independently, but meaningful placement requires component instances or imported board data.', viewId: 'component-library', status: 'start', evidence: `${evidence(snapshot.boards, 'board')} · ${evidence(snapshot.components, 'component')}` });
+    } else if (snapshot.traces === 0) {
+      actions.push({ domainId: 'pcb', title: 'Place footprints and inspect unrouted work', description: 'Open the board workspace, establish placement, and route only from explicit connectivity.', viewId: 'board-designer', status: 'continue', evidence: `${evidence(snapshot.boards, 'board')} · ${evidence(snapshot.traces, 'trace')}` });
+    } else {
+      actions.push({ domainId: 'pcb', title: 'Review board rules and current findings', description: 'Inspect routing, constraints, and DRC limitations before preparing manufacturing output.', viewId: 'pcb-constraints', status: 'review', evidence: `${evidence(snapshot.boards, 'board')} · ${evidence(snapshot.traces, 'trace')}` });
+    }
+  }
+
+  if (enabled.has('firmware')) {
+    if (snapshot.firmwareModules === 0) {
+      actions.push({ domainId: 'firmware', title: 'Define firmware responsibilities', description: 'Create modules around product behavior before generating or editing source structure.', viewId: 'firmware-studio', status: 'start', evidence: evidence(snapshot.firmwareModules, 'firmware module') });
+    } else if (snapshot.firmwareStates === 0) {
+      actions.push({ domainId: 'firmware', title: 'Describe device states and transitions', description: 'Make behavior explicit before connecting modules to hardware and source files.', viewId: 'state-machines', status: 'continue', evidence: evidence(snapshot.firmwareModules, 'firmware module') });
+    } else {
+      actions.push({ domainId: 'firmware', title: 'Review hardware mappings', description: 'Confirm that firmware functions reference real components, buses, and pins rather than free-form assumptions.', viewId: 'hardware-mapping', status: 'review', evidence: `${evidence(snapshot.firmwareModules, 'firmware module')} · ${evidence(snapshot.firmwareStates, 'state')}` });
+    }
+  }
+
+  if (enabled.has('validation')) {
+    if (snapshot.validationTests === 0) {
+      actions.push({ domainId: 'validation', title: 'Create the first validation procedure', description: 'Define what will be tested, the expected result, required evidence, and the source requirement or risk.', viewId: 'validation-studio', status: 'start', evidence: evidence(snapshot.validationTests, 'validation test') });
+    } else if (snapshot.validationRuns === 0) {
+      actions.push({ domainId: 'validation', title: 'Review test readiness and missing evidence', description: 'Check procedures and requirement links before recording any result as verified.', viewId: 'requirement-coverage', status: 'continue', evidence: `${evidence(snapshot.validationTests, 'validation test')} · ${evidence(snapshot.validationRuns, 'run')}` });
+    } else {
+      actions.push({ domainId: 'validation', title: 'Review coverage and retest needs', description: 'Inspect which requirements are covered and which results may be stale after design changes.', viewId: 'requirement-coverage', status: 'review', evidence: `${evidence(snapshot.validationTests, 'validation test')} · ${evidence(snapshot.validationRuns, 'run')}` });
+    }
+  }
+
+  if (enabled.has('outputs')) {
+    if (snapshot.revisions === 0) {
+      actions.push({ domainId: 'outputs', title: 'Create a named project revision', description: 'Capture a deliberate checkpoint before comparing changes or preparing output packages.', viewId: 'revisions', status: 'start', evidence: evidence(snapshot.revisions, 'revision') });
+    } else if (snapshot.factoryPackageStatus === 'Draft') {
+      actions.push({ domainId: 'outputs', title: 'Inspect output readiness without claiming release', description: 'Review available exports, missing source data, and draft classifications before building a handoff package.', viewId: 'exports', status: 'continue', evidence: `${evidence(snapshot.revisions, 'revision')} · package ${snapshot.factoryPackageStatus}` });
+    } else {
+      actions.push({ domainId: 'outputs', title: 'Review release and factory-package blockers', description: 'Confirm that outputs remain tied to exact source data and unresolved engineering work remains visible.', viewId: 'factory-builder', status: 'review', evidence: `${evidence(snapshot.revisions, 'revision')} · package ${snapshot.factoryPackageStatus}` });
+    }
+  }
+
+  return WORKFLOW_DOMAIN_IDS.flatMap((domainId) => actions.filter((action) => action.domainId === domainId));
+}

--- a/src/store/workflowPreferencesStore.ts
+++ b/src/store/workflowPreferencesStore.ts
@@ -1,0 +1,124 @@
+import { create } from 'zustand';
+import {
+  createPreferenceFromProfile,
+  DEFAULT_WORKFLOW_PREFERENCE,
+  inferProfileId,
+  normalizeWorkflowPreference,
+  toggleWorkflowDomain,
+  type WorkflowDomainId,
+  type WorkflowPreference,
+  type WorkflowProfileId,
+} from '../lib/workflowProfiles';
+
+export const WORKFLOW_PREFERENCES_STORAGE_KEY = 'hardware-studio:workflow-preferences:v1';
+
+interface WorkflowPreferencesState extends WorkflowPreference {
+  hydrated: boolean;
+  isSetupOpen: boolean;
+  hydrate: () => void;
+  openSetup: () => void;
+  closeSetup: () => void;
+  applyProfile: (profileId: WorkflowProfileId) => void;
+  replaceDomains: (domainIds: readonly WorkflowDomainId[]) => void;
+  toggleDomain: (domainId: WorkflowDomainId) => void;
+  setShowAllDomains: (showAll: boolean) => void;
+  completeSetup: () => void;
+  resetPreferences: () => void;
+}
+
+function persist(preference: WorkflowPreference): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(WORKFLOW_PREFERENCES_STORAGE_KEY, JSON.stringify(preference));
+  } catch {
+    // Workflow preferences are non-canonical UI state. The app remains usable in memory.
+  }
+}
+
+function preferenceFromState(state: WorkflowPreferencesState): WorkflowPreference {
+  return {
+    version: 1,
+    profileId: state.profileId,
+    enabledDomains: [...state.enabledDomains],
+    showAllDomains: state.showAllDomains,
+    hasCompletedSetup: state.hasCompletedSetup,
+  };
+}
+
+export const useWorkflowPreferencesStore = create<WorkflowPreferencesState>((set, get) => ({
+  ...DEFAULT_WORKFLOW_PREFERENCE,
+  enabledDomains: [...DEFAULT_WORKFLOW_PREFERENCE.enabledDomains],
+  hydrated: false,
+  isSetupOpen: false,
+
+  hydrate: () => {
+    if (get().hydrated) return;
+    let preference = normalizeWorkflowPreference(DEFAULT_WORKFLOW_PREFERENCE);
+
+    if (typeof window !== 'undefined') {
+      try {
+        const raw = window.localStorage.getItem(WORKFLOW_PREFERENCES_STORAGE_KEY);
+        if (raw) preference = normalizeWorkflowPreference(JSON.parse(raw));
+      } catch {
+        preference = normalizeWorkflowPreference(DEFAULT_WORKFLOW_PREFERENCE);
+      }
+    }
+
+    set({
+      ...preference,
+      enabledDomains: [...preference.enabledDomains],
+      hydrated: true,
+      isSetupOpen: !preference.hasCompletedSetup,
+    });
+  },
+
+  openSetup: () => set({ isSetupOpen: true }),
+  closeSetup: () => set({ isSetupOpen: false }),
+
+  applyProfile: (profileId) => {
+    const current = get();
+    const preference = createPreferenceFromProfile(profileId, current);
+    set({ ...preference, enabledDomains: [...preference.enabledDomains] });
+    persist(preference);
+  },
+
+  replaceDomains: (domainIds) => {
+    const normalized = normalizeWorkflowPreference({
+      ...preferenceFromState(get()),
+      enabledDomains: [...domainIds],
+      profileId: inferProfileId(domainIds),
+    });
+    set({ ...normalized, enabledDomains: [...normalized.enabledDomains] });
+    persist(normalized);
+  },
+
+  toggleDomain: (domainId) => {
+    const current = get();
+    const enabledDomains = toggleWorkflowDomain(current.enabledDomains, domainId);
+    const preference: WorkflowPreference = {
+      ...preferenceFromState(current),
+      profileId: inferProfileId(enabledDomains),
+      enabledDomains,
+    };
+    set({ ...preference, enabledDomains: [...enabledDomains] });
+    persist(preference);
+  },
+
+  setShowAllDomains: (showAllDomains) => {
+    const preference = { ...preferenceFromState(get()), showAllDomains };
+    set({ showAllDomains });
+    persist(preference);
+  },
+
+  completeSetup: () => {
+    const preference = { ...preferenceFromState(get()), hasCompletedSetup: true };
+    set({ hasCompletedSetup: true, isSetupOpen: false });
+    persist(preference);
+  },
+
+  resetPreferences: () => {
+    const preference = normalizeWorkflowPreference(DEFAULT_WORKFLOW_PREFERENCE);
+    set({ ...preference, enabledDomains: [...preference.enabledDomains], isSetupOpen: true });
+    persist(preference);
+  },
+}));


### PR DESCRIPTION
## Summary

Closes #59.

This replaces the one-size-fits-all shell with a capability-based workflow system that keeps domains connected when useful and independently usable when not.

## User workflow

A user can now:

1. choose Complete Product, Electronics + PCB, Mechanical + Assembly, Firmware + Device, Validation + Handoff, or Custom;
2. independently show or hide Product, Mechanical, Electronics, PCB, Firmware, Validation, and Outputs;
3. keep Overview available in every workflow;
4. understand exactly what connected context is unavailable when a domain is used standalone;
5. temporarily show all hidden domains without changing the saved workflow;
6. keep an active hidden workbench open until they leave it, with a clear explanation and recovery action;
7. see one honest next action per visible domain, derived from real canonical project data;
8. see what project records already exist and know that hiding a module does not delete them;
9. reconfigure the workflow from the shell or guided home at any time.

## Persistence and safety

- workflow preferences use a dedicated `hardware-studio:workflow-preferences:v1` key;
- preferences are not written into canonical project serialization;
- malformed JSON and unknown domain IDs normalize safely;
- blocked storage falls back to in-memory preferences;
- hiding a domain never calls project deletion or mutation actions;
- no silent redirect occurs when the current workbench becomes hidden.

## Guided home

The old universal pipeline dashboard and project-mutating “generate/fix” shortcuts are replaced by:

- selected workflow and visible/hidden domain summary;
- canonical project-data counts;
- connected versus standalone notices;
- one evidence-backed next action for each enabled domain;
- an overview-only empty state;
- direct workflow configuration.

## Research record

`docs/research/ADAPTIVE_WORKFLOWS.md` records the product decisions derived from official KiCad, Fusion, Blender, Onshape, and Three.js/CAD trust-boundary patterns.

## Tests

Contract tests cover:

- profile uniqueness and bounded domains;
- profile inference and custom combinations;
- malformed preference normalization;
- canonical domain ordering;
- Overview preservation;
- active hidden-workbench preservation;
- temporary Show all;
- standalone connection notices;
- exactly one guided action per enabled domain;
- start-to-review action transitions from actual project evidence;
- overview-only behavior.

## Required before merge

- clean install;
- lint;
- TypeScript typecheck;
- full Vitest suite;
- production Next.js build;
- successful Vercel deployment.

## Non-goals

- deleting hidden-domain data;
- forcing domain dependencies;
- creating separate product editions;
- completing the CAD kernel or all of shell issue #9;
- claiming parity with KiCad, Fusion, Blender, or Onshape.