### PR TITLE
Unify the Electronics → PCB → 3D Studio golden path

### DIFF
--- a/docs/architecture/UNIFIED_STUDIO_GOLDEN_PATH.md
+++ b/docs/architecture/UNIFIED_STUDIO_GOLDEN_PATH.md
@@ -1,0 +1,185 @@
+# Unified Hardware Studio golden path
+
+Status: active P0 integration architecture for issue #64.
+
+## Why this exists
+
+Hardware Studio accumulated useful workbenches, but a collection of routes is not a product. A user must be able to carry one engineering object through the complete build process without recreating it, losing context, or returning to a generic dashboard to unlock the next editor.
+
+The first production golden path is:
+
+`Component definition → project component instance → schematic placement → pins and nets → PCB placement/routing → lightweight board 3D → BOM → validation`
+
+This document defines which layer owns each fact and which UI state may be temporary.
+
+## Canonical engineering ownership
+
+### Component definition
+
+Owned by the component library domain.
+
+Contains reusable knowledge such as:
+
+- library ID and revision identity;
+- name, category, manufacturer and part number;
+- symbol and footprint references;
+- pin definitions and electrical roles;
+- package metadata and datasheet provenance.
+
+A definition is not automatically a project component and is not automatically placed in a schematic or PCB.
+
+### Project component instance
+
+Owned by canonical `boardComponents` project state.
+
+This is the shared identity used by every downstream workbench. It contains:
+
+- one stable instance ID;
+- source `libraryId`;
+- reference designator;
+- selected board ID;
+- component pins and their net assignments;
+- schematic placement state;
+- PCB placement state;
+- footprint/package references;
+- BOM link;
+- architecture and circuit links;
+- lifecycle and qualification notes.
+
+Component Library creates this instance. Schematic, PCB, BOM, 3D and Validation consume it. Those editors must not create parallel copies.
+
+### Board
+
+Owned by canonical `boards` plus `boardOutlines`.
+
+Board Designer can recover from an empty project by creating a starter board or opening Board Settings. It must never depend on a removed dashboard generator.
+
+A starter outline is explicitly provisional until the user verifies dimensions. It is not silently treated as manufacturing authority.
+
+### Schematic
+
+Owned by component `schematic` placement, `schematicWires`, `nets`, component pin net fields and `padNetAssignments`.
+
+The live unified Schematic editor:
+
+- places existing project instances;
+- connects their real pins;
+- creates or reuses canonical nets;
+- exposes ERC findings linked to responsible objects;
+- does not create a second project component from a library definition;
+- uses an in-app dependency review before whole-product deletion.
+
+### PCB
+
+Owned by component `pcb` placement, board geometry, traces, vias, constraints and pad-net assignments.
+
+The live Board Designer receives the selected board, component and net from shared UI context, while editing canonical project records.
+
+### Lightweight 3D
+
+Owned as a derived visual view, not engineering authority.
+
+The connected board 3D view:
+
+- filters to the selected board;
+- highlights the selected canonical component;
+- uses the board outline when available;
+- uses package dimensions when available;
+- labels provisional envelopes when exact dimensions are missing;
+- renders only on interaction, resize or visibility return;
+- does not auto-rotate or run a permanent animation loop;
+- releases WebGL resources when closed.
+
+It must never authorize dimensional clearance, interference, mass, manufacturing or release. Exact STEP/B-Rep authority remains part of the CAD-kernel roadmap.
+
+### BOM
+
+Owned by canonical `bom` records and the component instance's `bomItemId`.
+
+A selected project component can create one linked BOM record. Electrical values remain blank until they are explicitly qualified; the UI must not infer authoritative values from a generic family visual.
+
+### Validation
+
+Owned by canonical `validationTests` and `validationRuns`.
+
+A component-linked test stores the same component ID and current canonical net IDs. The validation editor remains capable of generic requirement/factory testing, but selected-object context is preserved above it.
+
+## UI-only Studio context
+
+`studioContextStore` is intentionally separate from project persistence.
+
+It may store:
+
+- active board ID;
+- active component-definition ID;
+- active component-instance ID;
+- active net name;
+- selected object type and ID;
+- origin and return workbench;
+- requested mechanical/3D mode.
+
+It must not become a second engineering database. Clearing this store must not modify project records.
+
+## Persistent Studio frame
+
+Every workbench is mounted under:
+
+1. the complete product build map;
+2. the context bar when the workbench participates in shared object flow;
+3. the workbench itself;
+4. the shared findings/status area.
+
+Workflow profiles control focus and emphasis. They do not remove discoverability of Product, Mechanical, Electronics, PCB, Firmware, Validation or Outputs from the build map.
+
+## Connected handoff rules
+
+### Components → Schematic
+
+- preserve board, definition and instance IDs;
+- place the selected instance if unplaced;
+- focus the existing symbol if already placed.
+
+### Schematic → PCB
+
+- preserve board, instance and net context;
+- open Board Settings when no board exists;
+- otherwise open Board Designer with the same selected object.
+
+### PCB → 3D
+
+- preserve board and selected instance;
+- open the event-driven board-context viewer;
+- mark provisional dimensions and preview trust.
+
+### Any engineering workbench → BOM
+
+- preserve selected component;
+- show its linked BOM row first;
+- create a link through `bomItemId`, not a copied name.
+
+### Any engineering workbench → Validation
+
+- preserve selected component and active net;
+- create tests with `linkedComponentIds` and `linkedNetIds`.
+
+## Empty-state rule
+
+Every empty state must do one of the following:
+
+- create the real missing canonical object;
+- route to the workbench that owns it;
+- explain why progress is blocked.
+
+It must not reference deleted actions, hidden generators or unrelated dashboards.
+
+## Completion requirements for issue #64
+
+The issue remains open until:
+
+- one canonical component identity completes the full golden path;
+- integration tests verify board, definition, component, pins, wires, nets, PCB placement, BOM and validation links;
+- touched native browser dialogs are removed;
+- CI and production builds pass;
+- a Vercel preview and merged production deployment are verified;
+- the production `/studio` route is healthy;
+- the broader open boundaries are documented without closing unrelated parent issues.

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { BUILD_STAGES, ELECTRONICS_FLOW } from '../components/studio/StudioBuildMap';
+import { useStudioContextStore } from '../store/studioContextStore';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+afterEach(() => {
+  useStudioContextStore.getState().clearContext();
+});
+
+describe('unified Hardware Studio build map', () => {
+  it('keeps every major product domain discoverable in one stable order', () => {
+    expect(BUILD_STAGES.map((stage) => stage.id)).toEqual([
+      'product',
+      'mechanical',
+      'electronics',
+      'pcb',
+      'firmware',
+      'validation',
+      'outputs',
+    ]);
+    expect(new Set(BUILD_STAGES.map((stage) => stage.viewId)).size).toBe(BUILD_STAGES.length);
+  });
+
+  it('defines a single connected electronics golden path including real 3D entry', () => {
+    expect(ELECTRONICS_FLOW.map((step) => step.id)).toEqual([
+      'component-library',
+      'schematic-editor',
+      'board-settings',
+      'board-designer',
+      'mechanical-studio',
+      'pcb-drc',
+    ]);
+    expect(ELECTRONICS_FLOW.find((step) => step.id === 'mechanical-studio')?.label).toBe('Assembly / 3D');
+  });
+});
+
+describe('shared cross-workbench engineering context', () => {
+  it('preserves board, component, net, origin, and requested 3D mode across handoffs', () => {
+    const context = useStudioContextStore.getState();
+    context.setActiveBoard('board-main');
+    context.setActiveComponentDefinition('lib-mcu');
+    context.setActiveComponent('comp-u1');
+    context.setActiveNet('I2C_SDA');
+    context.beginHandoff('schematic-editor', 'schematic-editor');
+    context.requestMechanicalMode('webgl-3d');
+
+    const next = useStudioContextStore.getState();
+    expect(next.activeBoardId).toBe('board-main');
+    expect(next.activeComponentDefinitionId).toBe('lib-mcu');
+    expect(next.activeComponentId).toBe('comp-u1');
+    expect(next.activeNetName).toBe('I2C_SDA');
+    expect(next.originView).toBe('schematic-editor');
+    expect(next.returnView).toBe('schematic-editor');
+    expect(next.requestedMechanicalMode).toBe('webgl-3d');
+    expect(next.selected).toEqual({ entity: 'net', id: 'I2C_SDA', label: 'I2C_SDA' });
+  });
+
+  it('clears only UI context without mutating project engineering data', () => {
+    const context = useStudioContextStore.getState();
+    context.setActiveBoard('board-main');
+    context.setActiveComponent('comp-u1');
+    context.requestMechanicalMode('webgl-3d');
+    context.clearContext();
+
+    expect(useStudioContextStore.getState()).toMatchObject({
+      activeBoardId: null,
+      activeComponentDefinitionId: null,
+      activeComponentId: null,
+      activeNetName: null,
+      selected: null,
+      originView: null,
+      returnView: null,
+      requestedMechanicalMode: null,
+    });
+  });
+});
+
+describe('golden-path regression guards', () => {
+  it('does not send an empty PCB editor to the removed dashboard generator', () => {
+    const boardDesigner = source('../components/board/BoardDesigner.tsx');
+    expect(boardDesigner).not.toContain('Generate a Full Product Plan from the Project Dashboard');
+    expect(boardDesigner).not.toContain('Go to Dashboard');
+    expect(boardDesigner).toContain('Create starter board');
+    expect(boardDesigner).toContain("setActiveView('board-settings')");
+    expect(boardDesigner).toContain("setActiveView('component-library')");
+    expect(boardDesigner).toContain("setActiveView('schematic-editor')");
+  });
+
+  it('mounts one persistent build map and shared engineering context above workbenches', () => {
+    const appShell = source('../components/AppShell.tsx');
+    expect(appShell).toContain('<StudioBuildMap />');
+    expect(appShell).toContain('<EngineeringContextBar />');
+    expect(appShell).toContain('UnifiedComponentLibraryWorkbench');
+    expect(appShell).toContain('UnifiedSchematicWorkbench');
+    expect(appShell).toContain('UnifiedMechanicalWorkbench');
+  });
+
+  it('adapts existing editors to the selected canonical component instance', () => {
+    const adapters = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
+    const contextBar = source('../components/studio/EngineeringContextBar.tsx');
+    expect(adapters).toContain('placeComponentOnSchematic');
+    expect(adapters).toContain('setActiveComponent(added.id)');
+    expect(contextBar).toContain("requestMechanicalMode('webgl-3d')");
+    expect(contextBar).toContain("viewId === 'board-designer' && !selectedBoard");
+  });
+});

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -39,7 +39,7 @@ describe('unified Hardware Studio build map', () => {
 });
 
 describe('shared cross-workbench engineering context', () => {
-  it('preserves board, component, net, origin, and requested 3D mode across handoffs', () => {
+  it('preserves definition, board, component, net, origin, and requested 3D mode across handoffs', () => {
     const context = useStudioContextStore.getState();
     context.setActiveBoard('board-main');
     context.setActiveComponentDefinition('lib-mcu');
@@ -99,12 +99,14 @@ describe('golden-path regression guards', () => {
     expect(appShell).toContain('UnifiedBoardDesignerWorkbench');
     expect(appShell).toContain('UnifiedMechanicalWorkbench');
     expect(appShell).toContain('<UnifiedBOMWorkbench />');
+    expect(appShell).toContain('<UnifiedValidationWorkbench initialMode="tests" />');
   });
 
-  it('adapts existing editors to the selected canonical component instance', () => {
+  it('adapts editors to the selected canonical definition and component instance', () => {
     const adapters = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
     const contextBar = source('../components/studio/EngineeringContextBar.tsx');
     expect(adapters).toContain('placeComponentOnSchematic');
+    expect(adapters).toContain('setActiveComponentDefinition(added.libraryId || null)');
     expect(adapters).toContain('setActiveComponent(added.id)');
     expect(adapters).toContain('UnifiedBoardDesignerWorkbench');
     expect(contextBar).toContain("requestMechanicalMode(viewId === 'mechanical-studio' ? 'webgl-3d' : null)");
@@ -130,6 +132,15 @@ describe('golden-path regression guards', () => {
     expect(bom).toContain("updateBoardComponent(selectedComponent.id, { bomItemId: id })");
     expect(bom).toContain('Linked to ${selectedComponent.referenceDesignator}');
     expect(bom).not.toContain('generateBOMFromMVP');
+    expect(bom).not.toContain('selectedComponent.electrical');
+  });
+
+  it('links validation to the selected component and its actual net IDs', () => {
+    const validation = source('../components/studio/UnifiedValidationWorkbench.tsx');
+    expect(validation).toContain('linkedComponentIds: [selectedComponent.id]');
+    expect(validation).toContain('linkedNetIds: selectedNetIds');
+    expect(validation).toContain('selectedComponent.architectureNodeId');
+    expect(validation).toContain("executeProjectCommand('ADD_COMPONENT_TEST'");
   });
 
   it('uses an event-driven selected-board 3D preview instead of permanent animation', () => {

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -96,7 +96,9 @@ describe('golden-path regression guards', () => {
     expect(appShell).toContain('<EngineeringContextBar />');
     expect(appShell).toContain('UnifiedComponentLibraryWorkbench');
     expect(appShell).toContain('UnifiedSchematicWorkbench');
+    expect(appShell).toContain('UnifiedBoardDesignerWorkbench');
     expect(appShell).toContain('UnifiedMechanicalWorkbench');
+    expect(appShell).toContain('<UnifiedBOMWorkbench />');
   });
 
   it('adapts existing editors to the selected canonical component instance', () => {
@@ -104,18 +106,40 @@ describe('golden-path regression guards', () => {
     const contextBar = source('../components/studio/EngineeringContextBar.tsx');
     expect(adapters).toContain('placeComponentOnSchematic');
     expect(adapters).toContain('setActiveComponent(added.id)');
-    expect(contextBar).toContain("requestMechanicalMode('webgl-3d')");
+    expect(adapters).toContain('UnifiedBoardDesignerWorkbench');
+    expect(contextBar).toContain("requestMechanicalMode(viewId === 'mechanical-studio' ? 'webgl-3d' : null)");
     expect(contextBar).toContain("viewId === 'board-designer' && !selectedBoard");
+    expect(contextBar).toContain("viewId: 'bom'");
+    expect(contextBar).toContain("viewId: 'validation-studio'");
   });
 
   it('routes the live schematic surface through canonical project actions and in-app confirmation', () => {
     const adapter = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
     const schematic = source('../components/schematic/UnifiedSchematicEditor.tsx');
-    expect(adapter).toContain('<UnifiedSchematicEditor />');
+    expect(adapter).toContain('<UnifiedSchematicEditor');
     expect(schematic).toContain('placeComponentOnSchematic');
     expect(schematic).toContain("deleteProjectComponent(deleteImpact.componentId, 'entire-product')");
     expect(schematic).toContain('<Dialog.Root');
     expect(schematic).not.toContain('window.confirm');
     expect(schematic).not.toContain('addProjectComponentFromLibrary');
+  });
+
+  it('keeps BOM records linked to the selected canonical component', () => {
+    const bom = source('../components/studio/UnifiedBOMWorkbench.tsx');
+    expect(bom).toContain('selectedComponent?.bomItemId');
+    expect(bom).toContain("updateBoardComponent(selectedComponent.id, { bomItemId: id })");
+    expect(bom).toContain('Linked to ${selectedComponent.referenceDesignator}');
+    expect(bom).not.toContain('generateBOMFromMVP');
+  });
+
+  it('uses an event-driven selected-board 3D preview instead of permanent animation', () => {
+    const view3d = source('../components/mechanical/UnifiedBoard3DView.tsx');
+    expect(view3d).toContain("powerPreference: 'low-power'");
+    expect(view3d).toContain('component.boardId === boardId');
+    expect(view3d).toContain('component.id === activeComponentId');
+    expect(view3d).toContain("controls.addEventListener('change', render)");
+    expect(view3d).toContain('renderer.forceContextLoss()');
+    expect(view3d).not.toContain('requestAnimationFrame');
+    expect(view3d).not.toContain('mainGroup.rotation');
   });
 });

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -25,7 +25,7 @@ describe('unified Hardware Studio build map', () => {
     expect(new Set(BUILD_STAGES.map((stage) => stage.viewId)).size).toBe(BUILD_STAGES.length);
   });
 
-  it('defines a single connected electronics golden path including real 3D entry', () => {
+  it('defines a single connected electronics golden path including real 3D and Checks entries', () => {
     expect(ELECTRONICS_FLOW.map((step) => step.id)).toEqual([
       'component-library',
       'schematic-editor',
@@ -35,6 +35,7 @@ describe('unified Hardware Studio build map', () => {
       'pcb-drc',
     ]);
     expect(ELECTRONICS_FLOW.find((step) => step.id === 'mechanical-studio')?.label).toBe('Assembly / 3D');
+    expect(ELECTRONICS_FLOW.find((step) => step.id === 'pcb-drc')?.label).toBe('Checks');
   });
 });
 
@@ -100,6 +101,8 @@ describe('golden-path regression guards', () => {
     expect(appShell).toContain('UnifiedMechanicalWorkbench');
     expect(appShell).toContain('<UnifiedBOMWorkbench />');
     expect(appShell).toContain('<UnifiedValidationWorkbench initialMode="tests" />');
+    expect(appShell).toContain("viewId === 'pcb-drc'");
+    expect(appShell).toContain('<UnifiedBoardDRCWorkbench />');
   });
 
   it('adapts editors to the selected canonical definition and component instance', () => {
@@ -141,6 +144,16 @@ describe('golden-path regression guards', () => {
     expect(validation).toContain('linkedNetIds: selectedNetIds');
     expect(validation).toContain('selectedComponent.architectureNodeId');
     expect(validation).toContain("executeProjectCommand('ADD_COMPONENT_TEST'");
+  });
+
+  it('routes board checks back to the responsible shared object', () => {
+    const drc = source('../components/studio/UnifiedBoardDRCWorkbench.tsx');
+    expect(drc).toContain('runBoardDRC(useProjectStore.getState())');
+    expect(drc).toContain("result.linkedObjectType === 'component'");
+    expect(drc).toContain('setActiveComponent(result.linkedObjectId)');
+    expect(drc).toContain("result.linkedObjectType === 'net'");
+    expect(drc).toContain('setActiveNet');
+    expect(drc).toContain("setActiveView('board-designer')");
   });
 
   it('uses an event-driven selected-board 3D preview instead of permanent animation', () => {

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -107,4 +107,15 @@ describe('golden-path regression guards', () => {
     expect(contextBar).toContain("requestMechanicalMode('webgl-3d')");
     expect(contextBar).toContain("viewId === 'board-designer' && !selectedBoard");
   });
+
+  it('routes the live schematic surface through canonical project actions and in-app confirmation', () => {
+    const adapter = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
+    const schematic = source('../components/schematic/UnifiedSchematicEditor.tsx');
+    expect(adapter).toContain('<UnifiedSchematicEditor />');
+    expect(schematic).toContain('placeComponentOnSchematic');
+    expect(schematic).toContain("deleteProjectComponent(deleteImpact.componentId, 'entire-product')");
+    expect(schematic).toContain('<Dialog.Root');
+    expect(schematic).not.toContain('window.confirm');
+    expect(schematic).not.toContain('addProjectComponentFromLibrary');
+  });
 });

--- a/src/__tests__/unifiedGoldenPath.integration.test.ts
+++ b/src/__tests__/unifiedGoldenPath.integration.test.ts
@@ -26,7 +26,7 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     useStudioContextStore.getState().clearContext();
   });
 
-  it('keeps the same component IDs, pins, net, board, sourcing, and validation links', () => {
+  it('keeps the same component IDs, representations, pins, net, board, sourcing, and validation links', () => {
     const store = useProjectStore.getState();
     const definitions = defaultComponents.filter((definition) => definition.pins.length > 0).slice(0, 2);
     expect(definitions).toHaveLength(2);
@@ -57,6 +57,9 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     expect(source.id).not.toBe(target.id);
     expect(source.libraryId).toBe(definitions[0].libraryId);
     expect(target.libraryId).toBe(definitions[1].libraryId);
+    expect(source.packageDimensions).toEqual(definitions[0].packageDimensions);
+    expect(source.footprintSvg).toBe(definitions[0].footprintSvg);
+    expect(source.manufacturer).toBe(definitions[0].manufacturer);
 
     store.placeComponentOnSchematic(source.id, 120, 160);
     store.placeComponentOnSchematic(target.id, 360, 160);
@@ -136,6 +139,9 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
       schematic: expect.objectContaining({ placed: true }),
       pcb: expect.objectContaining({ placed: true, xMm: 12, yMm: 16, side: 'Top' }),
     });
+    expect(finalSource?.packageDimensions).toEqual(definitions[0].packageDimensions);
+    expect(finalSource?.footprintSvg).toBe(definitions[0].footprintSvg);
+    expect(finalSource?.manufacturer).toBe(definitions[0].manufacturer);
     expect(finalTarget).toMatchObject({
       id: target.id,
       boardId: board.id,

--- a/src/__tests__/unifiedGoldenPath.integration.test.ts
+++ b/src/__tests__/unifiedGoldenPath.integration.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { defaultComponents } from '../lib/components/componentLibrary';
+import { normalizeProjectComponent } from '../lib/projectMigrations';
 import { useProjectStore } from '../store/projectStore';
 import { useStudioContextStore } from '../store/studioContextStore';
 import type { BOMItem } from '../types';
@@ -26,7 +27,7 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     useStudioContextStore.getState().clearContext();
   });
 
-  it('keeps the same component IDs, representations, pins, net, board, sourcing, and validation links', () => {
+  it('keeps the same component IDs, pins, net, board, sourcing, and validation links', () => {
     const store = useProjectStore.getState();
     const definitions = defaultComponents.filter((definition) => definition.pins.length > 0).slice(0, 2);
     expect(definitions).toHaveLength(2);
@@ -57,8 +58,8 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     expect(source.id).not.toBe(target.id);
     expect(source.libraryId).toBe(definitions[0].libraryId);
     expect(target.libraryId).toBe(definitions[1].libraryId);
-    expect(source.packageDimensions).toEqual(definitions[0].packageDimensions);
-    expect(source.footprintSvg).toBe(definitions[0].footprintSvg);
+    expect(source.packageName).toBe(definitions[0].package);
+    expect(source.footprint).toBe(definitions[0].footprint);
     expect(source.manufacturer).toBe(definitions[0].manufacturer);
 
     store.placeComponentOnSchematic(source.id, 120, 160);
@@ -135,13 +136,13 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
       id: source.id,
       boardId: board.id,
       libraryId: definitions[0].libraryId,
+      packageName: definitions[0].package,
+      footprint: definitions[0].footprint,
+      manufacturer: definitions[0].manufacturer,
       bomItemId: bomId,
       schematic: expect.objectContaining({ placed: true }),
       pcb: expect.objectContaining({ placed: true, xMm: 12, yMm: 16, side: 'Top' }),
     });
-    expect(finalSource?.packageDimensions).toEqual(definitions[0].packageDimensions);
-    expect(finalSource?.footprintSvg).toBe(definitions[0].footprintSvg);
-    expect(finalSource?.manufacturer).toBe(definitions[0].manufacturer);
     expect(finalTarget).toMatchObject({
       id: target.id,
       boardId: board.id,
@@ -164,5 +165,67 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
       linkedNetIds: [connection.net.id],
       status: 'Not Started',
     });
+  });
+
+  it('preserves optional representation and CAD metadata while normalizing legacy pins', () => {
+    const normalized = normalizeProjectComponent({
+      id: 'comp_legacy_sensor',
+      libraryId: 'sensor-reviewed-v3',
+      referenceDesignator: 'U7',
+      componentName: 'Qualified Sensor',
+      componentType: 'Sensor',
+      value: 'SENSOR-X',
+      boardId: 'board_main',
+      circuitBlockId: 'block_sensing',
+      packageName: 'LGA-12',
+      footprint: 'LGA-12_2.5x3.0mm',
+      manufacturer: 'Example Devices',
+      description: 'Reviewed component metadata.',
+      footprintSvg: '<svg viewBox="0 0 100 100"></svg>',
+      packageDimensions: { widthMm: 3, heightMm: 2.5, heightZMm: 0.8 },
+      packageOutline: { widthMm: 3, heightMm: 2.5, courtyardMm: 0.25 },
+      symbolRevisionId: 'symbol-rev-3',
+      footprintRevisionId: 'footprint-rev-5',
+      cadModelRevisionId: 'cad-rev-2',
+      model3dUrl: '/models/sensor-x.glb',
+      sourceLicense: 'Reviewed vendor distribution terms',
+      qualificationStatus: 'Reviewed',
+      pins: [{
+        number: '1',
+        name: 'VDD',
+        electricalType: 'PowerIn',
+        required: true,
+        voltage: 3.3,
+        protocol: 'Power',
+        notes: 'Qualified supply pin.',
+      }],
+    });
+
+    expect(normalized).toMatchObject({
+      id: 'comp_legacy_sensor',
+      libraryId: 'sensor-reviewed-v3',
+      manufacturer: 'Example Devices',
+      footprintSvg: '<svg viewBox="0 0 100 100"></svg>',
+      packageDimensions: { widthMm: 3, heightMm: 2.5, heightZMm: 0.8 },
+      packageOutline: { widthMm: 3, heightMm: 2.5, courtyardMm: 0.25 },
+      symbolRevisionId: 'symbol-rev-3',
+      footprintRevisionId: 'footprint-rev-5',
+      cadModelRevisionId: 'cad-rev-2',
+      model3dUrl: '/models/sensor-x.glb',
+      sourceLicense: 'Reviewed vendor distribution terms',
+      qualificationStatus: 'Reviewed',
+    });
+    expect(normalized.pins).toEqual([
+      expect.objectContaining({
+        componentId: 'comp_legacy_sensor',
+        pinNumber: '1',
+        pinName: 'VDD',
+        electricalType: 'PowerIn',
+        required: true,
+        voltage: 3.3,
+        protocol: 'Power',
+        notes: 'Qualified supply pin.',
+      }),
+    ]);
   });
 });

--- a/src/__tests__/unifiedGoldenPath.integration.test.ts
+++ b/src/__tests__/unifiedGoldenPath.integration.test.ts
@@ -27,7 +27,7 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     useStudioContextStore.getState().clearContext();
   });
 
-  it('keeps the same component IDs, pins, net, board, sourcing, and validation links', () => {
+  it('keeps one canonical identity through schematic, PCB, BOM, and validation', () => {
     const store = useProjectStore.getState();
     const definitions = defaultComponents.filter((definition) => definition.pins.length > 0).slice(0, 2);
     expect(definitions).toHaveLength(2);
@@ -55,12 +55,14 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
 
     const source = store.addProjectComponentFromLibrary(definitions[0], board.id);
     const target = store.addProjectComponentFromLibrary(definitions[1], board.id);
-    expect(source.id).not.toBe(target.id);
-    expect(source.libraryId).toBe(definitions[0].libraryId);
+
+    expect(source).toMatchObject({
+      libraryId: definitions[0].libraryId,
+      packageName: definitions[0].packageName,
+      footprint: definitions[0].footprintName,
+      manufacturer: definitions[0].manufacturer,
+    });
     expect(target.libraryId).toBe(definitions[1].libraryId);
-    expect(source.packageName).toBe(definitions[0].package);
-    expect(source.footprint).toBe(definitions[0].footprint);
-    expect(source.manufacturer).toBe(definitions[0].manufacturer);
 
     store.placeComponentOnSchematic(source.id, 120, 160);
     store.placeComponentOnSchematic(target.id, 360, 160);
@@ -128,16 +130,13 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     const finalState = useProjectStore.getState();
     const finalSource = finalState.boardComponents?.find((component) => component.id === source.id);
     const finalTarget = finalState.boardComponents?.find((component) => component.id === target.id);
-    const finalWire = finalState.schematicWires?.find((wire) => wire.id === connection.wire.id);
-    const finalNet = finalState.nets?.find((net) => net.id === connection.net.id);
-    const finalTest = finalState.validationTests?.[0];
 
     expect(finalSource).toMatchObject({
       id: source.id,
       boardId: board.id,
       libraryId: definitions[0].libraryId,
-      packageName: definitions[0].package,
-      footprint: definitions[0].footprint,
+      packageName: definitions[0].packageName,
+      footprint: definitions[0].footprintName,
       manufacturer: definitions[0].manufacturer,
       bomItemId: bomId,
       schematic: expect.objectContaining({ placed: true }),
@@ -152,15 +151,15 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     });
     expect(finalSource?.pins?.find((pin) => pin.pinNumber === sourcePin)?.netName).toBe('GOLDEN_SIGNAL');
     expect(finalTarget?.pins?.find((pin) => pin.pinNumber === targetPin)?.netName).toBe('GOLDEN_SIGNAL');
-    expect(finalWire).toMatchObject({
+    expect(finalState.schematicWires?.find((wire) => wire.id === connection.wire.id)).toMatchObject({
       netId: connection.net.id,
       netName: 'GOLDEN_SIGNAL',
       sourceAnchor: expect.objectContaining({ componentId: source.id, pinNumber: sourcePin }),
       targetAnchor: expect.objectContaining({ componentId: target.id, pinNumber: targetPin }),
     });
-    expect(finalNet?.netName).toBe('GOLDEN_SIGNAL');
+    expect(finalState.nets?.find((net) => net.id === connection.net.id)?.netName).toBe('GOLDEN_SIGNAL');
     expect(finalState.bom?.[0]).toMatchObject({ id: bomId, blockName: source.componentName });
-    expect(finalTest).toMatchObject({
+    expect(finalState.validationTests?.[0]).toMatchObject({
       linkedComponentIds: [source.id],
       linkedNetIds: [connection.net.id],
       status: 'Not Started',
@@ -180,10 +179,8 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
       packageName: 'LGA-12',
       footprint: 'LGA-12_2.5x3.0mm',
       manufacturer: 'Example Devices',
-      description: 'Reviewed component metadata.',
       footprintSvg: '<svg viewBox="0 0 100 100"></svg>',
       packageDimensions: { widthMm: 3, heightMm: 2.5, heightZMm: 0.8 },
-      packageOutline: { widthMm: 3, heightMm: 2.5, courtyardMm: 0.25 },
       symbolRevisionId: 'symbol-rev-3',
       footprintRevisionId: 'footprint-rev-5',
       cadModelRevisionId: 'cad-rev-2',
@@ -207,7 +204,6 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
       manufacturer: 'Example Devices',
       footprintSvg: '<svg viewBox="0 0 100 100"></svg>',
       packageDimensions: { widthMm: 3, heightMm: 2.5, heightZMm: 0.8 },
-      packageOutline: { widthMm: 3, heightMm: 2.5, courtyardMm: 0.25 },
       symbolRevisionId: 'symbol-rev-3',
       footprintRevisionId: 'footprint-rev-5',
       cadModelRevisionId: 'cad-rev-2',

--- a/src/__tests__/unifiedGoldenPath.integration.test.ts
+++ b/src/__tests__/unifiedGoldenPath.integration.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { defaultComponents } from '../lib/components/componentLibrary';
+import { useProjectStore } from '../store/projectStore';
+import { useStudioContextStore } from '../store/studioContextStore';
+import type { BOMItem } from '../types';
+
+describe('unified Electronics → PCB → BOM → Validation golden path', () => {
+  beforeEach(() => {
+    const state = useProjectStore.getState();
+    useProjectStore.setState({
+      ...state,
+      boards: [],
+      activeBoardId: '',
+      boardOutlines: [],
+      boardComponents: [],
+      schematicWires: [],
+      nets: [],
+      padNetAssignments: [],
+      traces: [],
+      bom: [],
+      validationTests: [],
+      reviewResults: [],
+      pastCommands: [],
+      futureCommands: [],
+    });
+    useStudioContextStore.getState().clearContext();
+  });
+
+  it('keeps the same component IDs, pins, net, board, sourcing, and validation links', () => {
+    const store = useProjectStore.getState();
+    const definitions = defaultComponents.filter((definition) => definition.pins.length > 0).slice(0, 2);
+    expect(definitions).toHaveLength(2);
+
+    const board = store.addBoard({
+      name: 'Golden Path Board',
+      boardType: 'Main PCB',
+      dimensionsMm: '60 x 40',
+      layerCount: 2,
+      substrate: 'FR4',
+      status: 'In Layout',
+    });
+    store.updateProjectState({
+      activeBoardId: board.id,
+      boardOutlines: [{
+        id: `outline_${board.id}`,
+        boardId: board.id,
+        points: [{ x: 0, y: 0 }, { x: 60, y: 0 }, { x: 60, y: 40 }, { x: 0, y: 40 }],
+        width: 60,
+        height: 40,
+        units: 'mm',
+        notes: 'Integration-test board outline.',
+      }],
+    });
+
+    const source = store.addProjectComponentFromLibrary(definitions[0], board.id);
+    const target = store.addProjectComponentFromLibrary(definitions[1], board.id);
+    expect(source.id).not.toBe(target.id);
+    expect(source.libraryId).toBe(definitions[0].libraryId);
+    expect(target.libraryId).toBe(definitions[1].libraryId);
+
+    store.placeComponentOnSchematic(source.id, 120, 160);
+    store.placeComponentOnSchematic(target.id, 360, 160);
+
+    const sourcePin = definitions[0].pins[0].pinNumber;
+    const targetPin = definitions[1].pins[0].pinNumber;
+    const connection = store.connectComponentPins(
+      source.id,
+      sourcePin,
+      target.id,
+      targetPin,
+      'GOLDEN_SIGNAL',
+      [{ x: 180, y: 160 }, { x: 300, y: 160 }],
+    );
+
+    store.placeComponentOnBoard(source.id, 12, 16, 'Top');
+    store.placeComponentOnBoard(target.id, 36, 16, 'Top');
+
+    const bomId = `bom_${source.id}`;
+    const bomItem: BOMItem = {
+      id: bomId,
+      blockName: source.componentName,
+      candidateComponent: source.value || source.componentName,
+      partNumber: source.partNumber,
+      stage: 'Prototype',
+      quantity: 1,
+      voltage: '',
+      currentEstimate: '',
+      interface: '',
+      packageSize: source.footprint,
+      dimensions: '',
+      costEstimate: '0.00',
+      supplier: source.supplier || '',
+      supplierUrl: '',
+      datasheetUrl: source.datasheetUrl || '',
+      status: 'Not Started',
+      risk: '',
+      alternative: '',
+      notes: `Linked to ${source.id}`,
+    };
+    store.updateProjectState({ bom: [bomItem] });
+    store.updateProjectComponent(source.id, { bomItemId: bomId });
+
+    store.addValidationTest({
+      name: `${source.referenceDesignator} connectivity validation`,
+      stage: 'EVT',
+      category: 'Electrical',
+      linkedRequirementIds: [],
+      linkedArchitectureNodeIds: [],
+      linkedComponentIds: [source.id],
+      linkedNetIds: [connection.net.id],
+      linkedFirmwareModuleIds: [],
+      steps: [{
+        stepNumber: 1,
+        instruction: 'Verify the selected component and GOLDEN_SIGNAL connection.',
+        expectedResult: 'The canonical component and net are present in schematic and PCB state.',
+        completed: false,
+      }],
+      measurements: [],
+      passCriteria: ['Canonical IDs and net continuity match the project graph.'],
+      status: 'Not Started',
+      evidence: [],
+    });
+
+    const finalState = useProjectStore.getState();
+    const finalSource = finalState.boardComponents?.find((component) => component.id === source.id);
+    const finalTarget = finalState.boardComponents?.find((component) => component.id === target.id);
+    const finalWire = finalState.schematicWires?.find((wire) => wire.id === connection.wire.id);
+    const finalNet = finalState.nets?.find((net) => net.id === connection.net.id);
+    const finalTest = finalState.validationTests?.[0];
+
+    expect(finalSource).toMatchObject({
+      id: source.id,
+      boardId: board.id,
+      libraryId: definitions[0].libraryId,
+      bomItemId: bomId,
+      schematic: expect.objectContaining({ placed: true }),
+      pcb: expect.objectContaining({ placed: true, xMm: 12, yMm: 16, side: 'Top' }),
+    });
+    expect(finalTarget).toMatchObject({
+      id: target.id,
+      boardId: board.id,
+      libraryId: definitions[1].libraryId,
+      schematic: expect.objectContaining({ placed: true }),
+      pcb: expect.objectContaining({ placed: true, xMm: 36, yMm: 16, side: 'Top' }),
+    });
+    expect(finalSource?.pins?.find((pin) => pin.pinNumber === sourcePin)?.netName).toBe('GOLDEN_SIGNAL');
+    expect(finalTarget?.pins?.find((pin) => pin.pinNumber === targetPin)?.netName).toBe('GOLDEN_SIGNAL');
+    expect(finalWire).toMatchObject({
+      netId: connection.net.id,
+      netName: 'GOLDEN_SIGNAL',
+      sourceAnchor: expect.objectContaining({ componentId: source.id, pinNumber: sourcePin }),
+      targetAnchor: expect.objectContaining({ componentId: target.id, pinNumber: targetPin }),
+    });
+    expect(finalNet?.netName).toBe('GOLDEN_SIGNAL');
+    expect(finalState.bom?.[0]).toMatchObject({ id: bomId, blockName: source.componentName });
+    expect(finalTest).toMatchObject({
+      linkedComponentIds: [source.id],
+      linkedNetIds: [connection.net.id],
+      status: 'Not Started',
+    });
+  });
+});

--- a/src/__tests__/unifiedGoldenPath.integration.test.ts
+++ b/src/__tests__/unifiedGoldenPath.integration.test.ts
@@ -61,8 +61,8 @@ describe('unified Electronics → PCB → BOM → Validation golden path', () =>
     store.placeComponentOnSchematic(source.id, 120, 160);
     store.placeComponentOnSchematic(target.id, 360, 160);
 
-    const sourcePin = definitions[0].pins[0].pinNumber;
-    const targetPin = definitions[1].pins[0].pinNumber;
+    const sourcePin = definitions[0].pins[0].number;
+    const targetPin = definitions[1].pins[0].number;
     const connection = store.connectComponentPins(
       source.id,
       sourcePin,

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -28,6 +28,7 @@ import { FirmwareStudio } from './firmware/FirmwareStudio';
 import { StudioBuildMap } from './studio/StudioBuildMap';
 import { EngineeringContextBar } from './studio/EngineeringContextBar';
 import { UnifiedBOMWorkbench } from './studio/UnifiedBOMWorkbench';
+import { UnifiedBoardDRCWorkbench } from './studio/UnifiedBoardDRCWorkbench';
 import { UnifiedValidationWorkbench } from './studio/UnifiedValidationWorkbench';
 import {
   UnifiedBoardDesignerWorkbench,
@@ -36,7 +37,9 @@ import {
   UnifiedSchematicWorkbench,
 } from './studio/UnifiedWorkbenchAdapters';
 
-function renderSurface(surface: NavigationSurface): React.ReactNode {
+function renderSurface(surface: NavigationSurface, viewId: string): React.ReactNode {
+  if (viewId === 'pcb-drc') return <UnifiedBoardDRCWorkbench />;
+
   switch (surface) {
     case 'dashboard': return <ProjectDashboard />;
     case 'legacy-blueprint': return <BlueprintCanvas />;
@@ -164,7 +167,7 @@ export const AppShell: React.FC = () => {
           <div className="relative flex min-h-0 flex-1">
             {showVisualizer && <ProductVisualizer />}
             <div className="relative flex h-full min-w-0 flex-1 flex-col">
-              {activeNavigationItem ? renderSurface(activeNavigationItem.surface) : (
+              {activeNavigationItem ? renderSurface(activeNavigationItem.surface, activeView) : (
                 <UnavailableWorkspace viewId={activeView} onReturn={() => setActiveView('dashboard')} />
               )}
             </div>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -32,6 +32,7 @@ import { MechanicalStudio } from './mechanical/MechanicalStudio';
 import { FirmwareStudio } from './firmware/FirmwareStudio';
 import { ValidationStudio } from './validation/ValidationStudio';
 import { StudioBuildMap } from './studio/StudioBuildMap';
+import { EngineeringContextBar } from './studio/EngineeringContextBar';
 
 function renderSurface(surface: NavigationSurface): React.ReactNode {
   switch (surface) {
@@ -145,6 +146,7 @@ export const AppShell: React.FC = () => {
         <Sidebar />
         <main className="relative flex h-full min-w-0 flex-1 flex-col overflow-hidden">
           <StudioBuildMap />
+          <EngineeringContextBar />
           {activeHiddenDomain && (
             <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-amber-950">
               <div className="flex min-w-0 items-center gap-2">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -24,13 +24,13 @@ import { ProjectDashboard } from './ProjectDashboard';
 import { BlueprintSheets } from './BlueprintSheets';
 import { FactoryPackageBuilder } from './FactoryPackageBuilder';
 import { RevisionsStudio } from './revisions/RevisionsStudio';
-import { BoardDesigner } from './board/BoardDesigner';
 import { ProductStudio } from './product/ProductStudio';
 import { FirmwareStudio } from './firmware/FirmwareStudio';
 import { ValidationStudio } from './validation/ValidationStudio';
 import { StudioBuildMap } from './studio/StudioBuildMap';
 import { EngineeringContextBar } from './studio/EngineeringContextBar';
 import {
+  UnifiedBoardDesignerWorkbench,
   UnifiedComponentLibraryWorkbench,
   UnifiedMechanicalWorkbench,
   UnifiedSchematicWorkbench,
@@ -49,7 +49,7 @@ function renderSurface(surface: NavigationSurface): React.ReactNode {
     case 'power-budget': return <PowerBudgetTable />;
     case 'pin-map': return <PinMapTable />;
     case 'bom': return <BOMTable />;
-    case 'board-designer': return <BoardDesigner />;
+    case 'board-designer': return <UnifiedBoardDesignerWorkbench />;
     case 'board-studio': return <BoardStudio />;
     case 'pcb-constraints': return <PCBConstraints />;
     case 'firmware-modules': return <FirmwareStudio initialMode="modules" />;

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -10,7 +10,6 @@ import { RECOVER_TO_DASHBOARD_KEY } from '../lib/reliability';
 import { TopBar } from './TopBar';
 import { Sidebar } from './Sidebar';
 import { BlueprintCanvas } from './BlueprintCanvas';
-import { BOMTable } from './BOMTable';
 import { ExportCenter } from './ExportCenter';
 import { PropertiesPanel } from './PropertiesPanel';
 import { ReviewWarnings } from './ReviewWarnings';
@@ -29,6 +28,7 @@ import { FirmwareStudio } from './firmware/FirmwareStudio';
 import { ValidationStudio } from './validation/ValidationStudio';
 import { StudioBuildMap } from './studio/StudioBuildMap';
 import { EngineeringContextBar } from './studio/EngineeringContextBar';
+import { UnifiedBOMWorkbench } from './studio/UnifiedBOMWorkbench';
 import {
   UnifiedBoardDesignerWorkbench,
   UnifiedComponentLibraryWorkbench,
@@ -48,7 +48,7 @@ function renderSurface(surface: NavigationSurface): React.ReactNode {
     case 'schematic-editor': return <UnifiedSchematicWorkbench />;
     case 'power-budget': return <PowerBudgetTable />;
     case 'pin-map': return <PinMapTable />;
-    case 'bom': return <BOMTable />;
+    case 'bom': return <UnifiedBOMWorkbench />;
     case 'board-designer': return <UnifiedBoardDesignerWorkbench />;
     case 'board-studio': return <BoardStudio />;
     case 'pcb-constraints': return <PCBConstraints />;

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -31,6 +31,7 @@ import { ProductStudio } from './product/ProductStudio';
 import { MechanicalStudio } from './mechanical/MechanicalStudio';
 import { FirmwareStudio } from './firmware/FirmwareStudio';
 import { ValidationStudio } from './validation/ValidationStudio';
+import { StudioBuildMap } from './studio/StudioBuildMap';
 
 function renderSurface(surface: NavigationSurface): React.ReactNode {
   switch (surface) {
@@ -143,14 +144,15 @@ export const AppShell: React.FC = () => {
       <div className="relative flex min-h-0 flex-1">
         <Sidebar />
         <main className="relative flex h-full min-w-0 flex-1 flex-col overflow-hidden">
+          <StudioBuildMap />
           {activeHiddenDomain && (
             <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-amber-950">
               <div className="flex min-w-0 items-center gap-2">
                 <EyeOff className="h-4 w-4 shrink-0" aria-hidden="true" />
-                <p className="text-xs leading-5"><strong>This workbench is hidden from your current workflow.</strong> It remains open until you leave, and its project data has not been changed.</p>
+                <p className="text-xs leading-5"><strong>This domain is outside the focused workflow.</strong> It stays fully available in the build map, and its project data has not been changed.</p>
               </div>
               <div className="flex shrink-0 gap-2">
-                <button type="button" onClick={() => toggleDomain(activeHiddenDomain)} className="rounded-lg border border-amber-300 bg-white px-2.5 py-1.5 text-xs font-semibold hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-500">Show this domain</button>
+                <button type="button" onClick={() => toggleDomain(activeHiddenDomain)} className="rounded-lg border border-amber-300 bg-white px-2.5 py-1.5 text-xs font-semibold hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-500">Add to focus</button>
                 <button type="button" onClick={openSetup} className="inline-flex items-center gap-1.5 rounded-lg bg-amber-900 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-amber-800 focus:outline-none focus:ring-2 focus:ring-amber-600 focus:ring-offset-1"><Settings2 className="h-3.5 w-3.5" aria-hidden="true" /> Configure</button>
               </div>
             </div>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -25,10 +25,10 @@ import { FactoryPackageBuilder } from './FactoryPackageBuilder';
 import { RevisionsStudio } from './revisions/RevisionsStudio';
 import { ProductStudio } from './product/ProductStudio';
 import { FirmwareStudio } from './firmware/FirmwareStudio';
-import { ValidationStudio } from './validation/ValidationStudio';
 import { StudioBuildMap } from './studio/StudioBuildMap';
 import { EngineeringContextBar } from './studio/EngineeringContextBar';
 import { UnifiedBOMWorkbench } from './studio/UnifiedBOMWorkbench';
+import { UnifiedValidationWorkbench } from './studio/UnifiedValidationWorkbench';
 import {
   UnifiedBoardDesignerWorkbench,
   UnifiedComponentLibraryWorkbench,
@@ -56,9 +56,9 @@ function renderSurface(surface: NavigationSurface): React.ReactNode {
     case 'firmware-state-machine': return <FirmwareStudio initialMode="state-machine" />;
     case 'firmware-hardware-map': return <FirmwareStudio initialMode="hardware-map" />;
     case 'firmware-source': return <FirmwareStudio initialMode="source" />;
-    case 'validation-tests': return <ValidationStudio initialMode="tests" />;
-    case 'validation-coverage': return <ValidationStudio initialMode="coverage" />;
-    case 'validation-factory-qa': return <ValidationStudio initialMode="factory-qa" />;
+    case 'validation-tests': return <UnifiedValidationWorkbench initialMode="tests" />;
+    case 'validation-coverage': return <UnifiedValidationWorkbench initialMode="coverage" />;
+    case 'validation-factory-qa': return <UnifiedValidationWorkbench initialMode="factory-qa" />;
     case 'blueprint-sheets': return <BlueprintSheets />;
     case 'exports': return <ExportCenter />;
     case 'revisions': return <RevisionsStudio />;

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -25,14 +25,16 @@ import { BlueprintSheets } from './BlueprintSheets';
 import { FactoryPackageBuilder } from './FactoryPackageBuilder';
 import { RevisionsStudio } from './revisions/RevisionsStudio';
 import { BoardDesigner } from './board/BoardDesigner';
-import { ComponentLibraryWorkbench } from './component-library/ComponentLibraryWorkbench';
-import { SchematicEditor } from './schematic/SchematicEditor';
 import { ProductStudio } from './product/ProductStudio';
-import { MechanicalStudio } from './mechanical/MechanicalStudio';
 import { FirmwareStudio } from './firmware/FirmwareStudio';
 import { ValidationStudio } from './validation/ValidationStudio';
 import { StudioBuildMap } from './studio/StudioBuildMap';
 import { EngineeringContextBar } from './studio/EngineeringContextBar';
+import {
+  UnifiedComponentLibraryWorkbench,
+  UnifiedMechanicalWorkbench,
+  UnifiedSchematicWorkbench,
+} from './studio/UnifiedWorkbenchAdapters';
 
 function renderSurface(surface: NavigationSurface): React.ReactNode {
   switch (surface) {
@@ -40,10 +42,10 @@ function renderSurface(surface: NavigationSurface): React.ReactNode {
     case 'legacy-blueprint': return <BlueprintCanvas />;
     case 'product-studio': return <ProductStudio />;
     case 'readiness': return <ReadinessDashboard />;
-    case 'mechanical-canvas': return <MechanicalStudio initialMode="canvas" />;
-    case 'mechanical-assembly': return <MechanicalStudio initialMode="assembly" />;
-    case 'component-library': return <ComponentLibraryWorkbench />;
-    case 'schematic-editor': return <SchematicEditor />;
+    case 'mechanical-canvas': return <UnifiedMechanicalWorkbench defaultMode="canvas" />;
+    case 'mechanical-assembly': return <UnifiedMechanicalWorkbench defaultMode="assembly" />;
+    case 'component-library': return <UnifiedComponentLibraryWorkbench />;
+    case 'schematic-editor': return <UnifiedSchematicWorkbench />;
     case 'power-budget': return <PowerBudgetTable />;
     case 'pin-map': return <PinMapTable />;
     case 'bom': return <BOMTable />;

--- a/src/components/board/BoardDesigner.tsx
+++ b/src/components/board/BoardDesigner.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
 import { BoardDesignerUIState, DEFAULT_VIEW_STATE } from './boardInteraction';
 import { BoardToolbar } from './BoardToolbar';
 import { BoardCanvas } from './BoardCanvas';
@@ -18,30 +19,76 @@ import {
   inferPadNetAssignments,
 } from './boardGeometry';
 import { ReviewResult } from '../../types';
-import { Network, AlertTriangle, Cpu } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Boxes,
+  CircuitBoard,
+  Cpu,
+  Network,
+  PenTool,
+  Plus,
+} from 'lucide-react';
 
 type RightTab = 'inspector' | 'nets' | 'drc';
 
 export const BoardDesigner: React.FC = () => {
   const store = useProjectStore();
   const {
-    boardOutlines, boardComponents, nets, traces,
-    boards, pcbLayers,
-    setActiveView, generateBlueprintPack, addTrace,
+    boardOutlines = [],
+    boardComponents = [],
+    nets = [],
+    traces = [],
+    boards = [],
+    pcbLayers = [],
+    setActiveView,
+    setActiveBoard,
+    addBoard,
+    updateProjectState,
+    generateBlueprintPack,
+    addTrace,
   } = store;
+  const {
+    activeBoardId: contextBoardId,
+    activeComponentId: contextComponentId,
+    activeNetName: contextNetName,
+    setActiveBoard: setContextBoard,
+    setActiveComponent: setContextComponent,
+    setActiveNet: setContextNet,
+    beginHandoff,
+  } = useStudioContextStore();
 
+  const initialBoardId = contextBoardId || store.activeBoardId || boards[0]?.id || null;
   const [viewState, setViewState] = useState<BoardDesignerUIState>({
     ...DEFAULT_VIEW_STATE,
-    activeLayerId: (pcbLayers || [])[0]?.id || 'top-copper',
+    activeBoardId: initialBoardId,
+    activeLayerId: pcbLayers[0]?.id || 'top-copper',
+    selectedComponentId: contextComponentId,
+    selectedNetName: contextNetName,
   });
   const [rightTab, setRightTab] = useState<RightTab>('inspector');
   const [drcResults, setDrcResults] = useState<ReviewResult[]>([]);
 
-  const updateView = useCallback((patch: Partial<BoardDesignerUIState>) => {
-    setViewState(prev => ({ ...prev, ...patch }));
-  }, []);
+  useEffect(() => {
+    const activeBoardId = contextBoardId || store.activeBoardId || boards[0]?.id || null;
+    setViewState((previous) => ({
+      ...previous,
+      activeBoardId,
+      selectedComponentId: contextComponentId ?? previous.selectedComponentId,
+      selectedNetName: contextNetName ?? previous.selectedNetName,
+    }));
+  }, [boards, contextBoardId, contextComponentId, contextNetName, store.activeBoardId]);
 
-  // ── Actions ──────────────────────────────────────────────
+  const updateView = useCallback((patch: Partial<BoardDesignerUIState>) => {
+    setViewState((previous) => ({ ...previous, ...patch }));
+    if (patch.activeBoardId !== undefined) {
+      setContextBoard(patch.activeBoardId);
+      if (patch.activeBoardId) setActiveBoard(patch.activeBoardId);
+    }
+    if (patch.selectedComponentId !== undefined) setContextComponent(patch.selectedComponentId);
+    if (patch.selectedNetName !== undefined) setContextNet(patch.selectedNetName);
+  }, [setActiveBoard, setContextBoard, setContextComponent, setContextNet]);
+
   const handleRunDRC = useCallback(() => {
     const project = useProjectStore.getState();
     const results = runBoardDRC(project);
@@ -50,84 +97,139 @@ export const BoardDesigner: React.FC = () => {
   }, []);
 
   const handleAutoPlace = useCallback(() => {
-    const outline = (boardOutlines || [])[0];
-    const comps = boardComponents || [];
-    const placed = autoPlaceFn(comps, outline);
-    // Update each component
-    for (const comp of placed) {
-      store.updateBoardComponent(comp.id, {
-        placementX: comp.placementX,
-        placementY: comp.placementY,
-        placementStatus: comp.placementStatus,
+    const outline = boardOutlines.find((candidate) => candidate.boardId === viewState.activeBoardId)
+      || boardOutlines[0];
+    const componentsForBoard = boardComponents.filter((component) => component.boardId === viewState.activeBoardId);
+    const placed = autoPlaceFn(componentsForBoard, outline);
+    for (const component of placed) {
+      store.updateBoardComponent(component.id, {
+        placementX: component.placementX,
+        placementY: component.placementY,
+        placementStatus: component.placementStatus,
       });
     }
-    // Also infer pad-net assignments
     const project = useProjectStore.getState();
     const assignments = inferPadNetAssignments(project);
     store.setPadNetAssignments(assignments);
     handleRunDRC();
-  }, [boardOutlines, boardComponents, store, handleRunDRC]);
+  }, [boardComponents, boardOutlines, handleRunDRC, store, viewState.activeBoardId]);
 
   const handleRoughAutoroute = useCallback(() => {
     const project = useProjectStore.getState();
-    const allNets = nets || [];
-    const primaryBoard = (boards || [])[0];
+    const primaryBoard = boards.find((board) => board.id === viewState.activeBoardId) || boards[0];
     const layerId = viewState.activeLayerId || 'top-copper';
 
-    for (const net of allNets) {
-      // Skip if already has traces
-      const existing = (traces || []).filter(t => t.netName === net.netName);
+    for (const net of nets) {
+      const existing = traces.filter((trace) => trace.netName === net.netName && trace.boardId === primaryBoard?.id);
       if (existing.length > 0) continue;
-
       const trace = roughAutorouteNet(project, net.netName, layerId, primaryBoard?.id || 'board-main');
-      if (trace) {
-        addTrace(trace);
-      }
+      if (trace) addTrace(trace);
     }
     handleRunDRC();
-  }, [nets, boards, traces, viewState.activeLayerId, addTrace, handleRunDRC]);
+  }, [addTrace, boards, handleRunDRC, nets, traces, viewState.activeBoardId, viewState.activeLayerId]);
 
   const handleGenerateBlueprint = useCallback(() => {
     generateBlueprintPack();
+    beginHandoff('board-designer', 'board-designer');
     setActiveView('blueprint-sheets');
-  }, [generateBlueprintPack, setActiveView]);
+  }, [beginHandoff, generateBlueprintPack, setActiveView]);
 
   const handleExportBoard = useCallback(() => {
+    beginHandoff('board-designer', 'board-designer');
     setActiveView('exports');
-  }, [setActiveView]);
+  }, [beginHandoff, setActiveView]);
 
   const handleOpenFactory = useCallback(() => {
+    beginHandoff('board-designer', 'board-designer');
     setActiveView('factory-builder');
-  }, [setActiveView]);
+  }, [beginHandoff, setActiveView]);
 
-  const drcCount = drcResults.filter(r => r.severity === 'Error' || r.severity === 'Blocker').length;
+  const createStarterBoard = useCallback(() => {
+    const board = addBoard({
+      name: 'Main PCB',
+      boardType: 'Main PCB',
+      purpose: 'Primary electronics board. Replace the starter dimensions and notes with project-specific engineering data.',
+      dimensionsMm: '50 x 30',
+      layerCount: 2,
+      substrate: 'FR4',
+      placement: 'Internal',
+      status: 'Concept',
+    });
+    const outline = {
+      id: `outline_${board.id}`,
+      boardId: board.id,
+      points: [
+        { x: 0, y: 0 },
+        { x: 50, y: 0 },
+        { x: 50, y: 30 },
+        { x: 0, y: 30 },
+      ],
+      width: 50,
+      height: 30,
+      units: 'mm' as const,
+      notes: 'Starter rectangular outline. Verify exact product dimensions before placement or release.',
+    };
+    updateProjectState({ boardOutlines: [...boardOutlines, outline], activeBoardId: board.id });
+    setActiveBoard(board.id);
+    setContextBoard(board.id);
+    setViewState((previous) => ({ ...previous, activeBoardId: board.id }));
+  }, [addBoard, boardOutlines, setActiveBoard, setContextBoard, updateProjectState]);
 
-  // Check if we have any board data
-  const hasBoards = (boards || []).length > 0;
+  const drcCount = drcResults.filter((result) => result.severity === 'Error' || result.severity === 'Blocker').length;
+  const activeBoard = boards.find((board) => board.id === viewState.activeBoardId) || boards[0];
+  const activeBoardComponents = activeBoard
+    ? boardComponents.filter((component) => component.boardId === activeBoard.id)
+    : [];
 
-  if (!hasBoards) {
+  if (!activeBoard) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-slate-950 text-slate-400">
-        <div className="text-center space-y-3 max-w-md">
-          <div className="text-4xl">🔧</div>
-          <h2 className="text-lg font-bold text-slate-200">Board Designer</h2>
-          <p className="text-[11px] text-slate-500 leading-relaxed">
-            No board data found. Generate a Full Product Plan from the Project Dashboard first to create boards, components, and nets.
-          </p>
-          <button
-            onClick={() => setActiveView('dashboard')}
-            className="px-4 py-2 bg-indigo-600 text-white rounded-lg text-[11px] font-bold hover:bg-indigo-500 transition-colors"
-          >
-            Go to Dashboard
-          </button>
+      <section className="flex h-full min-h-0 flex-1 items-center justify-center overflow-y-auto bg-slate-50 p-4 sm:p-6" aria-labelledby="pcb-empty-title">
+        <div className="w-full max-w-5xl rounded-3xl border border-slate-200 bg-white p-5 shadow-sm sm:p-7">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+            <div className="max-w-2xl">
+              <span className="grid h-12 w-12 place-items-center rounded-2xl bg-indigo-50 text-indigo-700"><CircuitBoard className="h-6 w-6" aria-hidden="true" /></span>
+              <p className="mt-4 text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">PCB · Connected entry</p>
+              <h1 id="pcb-empty-title" className="mt-1 text-2xl font-bold tracking-tight text-slate-950">Create or select a board before placing footprints</h1>
+              <p className="mt-2 text-sm leading-6 text-slate-600">PCB layout is part of the same project as components and schematic connectivity. Start with a real board record, then bring the same component instances and nets into this editor. No dashboard generator is required.</p>
+            </div>
+            <button type="button" onClick={createStarterBoard} className="inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-xl bg-slate-950 px-4 text-sm font-semibold text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2">
+              <Plus className="h-4 w-4" aria-hidden="true" /> Create starter board
+            </button>
+          </div>
+
+          <div className="mt-6 grid gap-3 md:grid-cols-3">
+            <button type="button" onClick={() => setActiveView('board-settings')} className="group rounded-2xl border border-slate-200 bg-slate-50 p-4 text-left hover:border-indigo-200 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <span className="flex items-center justify-between"><span className="flex items-center gap-2 text-sm font-bold text-slate-900"><CircuitBoard className="h-4 w-4 text-indigo-600" /> Board settings</span><ArrowRight className="h-4 w-4 text-slate-400 group-hover:text-indigo-700" /></span>
+              <span className="mt-2 block text-xs leading-5 text-slate-500">Create a custom board, dimensions, layer count, substrate, mounting, connector, thermal, and RF notes.</span>
+            </button>
+            <button type="button" onClick={() => setActiveView('component-library')} className="group rounded-2xl border border-slate-200 bg-slate-50 p-4 text-left hover:border-indigo-200 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <span className="flex items-center justify-between"><span className="flex items-center gap-2 text-sm font-bold text-slate-900"><Boxes className="h-4 w-4 text-indigo-600" /> Component library</span><ArrowRight className="h-4 w-4 text-slate-400 group-hover:text-indigo-700" /></span>
+              <span className="mt-2 block text-xs leading-5 text-slate-500">Choose reviewed definitions and create canonical project component instances before PCB placement.</span>
+            </button>
+            <button type="button" onClick={() => setActiveView('schematic-editor')} className="group rounded-2xl border border-slate-200 bg-slate-50 p-4 text-left hover:border-indigo-200 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <span className="flex items-center justify-between"><span className="flex items-center gap-2 text-sm font-bold text-slate-900"><PenTool className="h-4 w-4 text-indigo-600" /> Schematic</span><ArrowRight className="h-4 w-4 text-slate-400 group-hover:text-indigo-700" /></span>
+              <span className="mt-2 block text-xs leading-5 text-slate-500">Place the same project components, connect pins, and create the nets that PCB layout will consume.</span>
+            </button>
+          </div>
         </div>
-      </div>
+      </section>
     );
   }
 
   return (
-    <div className="flex flex-col h-full bg-slate-950 text-slate-200 overflow-hidden">
-      {/* Toolbar */}
+    <div className="flex h-full flex-col overflow-hidden bg-slate-950 text-slate-200">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-slate-800 bg-slate-900 px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-indigo-300">Active board context</p>
+          <p className="truncate text-xs font-bold text-white">{activeBoard.name} · {activeBoardComponents.length} components · {nets.length} nets · {traces.filter((trace) => trace.boardId === activeBoard.id).length} traces</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={() => setActiveView('component-library')} className="rounded-lg border border-slate-700 bg-slate-800 px-2.5 py-1.5 text-[10px] font-semibold text-slate-200 hover:bg-slate-700">Add component</button>
+          <button type="button" onClick={() => setActiveView('schematic-editor')} className="rounded-lg border border-slate-700 bg-slate-800 px-2.5 py-1.5 text-[10px] font-semibold text-slate-200 hover:bg-slate-700">Open schematic</button>
+          <button type="button" onClick={() => setActiveView('board-settings')} className="rounded-lg border border-slate-700 bg-slate-800 px-2.5 py-1.5 text-[10px] font-semibold text-slate-200 hover:bg-slate-700">Board settings</button>
+        </div>
+      </div>
+
       <BoardToolbar
         viewState={viewState}
         onViewStateChange={updateView}
@@ -140,70 +242,39 @@ export const BoardDesigner: React.FC = () => {
         onOpenFactory={handleOpenFactory}
       />
 
-      {/* Main content area */}
-      <div className="flex-1 flex min-h-0">
-        {/* Left: Layer panel */}
+      <div className="flex min-h-0 flex-1">
         <BoardLayerPanel viewState={viewState} onViewStateChange={updateView} />
-
-        {/* Center: Canvas & bin & status */}
-        <div className="flex-1 flex flex-col min-w-0">
-          <div className="flex-1 min-h-0 relative">
-            <BoardCanvas
-              viewState={viewState}
-              onViewStateChange={updateView}
-              drcResults={drcResults}
-            />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="relative min-h-0 flex-1">
+            <BoardCanvas viewState={viewState} onViewStateChange={updateView} drcResults={drcResults} />
           </div>
-
-          {/* Bottom: Component bin */}
-          <BoardComponentBin
-            viewState={viewState}
-            onViewStateChange={updateView}
-            onAutoPlace={handleAutoPlace}
-          />
-
-          {/* Bottom-most Status Bar */}
+          <BoardComponentBin viewState={viewState} onViewStateChange={updateView} onAutoPlace={handleAutoPlace} />
           <BoardStatusBar viewState={viewState} />
         </div>
 
-        {/* Right panel: tabbed */}
-        <div className="w-56 bg-slate-900 border-l border-slate-800 flex flex-col shrink-0 overflow-hidden">
-          {/* Tabs */}
-          <div className="flex border-b border-slate-800 shrink-0">
+        <div className="flex w-56 shrink-0 flex-col overflow-hidden border-l border-slate-800 bg-slate-900">
+          <div className="flex shrink-0 border-b border-slate-800">
             {([
               { key: 'inspector' as const, label: 'Inspector', Icon: Cpu },
               { key: 'nets' as const, label: 'Nets', Icon: Network },
               { key: 'drc' as const, label: 'DRC', Icon: AlertTriangle },
-            ]).map(tab => (
+            ]).map((tab) => (
               <button
                 key={tab.key}
+                type="button"
                 onClick={() => setRightTab(tab.key)}
-                className={`flex-1 flex items-center justify-center gap-1 py-1.5 text-[9px] font-bold uppercase tracking-wider transition-all ${
-                  rightTab === tab.key
-                    ? 'bg-slate-800 text-indigo-300 border-b-2 border-indigo-500'
-                    : 'text-slate-500 hover:text-slate-400'
-                }`}
+                className={`flex flex-1 items-center justify-center gap-1 py-1.5 text-[9px] font-bold uppercase tracking-wider transition-all ${rightTab === tab.key ? 'border-b-2 border-indigo-500 bg-slate-800 text-indigo-300' : 'text-slate-500 hover:text-slate-400'}`}
               >
-                <tab.Icon className="w-3 h-3" />
+                <tab.Icon className="h-3 w-3" aria-hidden="true" />
                 {tab.label}
-                {tab.key === 'drc' && drcCount > 0 && (
-                  <span className="bg-red-600 text-white text-[7px] rounded-full w-3.5 h-3.5 flex items-center justify-center font-bold">{drcCount > 9 ? '9+' : drcCount}</span>
-                )}
+                {tab.key === 'drc' && drcCount > 0 && <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-600 text-[7px] font-bold text-white">{drcCount > 9 ? '9+' : drcCount}</span>}
               </button>
             ))}
           </div>
-
-          {/* Tab content */}
-          <div className="flex-1 overflow-y-auto min-h-0">
-            {rightTab === 'inspector' && (
-              <BoardInspector viewState={viewState} onViewStateChange={updateView} />
-            )}
-            {rightTab === 'nets' && (
-              <BoardNetPanel viewState={viewState} onViewStateChange={updateView} />
-            )}
-            {rightTab === 'drc' && (
-              <BoardDRCPanel results={drcResults} viewState={viewState} onViewStateChange={updateView} />
-            )}
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {rightTab === 'inspector' && <BoardInspector viewState={viewState} onViewStateChange={updateView} />}
+            {rightTab === 'nets' && <BoardNetPanel viewState={viewState} onViewStateChange={updateView} />}
+            {rightTab === 'drc' && <BoardDRCPanel results={drcResults} viewState={viewState} onViewStateChange={updateView} />}
           </div>
         </div>
       </div>

--- a/src/components/board/BoardDesigner.tsx
+++ b/src/components/board/BoardDesigner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore } from '../../store/studioContextStore';
 import { BoardDesignerUIState, DEFAULT_VIEW_STATE } from './boardInteraction';
@@ -68,16 +68,6 @@ export const BoardDesigner: React.FC = () => {
   });
   const [rightTab, setRightTab] = useState<RightTab>('inspector');
   const [drcResults, setDrcResults] = useState<ReviewResult[]>([]);
-
-  useEffect(() => {
-    const activeBoardId = contextBoardId || store.activeBoardId || boards[0]?.id || null;
-    setViewState((previous) => ({
-      ...previous,
-      activeBoardId,
-      selectedComponentId: contextComponentId ?? previous.selectedComponentId,
-      selectedNetName: contextNetName ?? previous.selectedNetName,
-    }));
-  }, [boards, contextBoardId, contextComponentId, contextNetName, store.activeBoardId]);
 
   const updateView = useCallback((patch: Partial<BoardDesignerUIState>) => {
     setViewState((previous) => ({ ...previous, ...patch }));

--- a/src/components/mechanical/UnifiedBoard3DView.tsx
+++ b/src/components/mechanical/UnifiedBoard3DView.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import {
+  AlertTriangle,
+  Boxes,
+  CircuitBoard,
+  Eye,
+  Focus,
+  Gauge,
+  Layers3,
+} from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+
+export type Board3DQuality = 'low' | 'balanced' | 'high';
+
+const pixelRatioByQuality: Record<Board3DQuality, number> = {
+  low: 1,
+  balanced: 1.3,
+  high: 1.7,
+};
+
+function outlineSize(outline: { points?: { x: number; y: number }[]; width?: number; height?: number } | undefined) {
+  if (outline?.points?.length) {
+    const xs = outline.points.map((point) => point.x);
+    const ys = outline.points.map((point) => point.y);
+    return {
+      width: Math.max(1, Math.max(...xs) - Math.min(...xs)),
+      height: Math.max(1, Math.max(...ys) - Math.min(...ys)),
+      minX: Math.min(...xs),
+      minY: Math.min(...ys),
+      assumed: false,
+    };
+  }
+  if (outline?.width && outline?.height) {
+    return { width: outline.width, height: outline.height, minX: 0, minY: 0, assumed: false };
+  }
+  return { width: 50, height: 30, minX: 0, minY: 0, assumed: true };
+}
+
+function disposeObject(object: THREE.Object3D) {
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return;
+    child.geometry.dispose();
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    materials.forEach((material) => material.dispose());
+  });
+}
+
+export const UnifiedBoard3DView: React.FC = () => {
+  const mountRef = useRef<HTMLDivElement>(null);
+  const store = useProjectStore();
+  const {
+    boards = [],
+    boardOutlines = [],
+    boardComponents = [],
+    mechanicalObjects = [],
+    setActiveView,
+  } = store;
+  const {
+    activeBoardId,
+    activeComponentId,
+    setActiveComponent,
+  } = useStudioContextStore();
+  const [quality, setQuality] = useState<Board3DQuality>('balanced');
+  const [showEnclosure, setShowEnclosure] = useState(true);
+
+  const board = boards.find((candidate) => candidate.id === activeBoardId) || boards[0];
+  const boardId = board?.id || activeBoardId || '';
+  const outline = boardOutlines.find((candidate) => candidate.boardId === boardId);
+  const size = useMemo(() => outlineSize(outline), [outline]);
+  const components = useMemo(
+    () => boardComponents.filter((component) => component.boardId === boardId),
+    [boardComponents, boardId],
+  );
+  const selectedComponent = components.find((component) => component.id === activeComponentId);
+  const placedComponents = components.filter((component) => component.pcb?.placed || component.placementStatus === 'Placed' || component.placementX != null || component.placementY != null);
+  const unresolvedDimensions = components.filter((component) => !component.packageDimensions?.widthMm || !component.packageDimensions?.heightMm || !component.packageDimensions?.heightZMm);
+  const unplaced = components.filter((component) => !placedComponents.includes(component));
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount || !board) return;
+
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        antialias: quality !== 'low',
+        alpha: false,
+        powerPreference: 'low-power',
+        preserveDrawingBuffer: false,
+      });
+    } catch {
+      mount.replaceChildren();
+      const message = document.createElement('div');
+      message.className = 'absolute inset-0 grid place-items-center p-6 text-center text-sm text-slate-300';
+      message.textContent = 'WebGL is unavailable in this browser session. Board and component context is still preserved.';
+      mount.appendChild(message);
+      return;
+    }
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0f172a);
+    const camera = new THREE.PerspectiveCamera(38, 1, 0.1, 2000);
+    const extent = Math.max(size.width, size.height, 20);
+    camera.position.set(extent * 1.05, extent * 0.82, extent * 1.2);
+    camera.lookAt(0, 0, 0);
+
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, pixelRatioByQuality[quality]));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    mount.replaceChildren(renderer.domElement);
+
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x334155, 1.35));
+    const keyLight = new THREE.DirectionalLight(0xffffff, 2.2);
+    keyLight.position.set(extent, extent * 1.5, extent);
+    scene.add(keyLight);
+
+    const group = new THREE.Group();
+    group.rotation.x = -0.08;
+
+    const boardGeometry = new THREE.BoxGeometry(size.width, 1.6, size.height);
+    const boardMaterial = new THREE.MeshStandardMaterial({ color: 0x047857, roughness: 0.48, metalness: 0.04 });
+    const boardMesh = new THREE.Mesh(boardGeometry, boardMaterial);
+    boardMesh.position.set(0, 0, 0);
+    group.add(boardMesh);
+
+    const edgeLines = new THREE.LineSegments(
+      new THREE.EdgesGeometry(boardGeometry),
+      new THREE.LineBasicMaterial({ color: 0x6ee7b7 }),
+    );
+    edgeLines.position.copy(boardMesh.position);
+    group.add(edgeLines);
+
+    placedComponents.forEach((component, index) => {
+      const dimensions = component.packageDimensions;
+      const width = dimensions?.widthMm || 6;
+      const depth = dimensions?.heightMm || 6;
+      const height = dimensions?.heightZMm || 2;
+      const x = (component.pcb?.xMm ?? component.placementX ?? size.minX + 6 + index * 7) - size.minX - size.width / 2;
+      const z = (component.pcb?.yMm ?? component.placementY ?? size.minY + 6 + index * 5) - size.minY - size.height / 2;
+      const selected = component.id === activeComponentId;
+      const material = new THREE.MeshStandardMaterial({
+        color: selected ? 0xf59e0b : dimensions ? 0x1e293b : 0x94a3b8,
+        roughness: 0.4,
+        metalness: selected ? 0.18 : 0.08,
+        emissive: selected ? 0x78350f : 0x000000,
+        emissiveIntensity: selected ? 0.35 : 0,
+      });
+      const mesh = new THREE.Mesh(new THREE.BoxGeometry(width, height, depth), material);
+      mesh.position.set(x, 0.8 + height / 2, z);
+      mesh.userData.componentId = component.id;
+      group.add(mesh);
+
+      if (selected) {
+        const selectedEdges = new THREE.LineSegments(
+          new THREE.EdgesGeometry(mesh.geometry),
+          new THREE.LineBasicMaterial({ color: 0xfde68a }),
+        );
+        selectedEdges.position.copy(mesh.position);
+        group.add(selectedEdges);
+      }
+    });
+
+    if (showEnclosure) {
+      const enclosure = mechanicalObjects.find((object) => object.layer === 'Enclosure' || object.layer === 'Outer Enclosure');
+      if (enclosure?.widthMm && enclosure?.heightMm && enclosure?.depthMm) {
+        const geometry = new THREE.BoxGeometry(enclosure.widthMm, enclosure.depthMm, enclosure.heightMm);
+        const material = new THREE.MeshStandardMaterial({
+          color: 0x64748b,
+          transparent: true,
+          opacity: 0.18,
+          depthWrite: false,
+          side: THREE.DoubleSide,
+        });
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.position.set(0, enclosure.depthMm / 2 - 1, 0);
+        group.add(mesh);
+      }
+    }
+
+    scene.add(group);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = false;
+    controls.enablePan = true;
+    controls.minDistance = Math.max(5, extent * 0.35);
+    controls.maxDistance = extent * 6;
+    controls.target.set(0, 0, 0);
+
+    let visible = true;
+    const render = () => {
+      if (!visible) return;
+      renderer.render(scene, camera);
+    };
+    controls.addEventListener('change', render);
+
+    const resize = () => {
+      const width = Math.max(1, mount.clientWidth);
+      const height = Math.max(1, mount.clientHeight);
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      render();
+    };
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(mount);
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      visible = entries[0]?.isIntersecting ?? true;
+      if (visible) render();
+    });
+    intersectionObserver.observe(mount);
+
+    resize();
+
+    return () => {
+      controls.removeEventListener('change', render);
+      controls.dispose();
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      disposeObject(group);
+      scene.clear();
+      renderer.dispose();
+      renderer.forceContextLoss();
+      if (renderer.domElement.parentElement === mount) mount.removeChild(renderer.domElement);
+    };
+  }, [activeComponentId, board, mechanicalObjects, placedComponents, quality, showEnclosure, size]);
+
+  if (!board) {
+    return (
+      <div className="grid h-full place-items-center bg-slate-950 p-6 text-center text-slate-300">
+        <div><CircuitBoard className="mx-auto h-8 w-8 text-slate-500" /><h2 className="mt-3 text-lg font-bold text-white">No board selected</h2><p className="mt-2 text-sm text-slate-400">Create a board before opening the connected 3D view.</p><button type="button" onClick={() => setActiveView('board-settings')} className="mt-4 rounded-lg bg-indigo-500 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-400">Open board settings</button></div>
+      </div>
+    );
+  }
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-950 text-slate-200" aria-label="Connected lightweight board 3D view">
+      <header className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-slate-800 bg-slate-900 px-3 py-2">
+        <div className="min-w-0"><p className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-indigo-300">Lightweight board-context 3D</p><h1 className="truncate text-sm font-bold text-white">{board.name} · {selectedComponent ? `${selectedComponent.referenceDesignator} selected` : 'board overview'}</h1></div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="inline-flex h-8 items-center gap-2 rounded-lg border border-slate-700 bg-slate-800 px-2.5 text-[10px] font-semibold text-slate-300"><Gauge className="h-3.5 w-3.5" /> Quality<select value={quality} onChange={(event) => setQuality(event.target.value as Board3DQuality)} className="bg-transparent text-white outline-none"><option value="low">Low</option><option value="balanced">Balanced</option><option value="high">High</option></select></label>
+          <button type="button" onClick={() => setShowEnclosure((value) => !value)} aria-pressed={showEnclosure} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-800 px-2.5 text-[10px] font-semibold text-slate-300 hover:bg-slate-700"><Eye className="h-3.5 w-3.5" /> {showEnclosure ? 'Hide enclosure' : 'Show enclosure'}</button>
+          <button type="button" onClick={() => setActiveView('board-designer')} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-indigo-500 px-2.5 text-[10px] font-bold text-white hover:bg-indigo-400"><CircuitBoard className="h-3.5 w-3.5" /> Back to PCB</button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="relative min-w-0 flex-1"><div ref={mountRef} className="absolute inset-0" /></div>
+        <aside className="w-72 shrink-0 overflow-y-auto border-l border-slate-800 bg-slate-900/80 p-3">
+          <div className="flex items-center gap-2"><Layers3 className="h-4 w-4 text-indigo-400" /><h2 className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Preview context</h2></div>
+          <dl className="mt-3 space-y-2 rounded-xl border border-slate-800 bg-slate-950/50 p-3 text-xs"><div><dt className="text-[9px] uppercase text-slate-500">Board</dt><dd className="mt-0.5 font-semibold text-slate-200">{size.width.toFixed(1)} × {size.height.toFixed(1)} mm · {board.layerCount} layers</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Placed components</dt><dd className="mt-0.5 text-slate-300">{placedComponents.length} of {components.length}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Selected object</dt><dd className="mt-0.5 text-slate-300">{selectedComponent ? `${selectedComponent.referenceDesignator} · ${selectedComponent.componentName}` : 'None'}</dd></div></dl>
+
+          <p className="mt-4 text-[9px] font-bold uppercase tracking-wide text-slate-500">Components on this board</p>
+          <div className="mt-2 space-y-1.5">{components.map((component) => <button key={component.id} type="button" onClick={() => setActiveComponent(component.id)} className={`flex w-full items-center gap-2 rounded-lg border p-2 text-left focus:outline-none focus:ring-2 focus:ring-indigo-500 ${component.id === activeComponentId ? 'border-amber-500 bg-amber-950/50' : 'border-slate-800 bg-slate-950/40 hover:border-slate-700'}`}><Boxes className="h-3.5 w-3.5 shrink-0 text-slate-500" /><span className="min-w-0 flex-1"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></span><Focus className="h-3.5 w-3.5 text-slate-500" /></button>)}</div>
+
+          {(size.assumed || unresolvedDimensions.length > 0 || unplaced.length > 0) && <div className="mt-4 rounded-xl border border-amber-700/60 bg-amber-950/50 p-3 text-[10px] leading-5 text-amber-200"><div className="flex gap-2"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" /><div><p className="font-bold text-amber-300">Preview assumptions remain</p>{size.assumed && <p>Board outline is missing; a 50 × 30 mm preview envelope is shown and is not authoritative.</p>}{unresolvedDimensions.length > 0 && <p>{unresolvedDimensions.length} component(s) use provisional 6 × 6 × 2 mm bodies because exact package dimensions are missing.</p>}{unplaced.length > 0 && <p>{unplaced.length} unplaced component(s) are listed but not rendered on the board.</p>}</div></div></div>}
+
+          <div className="mt-4 rounded-xl border border-sky-800 bg-sky-950/40 p-3 text-[10px] leading-5 text-sky-200">This event-driven GL preview is for recognition and assembly context only. It is not exact STEP/B-Rep geometry and cannot authorize clearance, interference, mass, or manufacturing.</div>
+        </aside>
+      </div>
+    </section>
+  );
+};

--- a/src/components/schematic/UnifiedSchematicEditor.tsx
+++ b/src/components/schematic/UnifiedSchematicEditor.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Boxes,
+  CheckCircle2,
+  CircuitBoard,
+  Info,
+  MousePointer,
+  Plus,
+  RotateCw,
+  Route,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { runSchematicERC } from '../../lib/schematicERC';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+import { SchematicCanvas } from './SchematicCanvas';
+import { initialSchematicUIState, type SchematicUIState } from './schematicInteraction';
+
+interface DeleteImpact {
+  componentId: string;
+  title: string;
+  wires: number;
+  nets: string[];
+  traces: number;
+  bomLinked: boolean;
+}
+
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLInputElement
+    || target instanceof HTMLTextAreaElement
+    || target instanceof HTMLSelectElement
+    || (target instanceof HTMLElement && target.isContentEditable);
+}
+
+export const UnifiedSchematicEditor: React.FC = () => {
+  const project = useProjectStore();
+  const {
+    activeView,
+    boardComponents = [],
+    schematicWires = [],
+    padNetAssignments = [],
+    traces = [],
+    boards = [],
+    updateBoardComponent,
+    updateProjectState,
+    placeComponentOnSchematic,
+    unplaceComponentFromSchematic,
+    deleteProjectComponent,
+    setActiveView,
+  } = project;
+  const {
+    activeBoardId,
+    activeComponentId,
+    activeNetName,
+    setActiveComponent,
+    setActiveNet,
+    beginHandoff,
+  } = useStudioContextStore();
+
+  const [viewState, setViewState] = useState<SchematicUIState>({
+    ...initialSchematicUIState,
+    selectedComponentId: activeComponentId,
+    selectedNetName: activeNetName,
+    activeNetName: activeNetName || initialSchematicUIState.activeNetName,
+  });
+  const [deleteImpact, setDeleteImpact] = useState<DeleteImpact | null>(null);
+
+  const boardId = activeBoardId || project.activeBoardId || boards[0]?.id || '';
+  const boardComponentsForContext = useMemo(
+    () => boardComponents.filter((component) => !boardId || component.boardId === boardId),
+    [boardComponents, boardId],
+  );
+  const placedComponents = useMemo(
+    () => boardComponentsForContext.filter((component) => component.schematic?.placed),
+    [boardComponentsForContext],
+  );
+  const unplacedComponents = useMemo(
+    () => boardComponentsForContext.filter((component) => !component.schematic?.placed),
+    [boardComponentsForContext],
+  );
+  const ercResults = useMemo(() => runSchematicERC(project), [project]);
+  const selectedComponent = boardComponents.find((component) => component.id === viewState.selectedComponentId);
+  const selectedWire = schematicWires.find((wire) => wire.id === viewState.selectedWireId);
+
+  const focusComponent = useCallback((componentId: string) => {
+    const component = boardComponents.find((candidate) => candidate.id === componentId);
+    if (!component?.schematic?.placed || component.schematic.x == null || component.schematic.y == null) return;
+    setViewState((previous) => ({
+      ...previous,
+      selectedComponentId: component.id,
+      selectedWireId: null,
+      panX: 300 - component.schematic!.x! * previous.zoom,
+      panY: 250 - component.schematic!.y! * previous.zoom,
+    }));
+    setActiveComponent(component.id);
+  }, [boardComponents, setActiveComponent]);
+
+  const updateView = useCallback((patch: Partial<SchematicUIState>) => {
+    setViewState((previous) => ({ ...previous, ...patch }));
+    if (patch.selectedComponentId !== undefined) setActiveComponent(patch.selectedComponentId);
+    if (patch.selectedNetName !== undefined) setActiveNet(patch.selectedNetName);
+  }, [setActiveComponent, setActiveNet]);
+
+  useEffect(() => {
+    if (!activeComponentId || activeComponentId === viewState.selectedComponentId) return;
+    const component = boardComponents.find((candidate) => candidate.id === activeComponentId);
+    if (!component) return;
+    if (component.schematic?.placed) {
+      focusComponent(component.id);
+    } else {
+      setViewState((previous) => ({ ...previous, selectedComponentId: component.id, selectedWireId: null }));
+    }
+  }, [activeComponentId, boardComponents, focusComponent, viewState.selectedComponentId]);
+
+  useEffect(() => {
+    if (!activeNetName || activeNetName === viewState.selectedNetName) return;
+    setViewState((previous) => ({ ...previous, selectedNetName: activeNetName, activeNetName }));
+  }, [activeNetName, viewState.selectedNetName]);
+
+  const rotateSelected = useCallback(() => {
+    if (!selectedComponent) return;
+    updateBoardComponent(selectedComponent.id, {
+      schematic: {
+        ...selectedComponent.schematic,
+        placed: true,
+        rotation: ((selectedComponent.schematic?.rotation || 0) + 90) % 360,
+      },
+    });
+  }, [selectedComponent, updateBoardComponent]);
+
+  const requestDeleteSelected = useCallback(() => {
+    if (selectedComponent) {
+      const assignedNets = Array.from(new Set(
+        padNetAssignments
+          .filter((assignment) => assignment.componentId === selectedComponent.id)
+          .map((assignment) => assignment.netName),
+      ));
+      const wires = schematicWires.filter((wire) => {
+        const sourceComponent = wire.sourceAnchor?.type === 'pin' ? wire.sourceAnchor.componentId : undefined;
+        const targetComponent = wire.targetAnchor?.type === 'pin' ? wire.targetAnchor.componentId : undefined;
+        return sourceComponent === selectedComponent.id
+          || targetComponent === selectedComponent.id
+          || wire.sourcePinId?.includes(selectedComponent.id)
+          || wire.targetPinId?.includes(selectedComponent.id);
+      }).length;
+      const traceCount = traces.filter((trace) => assignedNets.includes(trace.netName || '')).length;
+      setDeleteImpact({
+        componentId: selectedComponent.id,
+        title: `${selectedComponent.referenceDesignator} · ${selectedComponent.componentName}`,
+        wires,
+        nets: assignedNets,
+        traces: traceCount,
+        bomLinked: Boolean(selectedComponent.bomItemId),
+      });
+      return;
+    }
+
+    if (selectedWire) {
+      updateProjectState({ schematicWires: schematicWires.filter((wire) => wire.id !== selectedWire.id) });
+      updateView({ selectedWireId: null, selectedNetName: null });
+    }
+  }, [padNetAssignments, schematicWires, selectedComponent, selectedWire, traces, updateProjectState, updateView]);
+
+  const confirmDeleteComponent = () => {
+    if (!deleteImpact) return;
+    deleteProjectComponent(deleteImpact.componentId, 'entire-product');
+    setDeleteImpact(null);
+    updateView({ selectedComponentId: null, selectedWireId: null, selectedNetName: null });
+  };
+
+  const placeComponent = useCallback((componentId: string) => {
+    const placedCount = placedComponents.length;
+    const column = placedCount % 4;
+    const row = Math.floor(placedCount / 4);
+    placeComponentOnSchematic(componentId, 140 + column * 180, 140 + row * 140);
+    setActiveComponent(componentId);
+    setViewState((previous) => ({ ...previous, selectedComponentId: componentId, selectedWireId: null }));
+  }, [placeComponentOnSchematic, placedComponents.length, setActiveComponent]);
+
+  const unplaceComponent = useCallback((componentId: string) => {
+    unplaceComponentFromSchematic(componentId);
+    if (viewState.selectedComponentId === componentId) updateView({ selectedComponentId: null });
+  }, [unplaceComponentFromSchematic, updateView, viewState.selectedComponentId]);
+
+  const openPcb = () => {
+    beginHandoff(activeView, activeView);
+    setActiveView(boards.length > 0 ? 'board-designer' : 'board-settings');
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isTextEntryTarget(event.target)) return;
+      if (event.key === 'r' || event.key === 'R') rotateSelected();
+      if (event.key === 'Delete' || event.key === 'Backspace') requestDeleteSelected();
+      if (event.key === 'Escape') {
+        updateView({ isDrawingWire: false, wirePoints: [], sourcePin: null });
+      }
+      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key) || !selectedComponent || selectedComponent.schematic?.locked) return;
+      event.preventDefault();
+      const amount = event.shiftKey ? 50 : 10;
+      const dx = event.key === 'ArrowLeft' ? -amount : event.key === 'ArrowRight' ? amount : 0;
+      const dy = event.key === 'ArrowUp' ? -amount : event.key === 'ArrowDown' ? amount : 0;
+      updateBoardComponent(selectedComponent.id, {
+        schematic: {
+          ...selectedComponent.schematic,
+          placed: true,
+          x: (selectedComponent.schematic?.x || 150) + dx,
+          y: (selectedComponent.schematic?.y || 150) + dy,
+        },
+      });
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [requestDeleteSelected, rotateSelected, selectedComponent, updateBoardComponent, updateView]);
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-950 text-slate-200" aria-label="Unified schematic editor">
+      <header className="flex min-h-11 shrink-0 flex-wrap items-center justify-between gap-2 border-b border-slate-800 bg-slate-900 px-3 py-2">
+        <div className="flex items-center gap-1">
+          <button type="button" onClick={() => updateView({ activeTool: 'select' })} aria-pressed={viewState.activeTool === 'select'} className={`grid h-8 w-8 place-items-center rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 ${viewState.activeTool === 'select' ? 'bg-emerald-400 text-slate-950' : 'text-slate-400 hover:bg-slate-800'}`} title="Select tool"><MousePointer className="h-4 w-4" /></button>
+          <button type="button" onClick={() => updateView({ activeTool: 'wire' })} aria-pressed={viewState.activeTool === 'wire'} className={`grid h-8 w-8 place-items-center rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-400 ${viewState.activeTool === 'wire' ? 'bg-emerald-400 text-slate-950' : 'text-slate-400 hover:bg-slate-800'}`} title="Wire tool"><Route className="h-4 w-4" /></button>
+          <button type="button" onClick={rotateSelected} disabled={!selectedComponent} className="grid h-8 w-8 place-items-center rounded-lg text-slate-400 hover:bg-slate-800 disabled:opacity-30" title="Rotate selected"><RotateCw className="h-4 w-4" /></button>
+          <button type="button" onClick={requestDeleteSelected} disabled={!selectedComponent && !selectedWire} className="grid h-8 w-8 place-items-center rounded-lg text-red-400 hover:bg-slate-800 disabled:opacity-30" title="Delete selected"><Trash2 className="h-4 w-4" /></button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-[10px] font-semibold">
+          <span className={`rounded-full border px-2 py-1 ${ercResults.length > 0 ? 'border-red-800 bg-red-950 text-red-300' : 'border-emerald-800 bg-emerald-950 text-emerald-300'}`}>{ercResults.length} ERC findings</span>
+          <button type="button" onClick={() => setActiveView('component-library')} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-800 px-2.5 text-slate-200 hover:bg-slate-700"><Boxes className="h-3.5 w-3.5" /> Add component</button>
+          <button type="button" onClick={openPcb} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-indigo-500 px-2.5 font-bold text-white hover:bg-indigo-400"><CircuitBoard className="h-3.5 w-3.5" /> {boards.length > 0 ? 'Open PCB' : 'Create board'} <ArrowRight className="h-3.5 w-3.5" /></button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <aside className="flex w-60 shrink-0 flex-col overflow-hidden border-r border-slate-800 bg-slate-900/70">
+          <div className="border-b border-slate-800 p-3">
+            <p className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Canonical project components</p>
+            <p className="mt-1 text-[10px] leading-4 text-slate-400">Definitions are created in Component Library. This editor only places and connects the same project instances.</p>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+            <div className="mb-2 flex items-center justify-between"><span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Unplaced</span><span className="font-mono text-[9px] text-slate-500">{unplacedComponents.length}</span></div>
+            <div className="space-y-1.5">
+              {unplacedComponents.map((component) => (
+                <button key={component.id} type="button" onClick={() => placeComponent(component.id)} className="flex w-full items-center justify-between rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-left hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                  <span className="min-w-0"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></span>
+                  <span className="rounded bg-indigo-950 px-1.5 py-0.5 text-[8px] font-bold uppercase text-indigo-300">Place</span>
+                </button>
+              ))}
+              {unplacedComponents.length === 0 && <p className="rounded-lg border border-dashed border-slate-800 p-3 text-center text-[9px] text-slate-600">No unplaced instances</p>}
+            </div>
+
+            <div className="mb-2 mt-4 flex items-center justify-between"><span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Placed</span><span className="font-mono text-[9px] text-slate-500">{placedComponents.length}</span></div>
+            <div className="space-y-1.5">
+              {placedComponents.map((component) => {
+                const active = component.id === viewState.selectedComponentId;
+                return (
+                  <div key={component.id} className={`flex items-center gap-1 rounded-lg border p-1.5 ${active ? 'border-emerald-500 bg-slate-800' : 'border-slate-800 bg-slate-950/40'}`}>
+                    <button type="button" onClick={() => focusComponent(component.id)} className="min-w-0 flex-1 text-left focus:outline-none"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></button>
+                    <button type="button" onClick={() => unplaceComponent(component.id)} className="rounded px-1.5 py-1 text-[8px] font-bold text-red-400 hover:bg-slate-800">Unplace</button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <button type="button" onClick={() => setActiveView('component-library')} className="m-2 inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-slate-700 bg-slate-800 text-xs font-semibold text-slate-200 hover:bg-slate-700"><Plus className="h-4 w-4" /> Choose another component</button>
+        </aside>
+
+        <SchematicCanvas viewState={viewState} onViewStateChange={updateView} ercResults={ercResults} />
+
+        <aside className="flex w-72 shrink-0 flex-col overflow-hidden border-l border-slate-800 bg-slate-900/70">
+          <section className="min-h-0 flex-1 overflow-y-auto border-b border-slate-800 p-3">
+            <div className="mb-3 flex items-center gap-2"><Info className="h-4 w-4 text-indigo-400" /><h2 className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Shared object inspector</h2></div>
+            {selectedComponent ? (
+              <div className="space-y-3 text-xs">
+                <div><label className="text-[9px] font-bold uppercase text-slate-500" htmlFor="schematic-reference">Reference</label><input id="schematic-reference" value={selectedComponent.referenceDesignator} onChange={(event) => updateBoardComponent(selectedComponent.id, { referenceDesignator: event.target.value })} className="mt-1 h-8 w-full rounded-lg border border-slate-700 bg-slate-950 px-2 font-mono text-xs text-slate-200 outline-none focus:border-indigo-500" /></div>
+                <div><label className="text-[9px] font-bold uppercase text-slate-500" htmlFor="schematic-value">Value</label><input id="schematic-value" value={selectedComponent.value || ''} onChange={(event) => updateBoardComponent(selectedComponent.id, { value: event.target.value })} className="mt-1 h-8 w-full rounded-lg border border-slate-700 bg-slate-950 px-2 font-mono text-xs text-slate-200 outline-none focus:border-indigo-500" /></div>
+                <dl className="space-y-2 rounded-xl border border-slate-800 bg-slate-950/40 p-3"><div><dt className="text-[9px] uppercase text-slate-500">Component</dt><dd className="mt-0.5 font-semibold text-slate-200">{selectedComponent.componentName}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Footprint</dt><dd className="mt-0.5 font-mono text-slate-300">{selectedComponent.footprint || 'Unresolved'}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Board</dt><dd className="mt-0.5 text-slate-300">{boards.find((board) => board.id === selectedComponent.boardId)?.name || selectedComponent.boardId}</dd></div></dl>
+                <div><p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Symbol terminals</p><div className="mt-2 max-h-48 space-y-1 overflow-y-auto rounded-xl border border-slate-800 bg-slate-950/40 p-2">{(selectedComponent.pins || []).map((pin) => <div key={pin.pinNumber} className="flex justify-between gap-2 font-mono text-[9px]"><span className="text-slate-400">{pin.pinNumber}. {pin.pinName}</span><span className={pin.netName ? 'text-emerald-400' : 'text-amber-400'}>{pin.netName || 'Unconnected'}</span></div>)}</div></div>
+              </div>
+            ) : selectedWire ? (
+              <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-xs"><p className="text-[9px] font-bold uppercase text-slate-500">Selected net</p><p className="mt-1 font-mono font-bold text-sky-300">{selectedWire.netName}</p><p className="mt-2 text-slate-500">{selectedWire.points.length} wire points</p></div>
+            ) : (
+              <p className="rounded-xl border border-dashed border-slate-800 p-4 text-center text-[10px] leading-5 text-slate-500">Select a component or wire. The shared context above remains the same when you move to PCB or 3D.</p>
+            )}
+          </section>
+
+          <section className="h-60 shrink-0 overflow-hidden bg-slate-950/60">
+            <div className="flex items-center justify-between border-b border-slate-800 px-3 py-2"><span className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-wide text-slate-500"><AlertTriangle className="h-3.5 w-3.5 text-amber-400" /> ERC findings</span><span className={`rounded px-1.5 py-0.5 text-[8px] font-bold ${ercResults.length > 0 ? 'bg-red-950 text-red-300' : 'bg-emerald-950 text-emerald-300'}`}>{ercResults.length || 'Pass'}</span></div>
+            <div className="h-[calc(100%-36px)] space-y-1 overflow-y-auto p-2">
+              {ercResults.map((result) => (
+                <button key={result.id} type="button" onClick={() => { if (result.linkedObjectType === 'component') focusComponent(result.linkedObjectId); }} className="w-full rounded-lg border border-slate-800 bg-slate-900/70 p-2 text-left hover:border-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="block text-[10px] font-bold text-slate-300">{result.title}</span><span className="mt-1 block text-[9px] leading-4 text-slate-500">{result.description}</span></button>
+              ))}
+              {ercResults.length === 0 && <div className="flex h-full flex-col items-center justify-center text-center text-[10px] text-slate-600"><CheckCircle2 className="mb-2 h-6 w-6 text-emerald-700" />No electrical violations detected</div>}
+            </div>
+          </section>
+        </aside>
+      </div>
+
+      <Dialog.Root open={Boolean(deleteImpact)} onOpenChange={(open) => { if (!open) setDeleteImpact(null); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-[150] bg-slate-950/65 backdrop-blur-sm" />
+          <Dialog.Content aria-describedby="schematic-delete-description" className="fixed left-1/2 top-1/2 z-[160] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-red-200 bg-white p-5 text-slate-900 shadow-2xl outline-none">
+            <div className="flex items-start justify-between gap-3"><div className="flex items-start gap-3"><span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-red-50 text-red-700"><Trash2 className="h-5 w-5" /></span><div><Dialog.Title className="text-base font-bold">Remove component from the whole product?</Dialog.Title><Dialog.Description id="schematic-delete-description" className="mt-1 text-sm leading-6 text-slate-600">This is not a schematic-only delete. Review the connected project data before continuing.</Dialog.Description></div></div><Dialog.Close asChild><button type="button" aria-label="Close deletion review" className="grid h-8 w-8 place-items-center rounded-lg text-slate-500 hover:bg-slate-100"><X className="h-4 w-4" /></button></Dialog.Close></div>
+            {deleteImpact && <div className="mt-4 rounded-xl border border-red-200 bg-red-50 p-4"><p className="text-sm font-bold text-red-950">{deleteImpact.title}</p><dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-red-900"><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">Schematic wires</dt><dd>{deleteImpact.wires}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">PCB traces</dt><dd>{deleteImpact.traces}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">Assigned nets</dt><dd>{deleteImpact.nets.join(', ') || 'None'}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">BOM link</dt><dd>{deleteImpact.bomLinked ? 'Present' : 'Not recorded'}</dd></div></dl></div>}
+            <div className="mt-5 flex justify-end gap-2"><Dialog.Close asChild><button type="button" className="h-9 rounded-lg border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-slate-100">Cancel</button></Dialog.Close><button type="button" onClick={confirmDeleteComponent} className="h-9 rounded-lg bg-red-700 px-3 text-sm font-semibold text-white hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">Remove from product</button></div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </section>
+  );
+};

--- a/src/components/schematic/UnifiedSchematicEditor.tsx
+++ b/src/components/schematic/UnifiedSchematicEditor.tsx
@@ -72,34 +72,21 @@ export const UnifiedSchematicEditor: React.FC = () => {
   const [deleteImpact, setDeleteImpact] = useState<DeleteImpact | null>(null);
 
   const boardId = activeBoardId || project.activeBoardId || boards[0]?.id || '';
-  const boardComponentsForContext = useMemo(
+  const contextualComponents = useMemo(
     () => boardComponents.filter((component) => !boardId || component.boardId === boardId),
     [boardComponents, boardId],
   );
   const placedComponents = useMemo(
-    () => boardComponentsForContext.filter((component) => component.schematic?.placed),
-    [boardComponentsForContext],
+    () => contextualComponents.filter((component) => component.schematic?.placed),
+    [contextualComponents],
   );
   const unplacedComponents = useMemo(
-    () => boardComponentsForContext.filter((component) => !component.schematic?.placed),
-    [boardComponentsForContext],
+    () => contextualComponents.filter((component) => !component.schematic?.placed),
+    [contextualComponents],
   );
   const ercResults = useMemo(() => runSchematicERC(project), [project]);
   const selectedComponent = boardComponents.find((component) => component.id === viewState.selectedComponentId);
   const selectedWire = schematicWires.find((wire) => wire.id === viewState.selectedWireId);
-
-  const focusComponent = useCallback((componentId: string) => {
-    const component = boardComponents.find((candidate) => candidate.id === componentId);
-    if (!component?.schematic?.placed || component.schematic.x == null || component.schematic.y == null) return;
-    setViewState((previous) => ({
-      ...previous,
-      selectedComponentId: component.id,
-      selectedWireId: null,
-      panX: 300 - component.schematic!.x! * previous.zoom,
-      panY: 250 - component.schematic!.y! * previous.zoom,
-    }));
-    setActiveComponent(component.id);
-  }, [boardComponents, setActiveComponent]);
 
   const updateView = useCallback((patch: Partial<SchematicUIState>) => {
     setViewState((previous) => ({ ...previous, ...patch }));
@@ -107,21 +94,22 @@ export const UnifiedSchematicEditor: React.FC = () => {
     if (patch.selectedNetName !== undefined) setActiveNet(patch.selectedNetName);
   }, [setActiveComponent, setActiveNet]);
 
-  useEffect(() => {
-    if (!activeComponentId || activeComponentId === viewState.selectedComponentId) return;
-    const component = boardComponents.find((candidate) => candidate.id === activeComponentId);
+  const focusComponent = useCallback((componentId: string) => {
+    const component = boardComponents.find((candidate) => candidate.id === componentId);
     if (!component) return;
-    if (component.schematic?.placed) {
-      focusComponent(component.id);
-    } else {
+    setActiveComponent(component.id);
+    if (!component.schematic?.placed || component.schematic.x == null || component.schematic.y == null) {
       setViewState((previous) => ({ ...previous, selectedComponentId: component.id, selectedWireId: null }));
+      return;
     }
-  }, [activeComponentId, boardComponents, focusComponent, viewState.selectedComponentId]);
-
-  useEffect(() => {
-    if (!activeNetName || activeNetName === viewState.selectedNetName) return;
-    setViewState((previous) => ({ ...previous, selectedNetName: activeNetName, activeNetName }));
-  }, [activeNetName, viewState.selectedNetName]);
+    setViewState((previous) => ({
+      ...previous,
+      selectedComponentId: component.id,
+      selectedWireId: null,
+      panX: 300 - component.schematic!.x! * previous.zoom,
+      panY: 250 - component.schematic!.y! * previous.zoom,
+    }));
+  }, [boardComponents, setActiveComponent]);
 
   const rotateSelected = useCallback(() => {
     if (!selectedComponent) return;
@@ -141,7 +129,7 @@ export const UnifiedSchematicEditor: React.FC = () => {
           .filter((assignment) => assignment.componentId === selectedComponent.id)
           .map((assignment) => assignment.netName),
       ));
-      const wires = schematicWires.filter((wire) => {
+      const wireCount = schematicWires.filter((wire) => {
         const sourceComponent = wire.sourceAnchor?.type === 'pin' ? wire.sourceAnchor.componentId : undefined;
         const targetComponent = wire.targetAnchor?.type === 'pin' ? wire.targetAnchor.componentId : undefined;
         return sourceComponent === selectedComponent.id
@@ -149,22 +137,19 @@ export const UnifiedSchematicEditor: React.FC = () => {
           || wire.sourcePinId?.includes(selectedComponent.id)
           || wire.targetPinId?.includes(selectedComponent.id);
       }).length;
-      const traceCount = traces.filter((trace) => assignedNets.includes(trace.netName || '')).length;
       setDeleteImpact({
         componentId: selectedComponent.id,
         title: `${selectedComponent.referenceDesignator} · ${selectedComponent.componentName}`,
-        wires,
+        wires: wireCount,
         nets: assignedNets,
-        traces: traceCount,
+        traces: traces.filter((trace) => assignedNets.includes(trace.netName || '')).length,
         bomLinked: Boolean(selectedComponent.bomItemId),
       });
       return;
     }
-
-    if (selectedWire) {
-      updateProjectState({ schematicWires: schematicWires.filter((wire) => wire.id !== selectedWire.id) });
-      updateView({ selectedWireId: null, selectedNetName: null });
-    }
+    if (!selectedWire) return;
+    updateProjectState({ schematicWires: schematicWires.filter((wire) => wire.id !== selectedWire.id) });
+    updateView({ selectedWireId: null, selectedNetName: null });
   }, [padNetAssignments, schematicWires, selectedComponent, selectedWire, traces, updateProjectState, updateView]);
 
   const confirmDeleteComponent = () => {
@@ -175,13 +160,11 @@ export const UnifiedSchematicEditor: React.FC = () => {
   };
 
   const placeComponent = useCallback((componentId: string) => {
-    const placedCount = placedComponents.length;
-    const column = placedCount % 4;
-    const row = Math.floor(placedCount / 4);
+    const column = placedComponents.length % 4;
+    const row = Math.floor(placedComponents.length / 4);
     placeComponentOnSchematic(componentId, 140 + column * 180, 140 + row * 140);
-    setActiveComponent(componentId);
-    setViewState((previous) => ({ ...previous, selectedComponentId: componentId, selectedWireId: null }));
-  }, [placeComponentOnSchematic, placedComponents.length, setActiveComponent]);
+    focusComponent(componentId);
+  }, [focusComponent, placeComponentOnSchematic, placedComponents.length]);
 
   const unplaceComponent = useCallback((componentId: string) => {
     unplaceComponentFromSchematic(componentId);
@@ -198,9 +181,7 @@ export const UnifiedSchematicEditor: React.FC = () => {
       if (isTextEntryTarget(event.target)) return;
       if (event.key === 'r' || event.key === 'R') rotateSelected();
       if (event.key === 'Delete' || event.key === 'Backspace') requestDeleteSelected();
-      if (event.key === 'Escape') {
-        updateView({ isDrawingWire: false, wirePoints: [], sourcePin: null });
-      }
+      if (event.key === 'Escape') updateView({ isDrawingWire: false, wirePoints: [], sourcePin: null });
       if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key) || !selectedComponent || selectedComponent.schematic?.locked) return;
       event.preventDefault();
       const amount = event.shiftKey ? 50 : 10;
@@ -228,7 +209,6 @@ export const UnifiedSchematicEditor: React.FC = () => {
           <button type="button" onClick={rotateSelected} disabled={!selectedComponent} className="grid h-8 w-8 place-items-center rounded-lg text-slate-400 hover:bg-slate-800 disabled:opacity-30" title="Rotate selected"><RotateCw className="h-4 w-4" /></button>
           <button type="button" onClick={requestDeleteSelected} disabled={!selectedComponent && !selectedWire} className="grid h-8 w-8 place-items-center rounded-lg text-red-400 hover:bg-slate-800 disabled:opacity-30" title="Delete selected"><Trash2 className="h-4 w-4" /></button>
         </div>
-
         <div className="flex flex-wrap items-center gap-2 text-[10px] font-semibold">
           <span className={`rounded-full border px-2 py-1 ${ercResults.length > 0 ? 'border-red-800 bg-red-950 text-red-300' : 'border-emerald-800 bg-emerald-950 text-emerald-300'}`}>{ercResults.length} ERC findings</span>
           <button type="button" onClick={() => setActiveView('component-library')} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-800 px-2.5 text-slate-200 hover:bg-slate-700"><Boxes className="h-3.5 w-3.5" /> Add component</button>
@@ -238,37 +218,13 @@ export const UnifiedSchematicEditor: React.FC = () => {
 
       <div className="flex min-h-0 flex-1">
         <aside className="flex w-60 shrink-0 flex-col overflow-hidden border-r border-slate-800 bg-slate-900/70">
-          <div className="border-b border-slate-800 p-3">
-            <p className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Canonical project components</p>
-            <p className="mt-1 text-[10px] leading-4 text-slate-400">Definitions are created in Component Library. This editor only places and connects the same project instances.</p>
-          </div>
-
+          <div className="border-b border-slate-800 p-3"><p className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Canonical project components</p><p className="mt-1 text-[10px] leading-4 text-slate-400">Definitions are created in Component Library. This editor places and connects the same project instances.</p></div>
           <div className="min-h-0 flex-1 overflow-y-auto p-2">
             <div className="mb-2 flex items-center justify-between"><span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Unplaced</span><span className="font-mono text-[9px] text-slate-500">{unplacedComponents.length}</span></div>
-            <div className="space-y-1.5">
-              {unplacedComponents.map((component) => (
-                <button key={component.id} type="button" onClick={() => placeComponent(component.id)} className="flex w-full items-center justify-between rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-left hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                  <span className="min-w-0"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></span>
-                  <span className="rounded bg-indigo-950 px-1.5 py-0.5 text-[8px] font-bold uppercase text-indigo-300">Place</span>
-                </button>
-              ))}
-              {unplacedComponents.length === 0 && <p className="rounded-lg border border-dashed border-slate-800 p-3 text-center text-[9px] text-slate-600">No unplaced instances</p>}
-            </div>
-
+            <div className="space-y-1.5">{unplacedComponents.map((component) => <button key={component.id} type="button" onClick={() => placeComponent(component.id)} className="flex w-full items-center justify-between rounded-lg border border-slate-800 bg-slate-950/60 p-2 text-left hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="min-w-0"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></span><span className="rounded bg-indigo-950 px-1.5 py-0.5 text-[8px] font-bold uppercase text-indigo-300">Place</span></button>)}{unplacedComponents.length === 0 && <p className="rounded-lg border border-dashed border-slate-800 p-3 text-center text-[9px] text-slate-600">No unplaced instances</p>}</div>
             <div className="mb-2 mt-4 flex items-center justify-between"><span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Placed</span><span className="font-mono text-[9px] text-slate-500">{placedComponents.length}</span></div>
-            <div className="space-y-1.5">
-              {placedComponents.map((component) => {
-                const active = component.id === viewState.selectedComponentId;
-                return (
-                  <div key={component.id} className={`flex items-center gap-1 rounded-lg border p-1.5 ${active ? 'border-emerald-500 bg-slate-800' : 'border-slate-800 bg-slate-950/40'}`}>
-                    <button type="button" onClick={() => focusComponent(component.id)} className="min-w-0 flex-1 text-left focus:outline-none"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></button>
-                    <button type="button" onClick={() => unplaceComponent(component.id)} className="rounded px-1.5 py-1 text-[8px] font-bold text-red-400 hover:bg-slate-800">Unplace</button>
-                  </div>
-                );
-              })}
-            </div>
+            <div className="space-y-1.5">{placedComponents.map((component) => <div key={component.id} className={`flex items-center gap-1 rounded-lg border p-1.5 ${component.id === viewState.selectedComponentId ? 'border-emerald-500 bg-slate-800' : 'border-slate-800 bg-slate-950/40'}`}><button type="button" onClick={() => focusComponent(component.id)} className="min-w-0 flex-1 text-left focus:outline-none"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></button><button type="button" onClick={() => unplaceComponent(component.id)} className="rounded px-1.5 py-1 text-[8px] font-bold text-red-400 hover:bg-slate-800">Unplace</button></div>)}</div>
           </div>
-
           <button type="button" onClick={() => setActiveView('component-library')} className="m-2 inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-slate-700 bg-slate-800 text-xs font-semibold text-slate-200 hover:bg-slate-700"><Plus className="h-4 w-4" /> Choose another component</button>
         </aside>
 
@@ -277,41 +233,14 @@ export const UnifiedSchematicEditor: React.FC = () => {
         <aside className="flex w-72 shrink-0 flex-col overflow-hidden border-l border-slate-800 bg-slate-900/70">
           <section className="min-h-0 flex-1 overflow-y-auto border-b border-slate-800 p-3">
             <div className="mb-3 flex items-center gap-2"><Info className="h-4 w-4 text-indigo-400" /><h2 className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Shared object inspector</h2></div>
-            {selectedComponent ? (
-              <div className="space-y-3 text-xs">
-                <div><label className="text-[9px] font-bold uppercase text-slate-500" htmlFor="schematic-reference">Reference</label><input id="schematic-reference" value={selectedComponent.referenceDesignator} onChange={(event) => updateBoardComponent(selectedComponent.id, { referenceDesignator: event.target.value })} className="mt-1 h-8 w-full rounded-lg border border-slate-700 bg-slate-950 px-2 font-mono text-xs text-slate-200 outline-none focus:border-indigo-500" /></div>
-                <div><label className="text-[9px] font-bold uppercase text-slate-500" htmlFor="schematic-value">Value</label><input id="schematic-value" value={selectedComponent.value || ''} onChange={(event) => updateBoardComponent(selectedComponent.id, { value: event.target.value })} className="mt-1 h-8 w-full rounded-lg border border-slate-700 bg-slate-950 px-2 font-mono text-xs text-slate-200 outline-none focus:border-indigo-500" /></div>
-                <dl className="space-y-2 rounded-xl border border-slate-800 bg-slate-950/40 p-3"><div><dt className="text-[9px] uppercase text-slate-500">Component</dt><dd className="mt-0.5 font-semibold text-slate-200">{selectedComponent.componentName}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Footprint</dt><dd className="mt-0.5 font-mono text-slate-300">{selectedComponent.footprint || 'Unresolved'}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Board</dt><dd className="mt-0.5 text-slate-300">{boards.find((board) => board.id === selectedComponent.boardId)?.name || selectedComponent.boardId}</dd></div></dl>
-                <div><p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Symbol terminals</p><div className="mt-2 max-h-48 space-y-1 overflow-y-auto rounded-xl border border-slate-800 bg-slate-950/40 p-2">{(selectedComponent.pins || []).map((pin) => <div key={pin.pinNumber} className="flex justify-between gap-2 font-mono text-[9px]"><span className="text-slate-400">{pin.pinNumber}. {pin.pinName}</span><span className={pin.netName ? 'text-emerald-400' : 'text-amber-400'}>{pin.netName || 'Unconnected'}</span></div>)}</div></div>
-              </div>
-            ) : selectedWire ? (
-              <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-xs"><p className="text-[9px] font-bold uppercase text-slate-500">Selected net</p><p className="mt-1 font-mono font-bold text-sky-300">{selectedWire.netName}</p><p className="mt-2 text-slate-500">{selectedWire.points.length} wire points</p></div>
-            ) : (
-              <p className="rounded-xl border border-dashed border-slate-800 p-4 text-center text-[10px] leading-5 text-slate-500">Select a component or wire. The shared context above remains the same when you move to PCB or 3D.</p>
-            )}
+            {selectedComponent ? <div className="space-y-3 text-xs"><div><label className="text-[9px] font-bold uppercase text-slate-500" htmlFor="schematic-reference">Reference</label><input id="schematic-reference" value={selectedComponent.referenceDesignator} onChange={(event) => updateBoardComponent(selectedComponent.id, { referenceDesignator: event.target.value })} className="mt-1 h-8 w-full rounded-lg border border-slate-700 bg-slate-950 px-2 font-mono text-xs text-slate-200 outline-none focus:border-indigo-500" /></div><div><label className="text-[9px] font-bold uppercase text-slate-500" htmlFor="schematic-value">Value</label><input id="schematic-value" value={selectedComponent.value || ''} onChange={(event) => updateBoardComponent(selectedComponent.id, { value: event.target.value })} className="mt-1 h-8 w-full rounded-lg border border-slate-700 bg-slate-950 px-2 font-mono text-xs text-slate-200 outline-none focus:border-indigo-500" /></div><dl className="space-y-2 rounded-xl border border-slate-800 bg-slate-950/40 p-3"><div><dt className="text-[9px] uppercase text-slate-500">Component</dt><dd className="mt-0.5 font-semibold text-slate-200">{selectedComponent.componentName}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Footprint</dt><dd className="mt-0.5 font-mono text-slate-300">{selectedComponent.footprint || 'Unresolved'}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Board</dt><dd className="mt-0.5 text-slate-300">{boards.find((board) => board.id === selectedComponent.boardId)?.name || selectedComponent.boardId}</dd></div></dl><div><p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Symbol terminals</p><div className="mt-2 max-h-48 space-y-1 overflow-y-auto rounded-xl border border-slate-800 bg-slate-950/40 p-2">{(selectedComponent.pins || []).map((pin) => <div key={pin.pinNumber} className="flex justify-between gap-2 font-mono text-[9px]"><span className="text-slate-400">{pin.pinNumber}. {pin.pinName}</span><span className={pin.netName ? 'text-emerald-400' : 'text-amber-400'}>{pin.netName || 'Unconnected'}</span></div>)}</div></div></div> : selectedWire ? <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-xs"><p className="text-[9px] font-bold uppercase text-slate-500">Selected net</p><p className="mt-1 font-mono font-bold text-sky-300">{selectedWire.netName}</p><p className="mt-2 text-slate-500">{selectedWire.points.length} wire points</p></div> : <p className="rounded-xl border border-dashed border-slate-800 p-4 text-center text-[10px] leading-5 text-slate-500">Select a component or wire. Shared context remains intact when moving to PCB or 3D.</p>}
           </section>
-
-          <section className="h-60 shrink-0 overflow-hidden bg-slate-950/60">
-            <div className="flex items-center justify-between border-b border-slate-800 px-3 py-2"><span className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-wide text-slate-500"><AlertTriangle className="h-3.5 w-3.5 text-amber-400" /> ERC findings</span><span className={`rounded px-1.5 py-0.5 text-[8px] font-bold ${ercResults.length > 0 ? 'bg-red-950 text-red-300' : 'bg-emerald-950 text-emerald-300'}`}>{ercResults.length || 'Pass'}</span></div>
-            <div className="h-[calc(100%-36px)] space-y-1 overflow-y-auto p-2">
-              {ercResults.map((result) => (
-                <button key={result.id} type="button" onClick={() => { if (result.linkedObjectType === 'component') focusComponent(result.linkedObjectId); }} className="w-full rounded-lg border border-slate-800 bg-slate-900/70 p-2 text-left hover:border-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="block text-[10px] font-bold text-slate-300">{result.title}</span><span className="mt-1 block text-[9px] leading-4 text-slate-500">{result.description}</span></button>
-              ))}
-              {ercResults.length === 0 && <div className="flex h-full flex-col items-center justify-center text-center text-[10px] text-slate-600"><CheckCircle2 className="mb-2 h-6 w-6 text-emerald-700" />No electrical violations detected</div>}
-            </div>
-          </section>
+          <section className="h-60 shrink-0 overflow-hidden bg-slate-950/60"><div className="flex items-center justify-between border-b border-slate-800 px-3 py-2"><span className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-wide text-slate-500"><AlertTriangle className="h-3.5 w-3.5 text-amber-400" /> ERC findings</span><span className={`rounded px-1.5 py-0.5 text-[8px] font-bold ${ercResults.length > 0 ? 'bg-red-950 text-red-300' : 'bg-emerald-950 text-emerald-300'}`}>{ercResults.length || 'Pass'}</span></div><div className="h-[calc(100%-36px)] space-y-1 overflow-y-auto p-2">{ercResults.map((result) => <button key={result.id} type="button" onClick={() => { if (result.linkedObjectType === 'component') focusComponent(result.linkedObjectId); }} className="w-full rounded-lg border border-slate-800 bg-slate-900/70 p-2 text-left hover:border-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"><span className="block text-[10px] font-bold text-slate-300">{result.title}</span><span className="mt-1 block text-[9px] leading-4 text-slate-500">{result.description}</span></button>)}{ercResults.length === 0 && <div className="flex h-full flex-col items-center justify-center text-center text-[10px] text-slate-600"><CheckCircle2 className="mb-2 h-6 w-6 text-emerald-700" />No electrical violations detected</div>}</div></section>
         </aside>
       </div>
 
       <Dialog.Root open={Boolean(deleteImpact)} onOpenChange={(open) => { if (!open) setDeleteImpact(null); }}>
-        <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 z-[150] bg-slate-950/65 backdrop-blur-sm" />
-          <Dialog.Content aria-describedby="schematic-delete-description" className="fixed left-1/2 top-1/2 z-[160] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-red-200 bg-white p-5 text-slate-900 shadow-2xl outline-none">
-            <div className="flex items-start justify-between gap-3"><div className="flex items-start gap-3"><span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-red-50 text-red-700"><Trash2 className="h-5 w-5" /></span><div><Dialog.Title className="text-base font-bold">Remove component from the whole product?</Dialog.Title><Dialog.Description id="schematic-delete-description" className="mt-1 text-sm leading-6 text-slate-600">This is not a schematic-only delete. Review the connected project data before continuing.</Dialog.Description></div></div><Dialog.Close asChild><button type="button" aria-label="Close deletion review" className="grid h-8 w-8 place-items-center rounded-lg text-slate-500 hover:bg-slate-100"><X className="h-4 w-4" /></button></Dialog.Close></div>
-            {deleteImpact && <div className="mt-4 rounded-xl border border-red-200 bg-red-50 p-4"><p className="text-sm font-bold text-red-950">{deleteImpact.title}</p><dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-red-900"><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">Schematic wires</dt><dd>{deleteImpact.wires}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">PCB traces</dt><dd>{deleteImpact.traces}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">Assigned nets</dt><dd>{deleteImpact.nets.join(', ') || 'None'}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">BOM link</dt><dd>{deleteImpact.bomLinked ? 'Present' : 'Not recorded'}</dd></div></dl></div>}
-            <div className="mt-5 flex justify-end gap-2"><Dialog.Close asChild><button type="button" className="h-9 rounded-lg border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-slate-100">Cancel</button></Dialog.Close><button type="button" onClick={confirmDeleteComponent} className="h-9 rounded-lg bg-red-700 px-3 text-sm font-semibold text-white hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">Remove from product</button></div>
-          </Dialog.Content>
-        </Dialog.Portal>
+        <Dialog.Portal><Dialog.Overlay className="fixed inset-0 z-[150] bg-slate-950/65 backdrop-blur-sm" /><Dialog.Content aria-describedby="schematic-delete-description" className="fixed left-1/2 top-1/2 z-[160] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-red-200 bg-white p-5 text-slate-900 shadow-2xl outline-none"><div className="flex items-start justify-between gap-3"><div className="flex items-start gap-3"><span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-red-50 text-red-700"><Trash2 className="h-5 w-5" /></span><div><Dialog.Title className="text-base font-bold">Remove component from the whole product?</Dialog.Title><Dialog.Description id="schematic-delete-description" className="mt-1 text-sm leading-6 text-slate-600">This is not a schematic-only delete. Review connected project data before continuing.</Dialog.Description></div></div><Dialog.Close asChild><button type="button" aria-label="Close deletion review" className="grid h-8 w-8 place-items-center rounded-lg text-slate-500 hover:bg-slate-100"><X className="h-4 w-4" /></button></Dialog.Close></div>{deleteImpact && <div className="mt-4 rounded-xl border border-red-200 bg-red-50 p-4"><p className="text-sm font-bold text-red-950">{deleteImpact.title}</p><dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-red-900"><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">Schematic wires</dt><dd>{deleteImpact.wires}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">PCB traces</dt><dd>{deleteImpact.traces}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">Assigned nets</dt><dd>{deleteImpact.nets.join(', ') || 'None'}</dd></div><div className="rounded-lg bg-white/70 p-2"><dt className="font-bold">BOM link</dt><dd>{deleteImpact.bomLinked ? 'Present' : 'Not recorded'}</dd></div></dl></div>}<div className="mt-5 flex justify-end gap-2"><Dialog.Close asChild><button type="button" className="h-9 rounded-lg border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-700 hover:bg-slate-100">Cancel</button></Dialog.Close><button type="button" onClick={confirmDeleteComponent} className="h-9 rounded-lg bg-red-700 px-3 text-sm font-semibold text-white hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">Remove from product</button></div></Dialog.Content></Dialog.Portal>
       </Dialog.Root>
     </section>
   );

--- a/src/components/studio/EngineeringContextBar.tsx
+++ b/src/components/studio/EngineeringContextBar.tsx
@@ -5,9 +5,11 @@ import {
   ArrowRight,
   Boxes,
   CircuitBoard,
+  FileSpreadsheet,
   Layers3,
   ListTree,
   PenTool,
+  TestTube2,
 } from 'lucide-react';
 import { getDomainIdForView } from '../../lib/workflowProfiles';
 import { useProjectStore } from '../../store/projectStore';
@@ -28,6 +30,7 @@ const contextualViews = new Set([
   'blueprint-sheets',
   'exports',
   'validation-studio',
+  'requirement-coverage',
 ]);
 
 export const EngineeringContextBar: React.FC = () => {
@@ -56,7 +59,8 @@ export const EngineeringContextBar: React.FC = () => {
   const visible = contextualViews.has(activeView)
     || activeDomain === 'electronics'
     || activeDomain === 'pcb'
-    || activeDomain === 'mechanical';
+    || activeDomain === 'mechanical'
+    || activeDomain === 'validation';
 
   const resolvedBoardId = activeBoardId || store.activeBoardId || boards[0]?.id || '';
   const componentsForBoard = useMemo(
@@ -94,11 +98,7 @@ export const EngineeringContextBar: React.FC = () => {
       setActiveView('board-settings');
       return;
     }
-    if (viewId === 'mechanical-studio') {
-      requestMechanicalMode('webgl-3d');
-    } else {
-      requestMechanicalMode(null);
-    }
+    requestMechanicalMode(viewId === 'mechanical-studio' ? 'webgl-3d' : null);
     setActiveView(viewId);
   };
 
@@ -112,9 +112,18 @@ export const EngineeringContextBar: React.FC = () => {
   const schematicActionLabel = selectedComponent?.schematic?.placed ? 'Schematic' : 'Place in schematic';
   const pcbActionLabel = selectedBoard ? 'PCB' : 'Create board';
 
+  const handoffs = [
+    { viewId: 'component-library', label: 'Components', Icon: Boxes },
+    { viewId: 'schematic-editor', label: schematicActionLabel, Icon: PenTool },
+    { viewId: 'board-designer', label: pcbActionLabel, Icon: CircuitBoard },
+    { viewId: 'mechanical-studio', label: 'Inspect in 3D', Icon: Layers3 },
+    { viewId: 'bom', label: 'BOM', Icon: FileSpreadsheet },
+    { viewId: 'validation-studio', label: 'Validate', Icon: TestTube2 },
+  ] as const;
+
   return (
     <section className="shrink-0 border-b border-slate-200 bg-slate-50 px-3 py-2" aria-label="Shared engineering context">
-      <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
+      <div className="flex flex-col gap-2 2xl:flex-row 2xl:items-center 2xl:justify-between">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="shrink-0 text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Working context</span>
 
@@ -146,13 +155,8 @@ export const EngineeringContextBar: React.FC = () => {
           </label>
         </div>
 
-        <div className="flex items-center gap-1.5 overflow-x-auto">
-          {[
-            { viewId: 'component-library', label: 'Components', Icon: Boxes },
-            { viewId: 'schematic-editor', label: schematicActionLabel, Icon: PenTool },
-            { viewId: 'board-designer', label: pcbActionLabel, Icon: CircuitBoard },
-            { viewId: 'mechanical-studio', label: 'Inspect in 3D', Icon: Layers3 },
-          ].map(({ viewId, label, Icon }, index) => (
+        <div className="flex items-center gap-1 overflow-x-auto pb-0.5">
+          {handoffs.map(({ viewId, label, Icon }, index) => (
             <React.Fragment key={viewId}>
               {index > 0 && <ArrowRight className="h-3.5 w-3.5 shrink-0 text-slate-300" aria-hidden="true" />}
               <button
@@ -174,6 +178,7 @@ export const EngineeringContextBar: React.FC = () => {
         <span className={`rounded-full border px-2 py-1 ${selectedComponent?.pcb?.placed || selectedComponent?.placementStatus === 'Placed' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-amber-200 bg-amber-50 text-amber-800'}`}>PCB: {selectedComponent ? selectedComponent.pcb?.placed || selectedComponent.placementStatus === 'Placed' ? 'placed' : 'unplaced' : 'no instance'}</span>
         <span className="rounded-full border border-slate-200 bg-white px-2 py-1">Footprint: {selectedComponent?.footprint || 'unresolved'}</span>
         <span className="rounded-full border border-slate-200 bg-white px-2 py-1">Pins: {selectedComponent?.pins?.length || 0}</span>
+        <span className="rounded-full border border-slate-200 bg-white px-2 py-1">BOM: {selectedComponent?.bomItemId ? 'linked' : 'unlinked'}</span>
         <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-1 text-amber-800">3D: preview context, not exact CAD</span>
       </div>
     </section>

--- a/src/components/studio/EngineeringContextBar.tsx
+++ b/src/components/studio/EngineeringContextBar.tsx
@@ -49,6 +49,7 @@ export const EngineeringContextBar: React.FC = () => {
     setActiveComponent,
     setActiveNet,
     beginHandoff,
+    requestMechanicalMode,
   } = useStudioContextStore();
 
   const activeDomain = getDomainIdForView(activeView);
@@ -92,6 +93,11 @@ export const EngineeringContextBar: React.FC = () => {
     if (viewId === 'board-designer' && !selectedBoard) {
       setActiveView('board-settings');
       return;
+    }
+    if (viewId === 'mechanical-studio') {
+      requestMechanicalMode('webgl-3d');
+    } else {
+      requestMechanicalMode(null);
     }
     setActiveView(viewId);
   };
@@ -145,7 +151,7 @@ export const EngineeringContextBar: React.FC = () => {
             { viewId: 'component-library', label: 'Components', Icon: Boxes },
             { viewId: 'schematic-editor', label: schematicActionLabel, Icon: PenTool },
             { viewId: 'board-designer', label: pcbActionLabel, Icon: CircuitBoard },
-            { viewId: 'mechanical-studio', label: 'Assembly / 3D', Icon: Layers3 },
+            { viewId: 'mechanical-studio', label: 'Inspect in 3D', Icon: Layers3 },
           ].map(({ viewId, label, Icon }, index) => (
             <React.Fragment key={viewId}>
               {index > 0 && <ArrowRight className="h-3.5 w-3.5 shrink-0 text-slate-300" aria-hidden="true" />}
@@ -168,6 +174,7 @@ export const EngineeringContextBar: React.FC = () => {
         <span className={`rounded-full border px-2 py-1 ${selectedComponent?.pcb?.placed || selectedComponent?.placementStatus === 'Placed' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-amber-200 bg-amber-50 text-amber-800'}`}>PCB: {selectedComponent ? selectedComponent.pcb?.placed || selectedComponent.placementStatus === 'Placed' ? 'placed' : 'unplaced' : 'no instance'}</span>
         <span className="rounded-full border border-slate-200 bg-white px-2 py-1">Footprint: {selectedComponent?.footprint || 'unresolved'}</span>
         <span className="rounded-full border border-slate-200 bg-white px-2 py-1">Pins: {selectedComponent?.pins?.length || 0}</span>
+        <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-1 text-amber-800">3D: preview context, not exact CAD</span>
       </div>
     </section>
   );

--- a/src/components/studio/EngineeringContextBar.tsx
+++ b/src/components/studio/EngineeringContextBar.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import {
+  ArrowRight,
+  Boxes,
+  CircuitBoard,
+  Layers3,
+  ListTree,
+  PenTool,
+} from 'lucide-react';
+import { getDomainIdForView } from '../../lib/workflowProfiles';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+
+const contextualViews = new Set([
+  'component-library',
+  'schematic-editor',
+  'power-tree',
+  'pin-map',
+  'bom',
+  'board-settings',
+  'board-designer',
+  'pcb-drc',
+  'pcb-constraints',
+  'mechanical-studio',
+  'assembly-stack',
+  'blueprint-sheets',
+  'exports',
+  'validation-studio',
+]);
+
+export const EngineeringContextBar: React.FC = () => {
+  const store = useProjectStore();
+  const {
+    activeView,
+    setActiveView,
+    setActiveBoard,
+    boards = [],
+    boardComponents = [],
+    nets = [],
+  } = store;
+  const {
+    activeBoardId,
+    activeComponentId,
+    activeNetName,
+    setActiveBoard: setContextBoard,
+    setActiveComponent,
+    setActiveNet,
+    beginHandoff,
+  } = useStudioContextStore();
+
+  const activeDomain = getDomainIdForView(activeView);
+  const visible = contextualViews.has(activeView)
+    || activeDomain === 'electronics'
+    || activeDomain === 'pcb'
+    || activeDomain === 'mechanical';
+
+  const resolvedBoardId = activeBoardId || store.activeBoardId || boards[0]?.id || '';
+  const componentsForBoard = useMemo(
+    () => boardComponents.filter((component) => !resolvedBoardId || component.boardId === resolvedBoardId),
+    [boardComponents, resolvedBoardId],
+  );
+  const selectedComponent = boardComponents.find((component) => component.id === activeComponentId)
+    || componentsForBoard[0];
+  const selectedBoard = boards.find((board) => board.id === resolvedBoardId) || boards[0];
+
+  useEffect(() => {
+    if (!activeBoardId && resolvedBoardId) setContextBoard(resolvedBoardId);
+  }, [activeBoardId, resolvedBoardId, setContextBoard]);
+
+  useEffect(() => {
+    if (!activeComponentId && componentsForBoard[0]) setActiveComponent(componentsForBoard[0].id);
+  }, [activeComponentId, componentsForBoard, setActiveComponent]);
+
+  if (!visible) return null;
+
+  const navigate = (viewId: string) => {
+    beginHandoff(activeView, activeView);
+    setActiveView(viewId);
+  };
+
+  const changeBoard = (boardId: string) => {
+    setContextBoard(boardId || null);
+    if (boardId) setActiveBoard(boardId);
+    const firstComponent = boardComponents.find((component) => component.boardId === boardId);
+    setActiveComponent(firstComponent?.id || null);
+  };
+
+  return (
+    <section className="shrink-0 border-b border-slate-200 bg-slate-50 px-3 py-2" aria-label="Shared engineering context">
+      <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="shrink-0 text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Working context</span>
+
+          <label className="flex min-w-[180px] items-center gap-2 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
+            <CircuitBoard className="h-3.5 w-3.5 shrink-0 text-indigo-600" aria-hidden="true" />
+            <span className="sr-only">Active board</span>
+            <select
+              value={resolvedBoardId}
+              onChange={(event) => changeBoard(event.target.value)}
+              className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none"
+            >
+              {boards.length === 0 && <option value="">No board yet</option>}
+              {boards.map((board) => <option key={board.id} value={board.id}>{board.name}</option>)}
+            </select>
+          </label>
+
+          <label className="flex min-w-[220px] items-center gap-2 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
+            <Boxes className="h-3.5 w-3.5 shrink-0 text-indigo-600" aria-hidden="true" />
+            <span className="sr-only">Active component instance</span>
+            <select
+              value={selectedComponent?.id || ''}
+              onChange={(event) => setActiveComponent(event.target.value || null)}
+              className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none"
+            >
+              {componentsForBoard.length === 0 && <option value="">No component instance</option>}
+              {componentsForBoard.map((component) => (
+                <option key={component.id} value={component.id}>{component.referenceDesignator} · {component.componentName}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex min-w-[150px] items-center gap-2 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
+            <ListTree className="h-3.5 w-3.5 shrink-0 text-indigo-600" aria-hidden="true" />
+            <span className="sr-only">Active net</span>
+            <select
+              value={activeNetName || ''}
+              onChange={(event) => setActiveNet(event.target.value || null)}
+              className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none"
+            >
+              <option value="">No net selected</option>
+              {nets.map((net) => <option key={net.id} value={net.netName}>{net.netName}</option>)}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex items-center gap-1.5 overflow-x-auto">
+          {[
+            { viewId: 'component-library', label: 'Components', Icon: Boxes },
+            { viewId: 'schematic-editor', label: 'Schematic', Icon: PenTool },
+            { viewId: 'board-designer', label: 'PCB', Icon: CircuitBoard },
+            { viewId: 'mechanical-studio', label: 'Assembly / 3D', Icon: Layers3 },
+          ].map(({ viewId, label, Icon }, index) => (
+            <React.Fragment key={viewId}>
+              {index > 0 && <ArrowRight className="h-3.5 w-3.5 shrink-0 text-slate-300" aria-hidden="true" />}
+              <button
+                type="button"
+                onClick={() => navigate(viewId)}
+                aria-current={activeView === viewId ? 'step' : undefined}
+                className={`inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 text-[10px] font-bold focus:outline-none focus:ring-2 focus:ring-indigo-500 ${activeView === viewId ? 'border-indigo-300 bg-indigo-100 text-indigo-900' : 'border-slate-200 bg-white text-slate-600 hover:border-indigo-200 hover:bg-indigo-50'}`}
+              >
+                <Icon className="h-3.5 w-3.5" aria-hidden="true" /> {label}
+              </button>
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[9px] font-semibold text-slate-600">
+        <span className="rounded-full border border-slate-200 bg-white px-2 py-1">Board: {selectedBoard ? `${selectedBoard.layerCount} layers · ${selectedBoard.dimensionsMm} mm` : 'not created'}</span>
+        <span className={`rounded-full border px-2 py-1 ${selectedComponent?.schematic?.placed ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-amber-200 bg-amber-50 text-amber-800'}`}>Schematic: {selectedComponent ? selectedComponent.schematic?.placed ? 'placed' : 'unplaced' : 'no instance'}</span>
+        <span className={`rounded-full border px-2 py-1 ${selectedComponent?.pcb?.placed || selectedComponent?.placementStatus === 'Placed' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-amber-200 bg-amber-50 text-amber-800'}`}>PCB: {selectedComponent ? selectedComponent.pcb?.placed || selectedComponent.placementStatus === 'Placed' ? 'placed' : 'unplaced' : 'no instance'}</span>
+        <span className="rounded-full border border-slate-200 bg-white px-2 py-1">Footprint: {selectedComponent?.footprint || 'unresolved'}</span>
+        <span className="rounded-full border border-slate-200 bg-white px-2 py-1">Pins: {selectedComponent?.pins?.length || 0}</span>
+      </div>
+    </section>
+  );
+};

--- a/src/components/studio/EngineeringContextBar.tsx
+++ b/src/components/studio/EngineeringContextBar.tsx
@@ -36,6 +36,7 @@ export const EngineeringContextBar: React.FC = () => {
     activeView,
     setActiveView,
     setActiveBoard,
+    placeComponentOnSchematic,
     boards = [],
     boardComponents = [],
     nets = [],
@@ -70,13 +71,28 @@ export const EngineeringContextBar: React.FC = () => {
   }, [activeBoardId, resolvedBoardId, setContextBoard]);
 
   useEffect(() => {
-    if (!activeComponentId && componentsForBoard[0]) setActiveComponent(componentsForBoard[0].id);
+    const selectedStillExists = activeComponentId
+      ? componentsForBoard.some((component) => component.id === activeComponentId)
+      : false;
+    if ((!activeComponentId || !selectedStillExists) && componentsForBoard[0]) {
+      setActiveComponent(componentsForBoard[0].id);
+    }
   }, [activeComponentId, componentsForBoard, setActiveComponent]);
 
   if (!visible) return null;
 
   const navigate = (viewId: string) => {
     beginHandoff(activeView, activeView);
+    if (viewId === 'schematic-editor' && selectedComponent && !selectedComponent.schematic?.placed) {
+      const placedCount = componentsForBoard.filter((component) => component.schematic?.placed).length;
+      const column = placedCount % 4;
+      const row = Math.floor(placedCount / 4);
+      placeComponentOnSchematic(selectedComponent.id, 140 + column * 180, 140 + row * 140);
+    }
+    if (viewId === 'board-designer' && !selectedBoard) {
+      setActiveView('board-settings');
+      return;
+    }
     setActiveView(viewId);
   };
 
@@ -87,6 +103,9 @@ export const EngineeringContextBar: React.FC = () => {
     setActiveComponent(firstComponent?.id || null);
   };
 
+  const schematicActionLabel = selectedComponent?.schematic?.placed ? 'Schematic' : 'Place in schematic';
+  const pcbActionLabel = selectedBoard ? 'PCB' : 'Create board';
+
   return (
     <section className="shrink-0 border-b border-slate-200 bg-slate-50 px-3 py-2" aria-label="Shared engineering context">
       <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
@@ -96,11 +115,7 @@ export const EngineeringContextBar: React.FC = () => {
           <label className="flex min-w-[180px] items-center gap-2 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
             <CircuitBoard className="h-3.5 w-3.5 shrink-0 text-indigo-600" aria-hidden="true" />
             <span className="sr-only">Active board</span>
-            <select
-              value={resolvedBoardId}
-              onChange={(event) => changeBoard(event.target.value)}
-              className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none"
-            >
+            <select value={resolvedBoardId} onChange={(event) => changeBoard(event.target.value)} className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none">
               {boards.length === 0 && <option value="">No board yet</option>}
               {boards.map((board) => <option key={board.id} value={board.id}>{board.name}</option>)}
             </select>
@@ -109,26 +124,16 @@ export const EngineeringContextBar: React.FC = () => {
           <label className="flex min-w-[220px] items-center gap-2 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
             <Boxes className="h-3.5 w-3.5 shrink-0 text-indigo-600" aria-hidden="true" />
             <span className="sr-only">Active component instance</span>
-            <select
-              value={selectedComponent?.id || ''}
-              onChange={(event) => setActiveComponent(event.target.value || null)}
-              className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none"
-            >
+            <select value={selectedComponent?.id || ''} onChange={(event) => setActiveComponent(event.target.value || null)} className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none">
               {componentsForBoard.length === 0 && <option value="">No component instance</option>}
-              {componentsForBoard.map((component) => (
-                <option key={component.id} value={component.id}>{component.referenceDesignator} · {component.componentName}</option>
-              ))}
+              {componentsForBoard.map((component) => <option key={component.id} value={component.id}>{component.referenceDesignator} · {component.componentName}</option>)}
             </select>
           </label>
 
           <label className="flex min-w-[150px] items-center gap-2 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
             <ListTree className="h-3.5 w-3.5 shrink-0 text-indigo-600" aria-hidden="true" />
             <span className="sr-only">Active net</span>
-            <select
-              value={activeNetName || ''}
-              onChange={(event) => setActiveNet(event.target.value || null)}
-              className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none"
-            >
+            <select value={activeNetName || ''} onChange={(event) => setActiveNet(event.target.value || null)} className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-slate-800 outline-none">
               <option value="">No net selected</option>
               {nets.map((net) => <option key={net.id} value={net.netName}>{net.netName}</option>)}
             </select>
@@ -138,8 +143,8 @@ export const EngineeringContextBar: React.FC = () => {
         <div className="flex items-center gap-1.5 overflow-x-auto">
           {[
             { viewId: 'component-library', label: 'Components', Icon: Boxes },
-            { viewId: 'schematic-editor', label: 'Schematic', Icon: PenTool },
-            { viewId: 'board-designer', label: 'PCB', Icon: CircuitBoard },
+            { viewId: 'schematic-editor', label: schematicActionLabel, Icon: PenTool },
+            { viewId: 'board-designer', label: pcbActionLabel, Icon: CircuitBoard },
             { viewId: 'mechanical-studio', label: 'Assembly / 3D', Icon: Layers3 },
           ].map(({ viewId, label, Icon }, index) => (
             <React.Fragment key={viewId}>

--- a/src/components/studio/StudioBuildMap.tsx
+++ b/src/components/studio/StudioBuildMap.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { getDomainIdForView, type WorkflowDomainId } from '../../lib/workflowProfiles';
 import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
 import { useWorkflowPreferencesStore } from '../../store/workflowPreferencesStore';
 
 export interface BuildStage {
@@ -41,7 +42,7 @@ export const ELECTRONICS_FLOW = [
   { id: 'schematic-editor', label: 'Schematic', icon: PenTool },
   { id: 'board-settings', label: 'Board setup', icon: CircuitBoard },
   { id: 'board-designer', label: 'PCB layout', icon: CircuitBoard },
-  { id: 'blueprint-sheets', label: '3D / drawings', icon: Layers3 },
+  { id: 'mechanical-studio', label: 'Assembly / 3D', icon: Layers3 },
   { id: 'pcb-drc', label: 'Checks', icon: FileCheck2 },
 ] as const;
 
@@ -53,6 +54,7 @@ export const StudioBuildMap: React.FC = () => {
   const store = useProjectStore();
   const project = store as unknown as Record<string, unknown>;
   const { activeView, setActiveView } = store;
+  const requestMechanicalMode = useStudioContextStore((state) => state.requestMechanicalMode);
   const enabledDomains = useWorkflowPreferencesStore((state) => state.enabledDomains);
   const activeDomain = getDomainIdForView(activeView);
 
@@ -71,13 +73,19 @@ export const StudioBuildMap: React.FC = () => {
     'schematic-editor': countOf(project.schematicWires),
     'board-settings': countOf(project.boards),
     'board-designer': countOf(project.traces),
-    'blueprint-sheets': countOf(project.blueprintSheets),
+    'mechanical-studio': countOf(project.mechanicalObjects) + countOf(project.mechanicalBodies),
     'pcb-drc': countOf(project.reviewResults),
   }), [project]);
 
   const showElectronicsFlow = activeDomain === 'electronics'
     || activeDomain === 'pcb'
-    || ['component-library', 'schematic-editor', 'board-settings', 'board-designer', 'pcb-drc', 'blueprint-sheets'].includes(activeView);
+    || activeDomain === 'mechanical'
+    || ['component-library', 'schematic-editor', 'board-settings', 'board-designer', 'pcb-drc'].includes(activeView);
+
+  const openView = (viewId: string) => {
+    requestMechanicalMode(viewId === 'mechanical-studio' ? 'webgl-3d' : null);
+    setActiveView(viewId);
+  };
 
   return (
     <div className="shrink-0 border-b border-slate-200 bg-white shadow-sm">
@@ -90,7 +98,10 @@ export const StudioBuildMap: React.FC = () => {
             <button
               key={stage.id}
               type="button"
-              onClick={() => setActiveView(stage.viewId)}
+              onClick={() => {
+                requestMechanicalMode(stage.id === 'mechanical' ? 'canvas' : null);
+                setActiveView(stage.viewId);
+              }}
               aria-current={active ? 'step' : undefined}
               className={`group flex min-w-[104px] shrink-0 items-center gap-2 rounded-lg border px-2.5 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
                 active
@@ -122,7 +133,7 @@ export const StudioBuildMap: React.FC = () => {
                 {index > 0 && <span className="shrink-0 text-slate-300" aria-hidden="true">→</span>}
                 <button
                   type="button"
-                  onClick={() => setActiveView(step.id)}
+                  onClick={() => openView(step.id)}
                   aria-current={active ? 'step' : undefined}
                   className={`flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-[10px] font-semibold transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${active ? 'bg-indigo-100 text-indigo-900' : 'text-slate-600 hover:bg-white hover:text-slate-950'}`}
                 >

--- a/src/components/studio/StudioBuildMap.tsx
+++ b/src/components/studio/StudioBuildMap.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import {
+  Boxes,
+  CircuitBoard,
+  Code2,
+  Cpu,
+  FileCheck2,
+  Layers3,
+  PackageCheck,
+  PenTool,
+  Shapes,
+  TestTube2,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+import { getDomainIdForView, type WorkflowDomainId } from '../../lib/workflowProfiles';
+import { useProjectStore } from '../../store/projectStore';
+import { useWorkflowPreferencesStore } from '../../store/workflowPreferencesStore';
+
+interface BuildStage {
+  id: WorkflowDomainId;
+  label: string;
+  viewId: string;
+  icon: LucideIcon;
+}
+
+const BUILD_STAGES: readonly BuildStage[] = [
+  { id: 'product', label: 'Product', viewId: 'requirements', icon: Shapes },
+  { id: 'mechanical', label: 'Mechanical', viewId: 'mechanical-studio', icon: Wrench },
+  { id: 'electronics', label: 'Electronics', viewId: 'component-library', icon: Cpu },
+  { id: 'pcb', label: 'PCB', viewId: 'board-designer', icon: CircuitBoard },
+  { id: 'firmware', label: 'Firmware', viewId: 'firmware-studio', icon: Code2 },
+  { id: 'validation', label: 'Validation', viewId: 'validation-studio', icon: TestTube2 },
+  { id: 'outputs', label: 'Outputs', viewId: 'exports', icon: PackageCheck },
+];
+
+const ELECTRONICS_FLOW = [
+  { id: 'component-library', label: 'Components', icon: Boxes },
+  { id: 'schematic-editor', label: 'Schematic', icon: PenTool },
+  { id: 'board-settings', label: 'Board setup', icon: CircuitBoard },
+  { id: 'board-designer', label: 'PCB layout', icon: CircuitBoard },
+  { id: 'blueprint-sheets', label: '3D / drawings', icon: Layers3 },
+  { id: 'pcb-drc', label: 'Checks', icon: FileCheck2 },
+] as const;
+
+function countOf(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+export const StudioBuildMap: React.FC = () => {
+  const store = useProjectStore();
+  const project = store as unknown as Record<string, unknown>;
+  const { activeView, setActiveView } = store;
+  const enabledDomains = useWorkflowPreferencesStore((state) => state.enabledDomains);
+  const activeDomain = getDomainIdForView(activeView);
+
+  const counts = useMemo(() => ({
+    product: Math.max(countOf(project.requirements), countOf(project.architectureNodes)),
+    mechanical: countOf(project.mechanicalObjects),
+    electronics: countOf(project.boardComponents),
+    pcb: countOf(project.boards),
+    firmware: countOf(project.firmwareModules),
+    validation: countOf(project.validationTests),
+    outputs: countOf(project.revisions),
+  }), [project]);
+
+  const electronicsCounts = useMemo(() => ({
+    'component-library': countOf(project.boardComponents),
+    'schematic-editor': countOf(project.schematicWires),
+    'board-settings': countOf(project.boards),
+    'board-designer': countOf(project.traces),
+    'blueprint-sheets': countOf(project.blueprintSheets),
+    'pcb-drc': countOf(project.reviewResults),
+  }), [project]);
+
+  const showElectronicsFlow = activeDomain === 'electronics'
+    || activeDomain === 'pcb'
+    || ['component-library', 'schematic-editor', 'board-settings', 'board-designer', 'pcb-drc', 'blueprint-sheets'].includes(activeView);
+
+  return (
+    <div className="shrink-0 border-b border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center gap-1 overflow-x-auto px-3 py-2" aria-label="Complete product build map">
+        {BUILD_STAGES.map((stage) => {
+          const Icon = stage.icon;
+          const active = activeDomain === stage.id;
+          const focused = enabledDomains.includes(stage.id);
+          return (
+            <button
+              key={stage.id}
+              type="button"
+              onClick={() => setActiveView(stage.viewId)}
+              aria-current={active ? 'step' : undefined}
+              className={`group flex min-w-[104px] shrink-0 items-center gap-2 rounded-lg border px-2.5 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                active
+                  ? 'border-slate-950 bg-slate-950 text-white'
+                  : focused
+                    ? 'border-slate-200 bg-white text-slate-700 hover:border-indigo-200 hover:bg-indigo-50'
+                    : 'border-dashed border-slate-200 bg-slate-50 text-slate-500 hover:border-slate-300 hover:bg-white'
+              }`}
+              title={focused ? `${stage.label} is in the active workflow` : `${stage.label} is outside the focused workflow but remains available`}
+            >
+              <Icon className={`h-4 w-4 shrink-0 ${active ? 'text-emerald-300' : focused ? 'text-indigo-600' : 'text-slate-400'}`} aria-hidden="true" />
+              <span className="min-w-0">
+                <span className="block truncate text-[10px] font-bold uppercase tracking-wide">{stage.label}</span>
+                <span className={`mt-0.5 block text-[9px] ${active ? 'text-slate-300' : 'text-slate-500'}`}>{counts[stage.id]} records</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {showElectronicsFlow && (
+        <div className="flex items-center gap-1 overflow-x-auto border-t border-slate-100 bg-slate-50 px-3 py-1.5" aria-label="Electronics to PCB connected workflow">
+          <span className="mr-1 shrink-0 text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Connected path</span>
+          {ELECTRONICS_FLOW.map((step, index) => {
+            const Icon = step.icon;
+            const active = activeView === step.id || (step.id === 'pcb-drc' && activeView === 'board-designer');
+            return (
+              <React.Fragment key={step.id}>
+                {index > 0 && <span className="shrink-0 text-slate-300" aria-hidden="true">→</span>}
+                <button
+                  type="button"
+                  onClick={() => setActiveView(step.id)}
+                  aria-current={active ? 'step' : undefined}
+                  className={`flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-[10px] font-semibold transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${active ? 'bg-indigo-100 text-indigo-900' : 'text-slate-600 hover:bg-white hover:text-slate-950'}`}
+                >
+                  <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                  {step.label}
+                  <span className="rounded bg-white/80 px-1.5 py-0.5 font-mono text-[8px] text-slate-500">{electronicsCounts[step.id]}</span>
+                </button>
+              </React.Fragment>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/studio/StudioBuildMap.tsx
+++ b/src/components/studio/StudioBuildMap.tsx
@@ -19,14 +19,14 @@ import { getDomainIdForView, type WorkflowDomainId } from '../../lib/workflowPro
 import { useProjectStore } from '../../store/projectStore';
 import { useWorkflowPreferencesStore } from '../../store/workflowPreferencesStore';
 
-interface BuildStage {
+export interface BuildStage {
   id: WorkflowDomainId;
   label: string;
   viewId: string;
   icon: LucideIcon;
 }
 
-const BUILD_STAGES: readonly BuildStage[] = [
+export const BUILD_STAGES: readonly BuildStage[] = [
   { id: 'product', label: 'Product', viewId: 'requirements', icon: Shapes },
   { id: 'mechanical', label: 'Mechanical', viewId: 'mechanical-studio', icon: Wrench },
   { id: 'electronics', label: 'Electronics', viewId: 'component-library', icon: Cpu },
@@ -36,7 +36,7 @@ const BUILD_STAGES: readonly BuildStage[] = [
   { id: 'outputs', label: 'Outputs', viewId: 'exports', icon: PackageCheck },
 ];
 
-const ELECTRONICS_FLOW = [
+export const ELECTRONICS_FLOW = [
   { id: 'component-library', label: 'Components', icon: Boxes },
   { id: 'schematic-editor', label: 'Schematic', icon: PenTool },
   { id: 'board-settings', label: 'Board setup', icon: CircuitBoard },

--- a/src/components/studio/StudioBuildMap.tsx
+++ b/src/components/studio/StudioBuildMap.tsx
@@ -127,7 +127,7 @@ export const StudioBuildMap: React.FC = () => {
           <span className="mr-1 shrink-0 text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Connected path</span>
           {ELECTRONICS_FLOW.map((step, index) => {
             const Icon = step.icon;
-            const active = activeView === step.id || (step.id === 'pcb-drc' && activeView === 'board-designer');
+            const active = activeView === step.id;
             return (
               <React.Fragment key={step.id}>
                 {index > 0 && <span className="shrink-0 text-slate-300" aria-hidden="true">→</span>}

--- a/src/components/studio/UnifiedBOMWorkbench.tsx
+++ b/src/components/studio/UnifiedBOMWorkbench.tsx
@@ -16,7 +16,7 @@ import type { BOMItem } from '../../types';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore } from '../../store/studioContextStore';
 
-const statusOptions = ['Not Started', 'Sourced', 'Ordered', 'Received', 'Tested'] as const;
+const statusOptions = ['Not Started', 'Sourced', 'Ordered', 'Received', 'Tested', 'Rejected'] as const satisfies readonly NonNullable<BOMItem['status']>[];
 
 export const UnifiedBOMWorkbench: React.FC = () => {
   const store = useProjectStore();
@@ -56,24 +56,24 @@ export const UnifiedBOMWorkbench: React.FC = () => {
       id,
       blockName: selectedComponent.componentName,
       candidateComponent: selectedComponent.value || selectedComponent.componentName,
-      partNumber: '',
+      partNumber: selectedComponent.partNumber || '',
       stage: 'Prototype',
-      quantity: 1,
-      voltage: selectedComponent.electrical?.supplyVoltage || '',
-      currentEstimate: selectedComponent.electrical?.currentDraw || '',
-      interface: selectedComponent.electrical?.interface || '',
-      packageSize: selectedComponent.footprint || '',
+      quantity: selectedComponent.quantity || 1,
+      voltage: '',
+      currentEstimate: '',
+      interface: '',
+      packageSize: selectedComponent.footprint || selectedComponent.packageName || '',
       dimensions: selectedComponent.packageDimensions
         ? `${selectedComponent.packageDimensions.widthMm} × ${selectedComponent.packageDimensions.heightMm} × ${selectedComponent.packageDimensions.heightZMm} mm`
         : '',
       costEstimate: '0.00',
-      supplier: '',
+      supplier: selectedComponent.supplier || '',
       supplierUrl: '',
-      datasheetUrl: '',
+      datasheetUrl: selectedComponent.datasheetUrl || '',
       status: 'Not Started',
       risk: '',
       alternative: '',
-      notes: `Linked to ${selectedComponent.referenceDesignator} (${selectedComponent.id}).`,
+      notes: `Linked to ${selectedComponent.referenceDesignator} (${selectedComponent.id}). Electrical values remain blank until explicitly qualified.`,
     };
     updateProjectState({ bom: [...bom, item] });
     updateBoardComponent(selectedComponent.id, { bomItemId: id });
@@ -125,7 +125,7 @@ export const UnifiedBOMWorkbench: React.FC = () => {
                 <thead className="bg-white text-[9px] font-bold uppercase tracking-wide text-slate-500"><tr className="border-b border-slate-200"><th className="px-3 py-2.5">Component</th><th className="px-3 py-2.5">Part number</th><th className="px-3 py-2.5">Package</th><th className="px-3 py-2.5">Qty</th><th className="px-3 py-2.5">Supplier</th><th className="px-3 py-2.5">Unit cost</th><th className="px-3 py-2.5">Status</th></tr></thead>
                 <tbody className="divide-y divide-slate-100">{orderedBom.map((item) => {
                   const highlighted = item.id === selectedBomItem?.id;
-                  return <tr key={item.id} className={highlighted ? 'bg-indigo-50' : 'hover:bg-slate-50'}><td className="px-3 py-2"><input value={item.blockName} onChange={(event) => updateBOMItem(item.id, { blockName: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-semibold text-slate-900 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" /></td><td className="px-3 py-2"><input value={item.partNumber || ''} onChange={(event) => updateBOMItem(item.id, { partNumber: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Manufacturer PN" /></td><td className="px-3 py-2"><input value={item.packageSize || ''} onChange={(event) => updateBOMItem(item.id, { packageSize: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Footprint/package" /></td><td className="px-3 py-2"><input type="number" min={1} value={item.quantity} onChange={(event) => updateBOMItem(item.id, { quantity: Math.max(1, Number(event.target.value) || 1) })} className="w-16 rounded border border-slate-200 bg-white px-2 py-1 text-center" /></td><td className="px-3 py-2"><input value={item.supplier || ''} onChange={(event) => updateBOMItem(item.id, { supplier: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Supplier" /></td><td className="px-3 py-2"><input value={item.costEstimate || ''} onChange={(event) => updateBOMItem(item.id, { costEstimate: event.target.value })} className="w-24 rounded border border-slate-200 bg-white px-2 py-1 text-right font-mono" placeholder="0.00" /></td><td className="px-3 py-2"><select value={item.status} onChange={(event) => updateBOMItem(item.id, { status: event.target.value })} className="rounded border border-slate-200 bg-white px-2 py-1">{statusOptions.map((status) => <option key={status} value={status}>{status}</option>)}</select></td></tr>;
+                  return <tr key={item.id} className={highlighted ? 'bg-indigo-50' : 'hover:bg-slate-50'}><td className="px-3 py-2"><input value={item.blockName} onChange={(event) => updateBOMItem(item.id, { blockName: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-semibold text-slate-900 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" /></td><td className="px-3 py-2"><input value={item.partNumber || ''} onChange={(event) => updateBOMItem(item.id, { partNumber: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Manufacturer PN" /></td><td className="px-3 py-2"><input value={item.packageSize || ''} onChange={(event) => updateBOMItem(item.id, { packageSize: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Footprint/package" /></td><td className="px-3 py-2"><input type="number" min={1} value={item.quantity} onChange={(event) => updateBOMItem(item.id, { quantity: Math.max(1, Number(event.target.value) || 1) })} className="w-16 rounded border border-slate-200 bg-white px-2 py-1 text-center" /></td><td className="px-3 py-2"><input value={item.supplier || ''} onChange={(event) => updateBOMItem(item.id, { supplier: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Supplier" /></td><td className="px-3 py-2"><input value={item.costEstimate || ''} onChange={(event) => updateBOMItem(item.id, { costEstimate: event.target.value })} className="w-24 rounded border border-slate-200 bg-white px-2 py-1 text-right font-mono" placeholder="0.00" /></td><td className="px-3 py-2"><select value={item.status} onChange={(event) => updateBOMItem(item.id, { status: event.target.value as NonNullable<BOMItem['status']> })} className="rounded border border-slate-200 bg-white px-2 py-1">{statusOptions.map((status) => <option key={status} value={status}>{status}</option>)}</select></td></tr>;
                 })}</tbody>
               </table>
               {bom.length === 0 && <div className="p-10 text-center"><FileSpreadsheet className="mx-auto h-7 w-7 text-slate-400" /><p className="mt-2 text-sm font-bold text-slate-800">No BOM records yet</p><p className="mt-1 text-xs text-slate-500">Select a project component and create its linked sourcing record. Generic architecture blocks are not silently converted into purchasable parts.</p></div>}

--- a/src/components/studio/UnifiedBOMWorkbench.tsx
+++ b/src/components/studio/UnifiedBOMWorkbench.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import {
+  ArrowRight,
+  Boxes,
+  CheckCircle2,
+  CircuitBoard,
+  FileSpreadsheet,
+  Link2,
+  PackageSearch,
+  PenTool,
+  Plus,
+} from 'lucide-react';
+import type { BOMItem } from '../../types';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+
+const statusOptions = ['Not Started', 'Sourced', 'Ordered', 'Received', 'Tested'] as const;
+
+export const UnifiedBOMWorkbench: React.FC = () => {
+  const store = useProjectStore();
+  const {
+    bom = [],
+    boardComponents = [],
+    updateProjectState,
+    updateBOMItem,
+    updateBoardComponent,
+    setActiveView,
+  } = store;
+  const {
+    activeComponentId,
+    activeBoardId,
+    setActiveComponent,
+    beginHandoff,
+  } = useStudioContextStore();
+
+  const contextualComponents = useMemo(
+    () => boardComponents.filter((component) => !activeBoardId || component.boardId === activeBoardId),
+    [activeBoardId, boardComponents],
+  );
+  const selectedComponent = boardComponents.find((component) => component.id === activeComponentId)
+    || contextualComponents[0];
+  const selectedBomItem = selectedComponent?.bomItemId
+    ? bom.find((item) => item.id === selectedComponent.bomItemId)
+    : undefined;
+  const orderedBom = useMemo(() => {
+    if (!selectedBomItem) return bom;
+    return [selectedBomItem, ...bom.filter((item) => item.id !== selectedBomItem.id)];
+  }, [bom, selectedBomItem]);
+
+  const ensureLinkedBom = () => {
+    if (!selectedComponent || selectedBomItem) return;
+    const id = `bom_${Date.now()}`;
+    const item: BOMItem = {
+      id,
+      blockName: selectedComponent.componentName,
+      candidateComponent: selectedComponent.value || selectedComponent.componentName,
+      partNumber: '',
+      stage: 'Prototype',
+      quantity: 1,
+      voltage: selectedComponent.electrical?.supplyVoltage || '',
+      currentEstimate: selectedComponent.electrical?.currentDraw || '',
+      interface: selectedComponent.electrical?.interface || '',
+      packageSize: selectedComponent.footprint || '',
+      dimensions: selectedComponent.packageDimensions
+        ? `${selectedComponent.packageDimensions.widthMm} × ${selectedComponent.packageDimensions.heightMm} × ${selectedComponent.packageDimensions.heightZMm} mm`
+        : '',
+      costEstimate: '0.00',
+      supplier: '',
+      supplierUrl: '',
+      datasheetUrl: '',
+      status: 'Not Started',
+      risk: '',
+      alternative: '',
+      notes: `Linked to ${selectedComponent.referenceDesignator} (${selectedComponent.id}).`,
+    };
+    updateProjectState({ bom: [...bom, item] });
+    updateBoardComponent(selectedComponent.id, { bomItemId: id });
+  };
+
+  const navigate = (viewId: string) => {
+    beginHandoff('bom', 'bom');
+    setActiveView(viewId);
+  };
+
+  return (
+    <section className="h-full overflow-y-auto bg-slate-50 p-4 text-slate-900 sm:p-5 lg:p-6" aria-labelledby="unified-bom-title">
+      <div className="mx-auto max-w-7xl space-y-4">
+        <header className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">Connected sourcing record</p>
+              <h1 id="unified-bom-title" className="mt-1 text-2xl font-bold tracking-tight text-slate-950">Bill of Materials</h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">BOM records stay attached to the same component instance used in Schematic, PCB, and 3D. Selecting a component above brings its linked sourcing row to the top.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button type="button" onClick={() => navigate('component-library')} className="inline-flex h-9 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 hover:bg-slate-100"><Boxes className="h-4 w-4" /> Components</button>
+              <button type="button" onClick={() => navigate('schematic-editor')} className="inline-flex h-9 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 hover:bg-slate-100"><PenTool className="h-4 w-4" /> Schematic</button>
+              <button type="button" onClick={() => navigate('board-designer')} className="inline-flex h-9 items-center gap-2 rounded-lg bg-slate-950 px-3 text-xs font-semibold text-white hover:bg-slate-800"><CircuitBoard className="h-4 w-4" /> PCB <ArrowRight className="h-4 w-4" /></button>
+            </div>
+          </div>
+        </header>
+
+        <section className="grid gap-4 lg:grid-cols-[360px_minmax(0,1fr)]">
+          <aside className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="flex items-center gap-2"><Link2 className="h-4 w-4 text-indigo-600" /><h2 className="text-sm font-bold text-slate-950">Selected component identity</h2></div>
+            {selectedComponent ? (
+              <div className="mt-3 space-y-3">
+                <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-3"><p className="text-[10px] font-extrabold uppercase tracking-wide text-indigo-700">{selectedComponent.referenceDesignator}</p><p className="mt-1 text-sm font-bold text-slate-950">{selectedComponent.componentName}</p><p className="mt-1 font-mono text-[10px] text-slate-600">{selectedComponent.id}</p></div>
+                <dl className="grid grid-cols-2 gap-2 text-xs"><div className="rounded-lg border border-slate-200 bg-slate-50 p-2"><dt className="text-[9px] uppercase text-slate-500">Footprint</dt><dd className="mt-1 font-mono text-slate-800">{selectedComponent.footprint || 'Unresolved'}</dd></div><div className="rounded-lg border border-slate-200 bg-slate-50 p-2"><dt className="text-[9px] uppercase text-slate-500">Pins</dt><dd className="mt-1 font-bold text-slate-800">{selectedComponent.pins?.length || 0}</dd></div><div className="rounded-lg border border-slate-200 bg-slate-50 p-2"><dt className="text-[9px] uppercase text-slate-500">Schematic</dt><dd className="mt-1 text-slate-800">{selectedComponent.schematic?.placed ? 'Placed' : 'Unplaced'}</dd></div><div className="rounded-lg border border-slate-200 bg-slate-50 p-2"><dt className="text-[9px] uppercase text-slate-500">PCB</dt><dd className="mt-1 text-slate-800">{selectedComponent.pcb?.placed || selectedComponent.placementStatus === 'Placed' ? 'Placed' : 'Unplaced'}</dd></div></dl>
+                {selectedBomItem ? <div className="flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" /><p><strong>Linked BOM record:</strong> {selectedBomItem.id}. Editing the highlighted row updates this component’s sourcing record.</p></div> : <button type="button" onClick={ensureLinkedBom} className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-3 text-sm font-semibold text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"><Plus className="h-4 w-4" /> Create linked BOM record</button>}
+              </div>
+            ) : (
+              <div className="mt-3 rounded-xl border border-dashed border-slate-300 p-4 text-center"><PackageSearch className="mx-auto h-6 w-6 text-slate-400" /><p className="mt-2 text-xs text-slate-500">No canonical component instance exists in this board context.</p><button type="button" onClick={() => setActiveView('component-library')} className="mt-3 rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-100">Open Component Library</button></div>
+            )}
+
+            {contextualComponents.length > 1 && <div className="mt-4"><p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Other board components</p><div className="mt-2 max-h-48 space-y-1 overflow-y-auto">{contextualComponents.map((component) => <button key={component.id} type="button" onClick={() => setActiveComponent(component.id)} className={`flex w-full items-center justify-between rounded-lg border px-2.5 py-2 text-left text-xs ${component.id === selectedComponent?.id ? 'border-indigo-300 bg-indigo-50' : 'border-slate-200 bg-white hover:bg-slate-50'}`}><span className="font-bold text-slate-800">{component.referenceDesignator}</span><span className="max-w-[190px] truncate text-slate-500">{component.componentName}</span></button>)}</div></div>}
+          </aside>
+
+          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-4 py-3"><div className="flex items-center gap-2"><FileSpreadsheet className="h-4 w-4 text-slate-600" /><h2 className="text-sm font-bold text-slate-950">Project BOM records</h2></div><span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[10px] font-bold text-slate-600">{bom.length} records</span></div>
+            <div className="overflow-x-auto">
+              <table className="min-w-[980px] w-full border-collapse text-left text-xs">
+                <thead className="bg-white text-[9px] font-bold uppercase tracking-wide text-slate-500"><tr className="border-b border-slate-200"><th className="px-3 py-2.5">Component</th><th className="px-3 py-2.5">Part number</th><th className="px-3 py-2.5">Package</th><th className="px-3 py-2.5">Qty</th><th className="px-3 py-2.5">Supplier</th><th className="px-3 py-2.5">Unit cost</th><th className="px-3 py-2.5">Status</th></tr></thead>
+                <tbody className="divide-y divide-slate-100">{orderedBom.map((item) => {
+                  const highlighted = item.id === selectedBomItem?.id;
+                  return <tr key={item.id} className={highlighted ? 'bg-indigo-50' : 'hover:bg-slate-50'}><td className="px-3 py-2"><input value={item.blockName} onChange={(event) => updateBOMItem(item.id, { blockName: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-semibold text-slate-900 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" /></td><td className="px-3 py-2"><input value={item.partNumber || ''} onChange={(event) => updateBOMItem(item.id, { partNumber: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Manufacturer PN" /></td><td className="px-3 py-2"><input value={item.packageSize || ''} onChange={(event) => updateBOMItem(item.id, { packageSize: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Footprint/package" /></td><td className="px-3 py-2"><input type="number" min={1} value={item.quantity} onChange={(event) => updateBOMItem(item.id, { quantity: Math.max(1, Number(event.target.value) || 1) })} className="w-16 rounded border border-slate-200 bg-white px-2 py-1 text-center" /></td><td className="px-3 py-2"><input value={item.supplier || ''} onChange={(event) => updateBOMItem(item.id, { supplier: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Supplier" /></td><td className="px-3 py-2"><input value={item.costEstimate || ''} onChange={(event) => updateBOMItem(item.id, { costEstimate: event.target.value })} className="w-24 rounded border border-slate-200 bg-white px-2 py-1 text-right font-mono" placeholder="0.00" /></td><td className="px-3 py-2"><select value={item.status} onChange={(event) => updateBOMItem(item.id, { status: event.target.value })} className="rounded border border-slate-200 bg-white px-2 py-1">{statusOptions.map((status) => <option key={status} value={status}>{status}</option>)}</select></td></tr>;
+                })}</tbody>
+              </table>
+              {bom.length === 0 && <div className="p-10 text-center"><FileSpreadsheet className="mx-auto h-7 w-7 text-slate-400" /><p className="mt-2 text-sm font-bold text-slate-800">No BOM records yet</p><p className="mt-1 text-xs text-slate-500">Select a project component and create its linked sourcing record. Generic architecture blocks are not silently converted into purchasable parts.</p></div>}
+            </div>
+          </div>
+        </section>
+      </div>
+    </section>
+  );
+};

--- a/src/components/studio/UnifiedBoardDRCWorkbench.tsx
+++ b/src/components/studio/UnifiedBoardDRCWorkbench.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  CircuitBoard,
+  Component,
+  ListTree,
+  RefreshCw,
+  Route,
+  ShieldCheck,
+} from 'lucide-react';
+import { runBoardDRC } from '../../lib/boardDRC';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+import type { ReviewResult } from '../../types';
+
+const severityStyles: Record<ReviewResult['severity'], string> = {
+  Blocker: 'border-red-300 bg-red-50 text-red-950',
+  Error: 'border-red-200 bg-red-50 text-red-900',
+  Warning: 'border-amber-200 bg-amber-50 text-amber-950',
+  Info: 'border-sky-200 bg-sky-50 text-sky-950',
+};
+
+export const UnifiedBoardDRCWorkbench: React.FC = () => {
+  const project = useProjectStore();
+  const {
+    boards = [],
+    boardComponents = [],
+    nets = [],
+    traces = [],
+    setActiveView,
+    setActiveBoard,
+  } = project;
+  const {
+    activeBoardId,
+    setActiveBoard: setContextBoard,
+    setActiveComponent,
+    setActiveNet,
+    beginHandoff,
+  } = useStudioContextStore();
+  const [results, setResults] = useState<ReviewResult[]>(() => runBoardDRC(useProjectStore.getState()));
+
+  const board = boards.find((candidate) => candidate.id === activeBoardId) || boards[0];
+  const boardId = board?.id || activeBoardId || '';
+  const boardComponentIds = useMemo(
+    () => new Set(boardComponents.filter((component) => !boardId || component.boardId === boardId).map((component) => component.id)),
+    [boardComponents, boardId],
+  );
+  const boardTraceIds = useMemo(
+    () => new Set(traces.filter((trace) => !boardId || trace.boardId === boardId).map((trace) => trace.id)),
+    [boardId, traces],
+  );
+
+  const boardResults = useMemo(() => results.filter((result) => {
+    if (!boardId) return true;
+    if (result.linkedObjectType === 'board') return result.linkedObjectId === boardId;
+    if (result.linkedObjectType === 'component') return boardComponentIds.has(result.linkedObjectId);
+    if (result.linkedObjectType === 'trace') return boardTraceIds.has(result.linkedObjectId);
+    if (result.linkedObjectType === 'net') {
+      const linkedNet = nets.find((net) => net.id === result.linkedObjectId || net.netName === result.linkedObjectId);
+      return Boolean(linkedNet);
+    }
+    return true;
+  }), [boardComponentIds, boardId, boardTraceIds, nets, results]);
+
+  const counts = useMemo(() => ({
+    blockers: boardResults.filter((result) => result.severity === 'Blocker').length,
+    errors: boardResults.filter((result) => result.severity === 'Error').length,
+    warnings: boardResults.filter((result) => result.severity === 'Warning').length,
+    info: boardResults.filter((result) => result.severity === 'Info').length,
+  }), [boardResults]);
+
+  const openFinding = (result: ReviewResult) => {
+    beginHandoff('pcb-drc', 'pcb-drc');
+    if (boardId) {
+      setContextBoard(boardId);
+      setActiveBoard(boardId);
+    }
+
+    if (result.linkedObjectType === 'component') {
+      setActiveComponent(result.linkedObjectId);
+    } else if (result.linkedObjectType === 'net') {
+      const net = nets.find((candidate) => candidate.id === result.linkedObjectId || candidate.netName === result.linkedObjectId);
+      setActiveNet(net?.netName || result.linkedObjectId);
+    } else if (result.linkedObjectType === 'trace') {
+      const trace = traces.find((candidate) => candidate.id === result.linkedObjectId);
+      if (trace?.netName) setActiveNet(trace.netName);
+    }
+
+    setActiveView('board-designer');
+  };
+
+  if (!board) {
+    return (
+      <section className="grid h-full place-items-center overflow-y-auto bg-slate-50 p-6 text-center">
+        <div className="max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <CircuitBoard className="mx-auto h-8 w-8 text-slate-400" aria-hidden="true" />
+          <h1 className="mt-3 text-xl font-bold text-slate-950">Create a board before running PCB checks</h1>
+          <p className="mt-2 text-sm leading-6 text-slate-600">DRC evaluates canonical board geometry, component placement, traces, nets, and constraints. There is no board context to inspect yet.</p>
+          <button type="button" onClick={() => setActiveView('board-settings')} className="mt-4 inline-flex h-10 items-center gap-2 rounded-lg bg-slate-950 px-4 text-sm font-semibold text-white hover:bg-slate-800">Open board settings <ArrowRight className="h-4 w-4" /></button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="h-full overflow-y-auto bg-slate-50 p-4 text-slate-900 sm:p-5 lg:p-6" aria-labelledby="unified-drc-title">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <header className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-indigo-600" aria-hidden="true" /><p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">PCB checks in shared context</p></div>
+              <h1 id="unified-drc-title" className="mt-2 text-2xl font-bold tracking-tight text-slate-950">{board.name} design-rule findings</h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">Findings reference the same board components, nets, and traces used by Schematic and PCB. Open a finding to carry its responsible object back into Board Designer.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button type="button" onClick={() => setResults(runBoardDRC(useProjectStore.getState()))} className="inline-flex h-9 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 hover:bg-slate-100"><RefreshCw className="h-4 w-4" /> Run checks again</button>
+              <button type="button" onClick={() => setActiveView('board-designer')} className="inline-flex h-9 items-center gap-2 rounded-lg bg-slate-950 px-3 text-xs font-semibold text-white hover:bg-slate-800"><CircuitBoard className="h-4 w-4" /> Open PCB <ArrowRight className="h-4 w-4" /></button>
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {[
+              ['Blockers', counts.blockers, 'border-red-200 bg-red-50 text-red-900'],
+              ['Errors', counts.errors, 'border-red-200 bg-red-50 text-red-900'],
+              ['Warnings', counts.warnings, 'border-amber-200 bg-amber-50 text-amber-900'],
+              ['Information', counts.info, 'border-sky-200 bg-sky-50 text-sky-900'],
+            ].map(([label, value, style]) => (
+              <div key={String(label)} className={`rounded-xl border p-3 ${style}`}><p className="text-2xl font-bold">{value}</p><p className="mt-1 text-[9px] font-extrabold uppercase tracking-wide">{label}</p></div>
+            ))}
+          </div>
+        </header>
+
+        {boardResults.length === 0 ? (
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-8 text-center text-emerald-950 shadow-sm">
+            <CheckCircle2 className="mx-auto h-8 w-8 text-emerald-600" aria-hidden="true" />
+            <h2 className="mt-3 text-lg font-bold">No current board-rule findings</h2>
+            <p className="mt-1 text-sm text-emerald-800">This means the implemented DRC checks passed for the current project state. It is not a substitute for manufacturer review or a qualified external CAD tool.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {boardResults.map((result) => {
+              const Icon = result.linkedObjectType === 'component'
+                ? Component
+                : result.linkedObjectType === 'net'
+                  ? ListTree
+                  : result.linkedObjectType === 'trace'
+                    ? Route
+                    : AlertTriangle;
+              return (
+                <button key={result.id} type="button" onClick={() => openFinding(result)} className={`group flex w-full items-start gap-3 rounded-2xl border p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${severityStyles[result.severity]}`}>
+                  <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-white/80"><Icon className="h-4 w-4" aria-hidden="true" /></span>
+                  <span className="min-w-0 flex-1"><span className="flex flex-wrap items-center gap-2"><span className="text-sm font-bold">{result.title}</span><span className="rounded-full border border-current/20 bg-white/50 px-2 py-0.5 text-[9px] font-extrabold uppercase tracking-wide">{result.severity}</span><span className="rounded-full border border-current/20 bg-white/50 px-2 py-0.5 text-[9px] font-semibold">{result.category}</span></span><span className="mt-1 block text-xs leading-5 opacity-80">{result.description}</span><span className="mt-2 block font-mono text-[9px] opacity-65">{result.linkedObjectType}: {result.linkedObjectId}</span></span>
+                  <ArrowRight className="mt-2 h-4 w-4 shrink-0 opacity-50 transition group-hover:translate-x-0.5 group-hover:opacity-100" aria-hidden="true" />
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/src/components/studio/UnifiedValidationWorkbench.tsx
+++ b/src/components/studio/UnifiedValidationWorkbench.tsx
@@ -47,7 +47,7 @@ export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProp
       .filter((netId): netId is string => Boolean(netId)),
   ));
   const linkedTests = selectedComponent
-    ? validationTests.filter((test) => test.linkedComponentIds.includes(selectedComponent.id))
+    ? validationTests.filter((test) => (test.linkedComponentIds || []).includes(selectedComponent.id))
     : [];
 
   const createLinkedTest = () => {

--- a/src/components/studio/UnifiedValidationWorkbench.tsx
+++ b/src/components/studio/UnifiedValidationWorkbench.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import {
+  ArrowRight,
+  Boxes,
+  CheckCircle2,
+  CircuitBoard,
+  Link2,
+  Plus,
+  TestTube2,
+} from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+import { ValidationStudio } from '../validation/ValidationStudio';
+
+interface UnifiedValidationWorkbenchProps {
+  initialMode: 'tests' | 'coverage' | 'factory-qa';
+}
+
+export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProps> = ({ initialMode }) => {
+  const store = useProjectStore();
+  const {
+    boardComponents = [],
+    validationTests = [],
+    addValidationTest,
+    executeProjectCommand,
+    setActiveView,
+  } = store;
+  const {
+    activeBoardId,
+    activeComponentId,
+    activeNetName,
+    setActiveComponent,
+    beginHandoff,
+  } = useStudioContextStore();
+
+  const contextualComponents = useMemo(
+    () => boardComponents.filter((component) => !activeBoardId || component.boardId === activeBoardId),
+    [activeBoardId, boardComponents],
+  );
+  const selectedComponent = boardComponents.find((component) => component.id === activeComponentId)
+    || contextualComponents[0];
+  const selectedNetIds = Array.from(new Set(
+    (selectedComponent?.pins || [])
+      .map((pin) => pin.netId)
+      .filter((netId): netId is string => Boolean(netId)),
+  ));
+  const linkedTests = selectedComponent
+    ? validationTests.filter((test) => test.linkedComponentIds.includes(selectedComponent.id))
+    : [];
+
+  const createLinkedTest = () => {
+    if (!selectedComponent) return;
+    executeProjectCommand('ADD_COMPONENT_TEST', `Create validation test for ${selectedComponent.referenceDesignator}`, () =>
+      addValidationTest({
+        name: `${selectedComponent.referenceDesignator} ${selectedComponent.componentName} validation`,
+        stage: 'EVT',
+        category: 'Electrical',
+        linkedRequirementIds: [],
+        linkedArchitectureNodeIds: selectedComponent.architectureNodeId ? [selectedComponent.architectureNodeId] : [],
+        linkedComponentIds: [selectedComponent.id],
+        linkedNetIds: selectedNetIds,
+        linkedFirmwareModuleIds: [],
+        steps: [
+          {
+            stepNumber: 1,
+            instruction: `Inspect ${selectedComponent.referenceDesignator}, its footprint, orientation, and connected nets before applying power.`,
+            expectedResult: 'The physical and electrical implementation matches the reviewed component definition and schematic intent.',
+            completed: false,
+          },
+        ],
+        measurements: [],
+        passCriteria: [
+          `${selectedComponent.referenceDesignator} is correctly placed and electrically connected for the intended test.`,
+        ],
+        status: 'Not Started',
+        evidence: [],
+      })
+    );
+  };
+
+  const navigate = (viewId: string) => {
+    beginHandoff('validation-studio', 'validation-studio');
+    setActiveView(viewId);
+  };
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-50" aria-label="Context-aware validation workbench">
+      <header className="shrink-0 border-b border-slate-200 bg-white px-4 py-3 shadow-sm">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <TestTube2 className="h-4 w-4 text-indigo-600" aria-hidden="true" />
+              <p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">Validation in the same product context</p>
+            </div>
+            {selectedComponent ? (
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-600">
+                <strong className="text-slate-950">{selectedComponent.referenceDesignator} · {selectedComponent.componentName}</strong>
+                <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5">{linkedTests.length} linked test{linkedTests.length === 1 ? '' : 's'}</span>
+                <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5">{selectedNetIds.length} linked net{selectedNetIds.length === 1 ? '' : 's'}</span>
+                {activeNetName && <span className="rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-sky-800">Active net: {activeNetName}</span>}
+              </div>
+            ) : (
+              <p className="mt-1 text-xs text-slate-500">No component is selected. Generic requirement and factory tests remain available below.</p>
+            )}
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button type="button" onClick={() => navigate('component-library')} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100"><Boxes className="h-3.5 w-3.5" /> Components</button>
+            <button type="button" onClick={() => navigate('board-designer')} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100"><CircuitBoard className="h-3.5 w-3.5" /> PCB</button>
+            <button type="button" onClick={createLinkedTest} disabled={!selectedComponent} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-indigo-600 px-2.5 text-[10px] font-bold text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"><Plus className="h-3.5 w-3.5" /> Create linked test</button>
+          </div>
+        </div>
+
+        {selectedComponent && linkedTests.length > 0 && (
+          <div className="mt-3 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-2.5 text-[10px] leading-5 text-emerald-900">
+            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div className="min-w-0">
+              <strong>Linked validation:</strong>{' '}
+              {linkedTests.map((test) => `${test.name} (${test.status})`).join(' · ')}
+            </div>
+          </div>
+        )}
+
+        {selectedComponent && linkedTests.length === 0 && (
+          <div className="mt-3 flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-2.5 text-[10px] leading-5 text-amber-900">
+            <Link2 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <p>This component has no validation record yet. Create one here; it will store the same component ID and current net IDs instead of relying on a copied name.</p>
+          </div>
+        )}
+      </header>
+
+      <div className="min-h-0 flex-1">
+        <ValidationStudio initialMode={initialMode} />
+      </div>
+
+      <footer className="flex shrink-0 items-center justify-between border-t border-slate-200 bg-white px-4 py-1.5 text-[9px] text-slate-500">
+        <span>Validation records remain part of canonical project state.</span>
+        {selectedComponent && (
+          <button type="button" onClick={() => setActiveComponent(selectedComponent.id)} className="inline-flex items-center gap-1 font-semibold text-indigo-700 hover:text-indigo-900">
+            Keep {selectedComponent.referenceDesignator} selected <ArrowRight className="h-3 w-3" />
+          </button>
+        )}
+      </footer>
+    </section>
+  );
+};

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore, type MechanicalWorkbenchMode } from '../../store/studioContextStore';
+import { ComponentLibraryWorkbench } from '../component-library/ComponentLibraryWorkbench';
+import { SchematicEditor } from '../schematic/SchematicEditor';
+import { MechanicalStudio } from '../mechanical/MechanicalStudio';
+
+export const UnifiedComponentLibraryWorkbench: React.FC = () => {
+  const boardComponents = useProjectStore((state) => state.boardComponents || []);
+  const previousIds = useRef(new Set(boardComponents.map((component) => component.id)));
+  const setActiveBoard = useStudioContextStore((state) => state.setActiveBoard);
+  const setActiveComponent = useStudioContextStore((state) => state.setActiveComponent);
+
+  useEffect(() => {
+    const previous = previousIds.current;
+    const added = boardComponents.find((component) => !previous.has(component.id));
+    previousIds.current = new Set(boardComponents.map((component) => component.id));
+    if (!added) return;
+    setActiveBoard(added.boardId || null);
+    setActiveComponent(added.id);
+  }, [boardComponents, setActiveBoard, setActiveComponent]);
+
+  return <ComponentLibraryWorkbench />;
+};
+
+export const UnifiedSchematicWorkbench: React.FC = () => {
+  const activeComponentId = useStudioContextStore((state) => state.activeComponentId);
+  const activeBoardId = useStudioContextStore((state) => state.activeBoardId);
+  const boardComponents = useProjectStore((state) => state.boardComponents || []);
+  const placeComponentOnSchematic = useProjectStore((state) => state.placeComponentOnSchematic);
+  const setActiveComponent = useStudioContextStore((state) => state.setActiveComponent);
+
+  useEffect(() => {
+    const selected = boardComponents.find((component) => component.id === activeComponentId)
+      || boardComponents.find((component) => !activeBoardId || component.boardId === activeBoardId);
+    if (!selected) return;
+    if (!activeComponentId) setActiveComponent(selected.id);
+    if (selected.schematic?.placed) return;
+
+    const boardPeers = boardComponents.filter((component) => component.boardId === selected.boardId && component.schematic?.placed);
+    const column = boardPeers.length % 4;
+    const row = Math.floor(boardPeers.length / 4);
+    placeComponentOnSchematic(selected.id, 140 + column * 180, 140 + row * 140);
+  }, [activeBoardId, activeComponentId, boardComponents, placeComponentOnSchematic, setActiveComponent]);
+
+  return <SchematicEditor />;
+};
+
+export const UnifiedMechanicalWorkbench: React.FC<{ defaultMode: MechanicalWorkbenchMode }> = ({ defaultMode }) => {
+  const requestedMode = useStudioContextStore((state) => state.requestedMechanicalMode);
+  const resolvedMode = requestedMode || defaultMode;
+  return <MechanicalStudio key={resolvedMode} initialMode={resolvedMode} />;
+};

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -6,6 +6,7 @@ import { useStudioContextStore, type MechanicalWorkbenchMode } from '../../store
 import { ComponentLibraryWorkbench } from '../component-library/ComponentLibraryWorkbench';
 import { UnifiedSchematicEditor } from '../schematic/UnifiedSchematicEditor';
 import { MechanicalStudio } from '../mechanical/MechanicalStudio';
+import { UnifiedBoard3DView } from '../mechanical/UnifiedBoard3DView';
 
 export const UnifiedComponentLibraryWorkbench: React.FC = () => {
   const boardComponents = useProjectStore((state) => state.boardComponents || []);
@@ -51,5 +52,6 @@ export const UnifiedSchematicWorkbench: React.FC = () => {
 export const UnifiedMechanicalWorkbench: React.FC<{ defaultMode: MechanicalWorkbenchMode }> = ({ defaultMode }) => {
   const requestedMode = useStudioContextStore((state) => state.requestedMechanicalMode);
   const resolvedMode = requestedMode || defaultMode;
+  if (resolvedMode === 'webgl-3d') return <UnifiedBoard3DView />;
   return <MechanicalStudio key={resolvedMode} initialMode={resolvedMode} />;
 };

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore, type MechanicalWorkbenchMode } from '../../store/studioContextStore';
 import { ComponentLibraryWorkbench } from '../component-library/ComponentLibraryWorkbench';
+import { BoardDesigner } from '../board/BoardDesigner';
 import { UnifiedSchematicEditor } from '../schematic/UnifiedSchematicEditor';
 import { MechanicalStudio } from '../mechanical/MechanicalStudio';
 import { UnifiedBoard3DView } from '../mechanical/UnifiedBoard3DView';
@@ -29,6 +30,7 @@ export const UnifiedComponentLibraryWorkbench: React.FC = () => {
 export const UnifiedSchematicWorkbench: React.FC = () => {
   const activeComponentId = useStudioContextStore((state) => state.activeComponentId);
   const activeBoardId = useStudioContextStore((state) => state.activeBoardId);
+  const activeNetName = useStudioContextStore((state) => state.activeNetName);
   const boardComponents = useProjectStore((state) => state.boardComponents || []);
   const placeComponentOnSchematic = useProjectStore((state) => state.placeComponentOnSchematic);
   const setActiveComponent = useStudioContextStore((state) => state.setActiveComponent);
@@ -46,7 +48,14 @@ export const UnifiedSchematicWorkbench: React.FC = () => {
     placeComponentOnSchematic(selected.id, 140 + column * 180, 140 + row * 140);
   }, [activeBoardId, activeComponentId, boardComponents, placeComponentOnSchematic, setActiveComponent]);
 
-  return <UnifiedSchematicEditor />;
+  return <UnifiedSchematicEditor key={`${activeBoardId || ''}:${activeComponentId || ''}:${activeNetName || ''}`} />;
+};
+
+export const UnifiedBoardDesignerWorkbench: React.FC = () => {
+  const activeBoardId = useStudioContextStore((state) => state.activeBoardId);
+  const activeComponentId = useStudioContextStore((state) => state.activeComponentId);
+  const activeNetName = useStudioContextStore((state) => state.activeNetName);
+  return <BoardDesigner key={`${activeBoardId || ''}:${activeComponentId || ''}:${activeNetName || ''}`} />;
 };
 
 export const UnifiedMechanicalWorkbench: React.FC<{ defaultMode: MechanicalWorkbenchMode }> = ({ defaultMode }) => {

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -13,6 +13,7 @@ export const UnifiedComponentLibraryWorkbench: React.FC = () => {
   const boardComponents = useProjectStore((state) => state.boardComponents || []);
   const previousIds = useRef(new Set(boardComponents.map((component) => component.id)));
   const setActiveBoard = useStudioContextStore((state) => state.setActiveBoard);
+  const setActiveComponentDefinition = useStudioContextStore((state) => state.setActiveComponentDefinition);
   const setActiveComponent = useStudioContextStore((state) => state.setActiveComponent);
 
   useEffect(() => {
@@ -21,8 +22,9 @@ export const UnifiedComponentLibraryWorkbench: React.FC = () => {
     previousIds.current = new Set(boardComponents.map((component) => component.id));
     if (!added) return;
     setActiveBoard(added.boardId || null);
+    setActiveComponentDefinition(added.libraryId || null);
     setActiveComponent(added.id);
-  }, [boardComponents, setActiveBoard, setActiveComponent]);
+  }, [boardComponents, setActiveBoard, setActiveComponent, setActiveComponentDefinition]);
 
   return <ComponentLibraryWorkbench />;
 };
@@ -33,6 +35,7 @@ export const UnifiedSchematicWorkbench: React.FC = () => {
   const activeNetName = useStudioContextStore((state) => state.activeNetName);
   const boardComponents = useProjectStore((state) => state.boardComponents || []);
   const placeComponentOnSchematic = useProjectStore((state) => state.placeComponentOnSchematic);
+  const setActiveComponentDefinition = useStudioContextStore((state) => state.setActiveComponentDefinition);
   const setActiveComponent = useStudioContextStore((state) => state.setActiveComponent);
 
   useEffect(() => {
@@ -40,13 +43,14 @@ export const UnifiedSchematicWorkbench: React.FC = () => {
       || boardComponents.find((component) => !activeBoardId || component.boardId === activeBoardId);
     if (!selected) return;
     if (!activeComponentId) setActiveComponent(selected.id);
+    if (selected.libraryId) setActiveComponentDefinition(selected.libraryId);
     if (selected.schematic?.placed) return;
 
     const boardPeers = boardComponents.filter((component) => component.boardId === selected.boardId && component.schematic?.placed);
     const column = boardPeers.length % 4;
     const row = Math.floor(boardPeers.length / 4);
     placeComponentOnSchematic(selected.id, 140 + column * 180, 140 + row * 140);
-  }, [activeBoardId, activeComponentId, boardComponents, placeComponentOnSchematic, setActiveComponent]);
+  }, [activeBoardId, activeComponentId, boardComponents, placeComponentOnSchematic, setActiveComponent, setActiveComponentDefinition]);
 
   return <UnifiedSchematicEditor key={`${activeBoardId || ''}:${activeComponentId || ''}:${activeNetName || ''}`} />;
 };

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef } from 'react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore, type MechanicalWorkbenchMode } from '../../store/studioContextStore';
 import { ComponentLibraryWorkbench } from '../component-library/ComponentLibraryWorkbench';
-import { SchematicEditor } from '../schematic/SchematicEditor';
+import { UnifiedSchematicEditor } from '../schematic/UnifiedSchematicEditor';
 import { MechanicalStudio } from '../mechanical/MechanicalStudio';
 
 export const UnifiedComponentLibraryWorkbench: React.FC = () => {
@@ -45,7 +45,7 @@ export const UnifiedSchematicWorkbench: React.FC = () => {
     placeComponentOnSchematic(selected.id, 140 + column * 180, 140 + row * 140);
   }, [activeBoardId, activeComponentId, boardComponents, placeComponentOnSchematic, setActiveComponent]);
 
-  return <SchematicEditor />;
+  return <UnifiedSchematicEditor />;
 };
 
 export const UnifiedMechanicalWorkbench: React.FC<{ defaultMode: MechanicalWorkbenchMode }> = ({ defaultMode }) => {

--- a/src/lib/projectMigrations.ts
+++ b/src/lib/projectMigrations.ts
@@ -1,11 +1,14 @@
 // projectMigrations.ts — Phase 23 Project Import/Export Correctness and Schema Migrations
 import { Project, BoardComponent } from '../types';
+import { defaultComponents } from './components/componentLibrary';
 
 export const CURRENT_SCHEMA_VERSION = 4;
 
 export function normalizeProjectComponent(bc: Record<string, unknown>): BoardComponent {
   const compId = (bc.id as string) || `cmp_${Date.now()}_${Math.random()}`;
   const preserved = bc as unknown as Partial<BoardComponent>;
+  const libraryId = (bc.libraryId as string) || '';
+  const sourceDefinition = defaultComponents.find((definition) => definition.libraryId === libraryId);
 
   // Accept canonical project-pin fields and reusable library-definition fields.
   // Every downstream editor must receive the same BoardComponentPin shape.
@@ -55,23 +58,24 @@ export function normalizeProjectComponent(bc: Record<string, unknown>): BoardCom
     // fields that are not rewritten by migration. Canonical fields below win.
     ...preserved,
     id: compId,
-    libraryId: (bc.libraryId as string) || '',
+    libraryId,
     referenceDesignator: (bc.referenceDesignator as string) || 'U1',
-    componentName: (bc.componentName as string) || '',
-    componentType: (bc.componentType as string) || '',
-    value: (bc.value as string) || '',
-    packageName: (bc.packageName as string) || '',
-    footprint: (bc.footprint as string) || '',
-    partNumber: (bc.partNumber as string) || '',
+    componentName: (bc.componentName as string) || sourceDefinition?.name || '',
+    componentType: (bc.componentType as string) || sourceDefinition?.category || '',
+    value: (bc.value as string) || sourceDefinition?.value || '',
+    packageName: (bc.packageName as string) || sourceDefinition?.packageName || '',
+    footprint: (bc.footprint as string) || sourceDefinition?.footprintName || '',
+    partNumber: (bc.partNumber as string) || sourceDefinition?.partNumber || '',
+    manufacturer: (bc.manufacturer as string) || sourceDefinition?.manufacturer || '',
     pins,
     boardId: (bc.boardId as string) || 'board_0',
     circuitBlockId: (bc.circuitBlockId as string) || 'block_0',
     bomItemId: (bc.bomItemId as string) || '',
-    quantity: Number(bc.quantity) || 1,
+    quantity: Number(bc.quantity) || sourceDefinition?.defaultQuantity || 1,
     schematic,
     pcb,
     status: (bc.status as BoardComponent['status']) || 'Draft',
-    notes: (bc.notes as string) || '',
+    notes: (bc.notes as string) || sourceDefinition?.description || '',
 
     placementX: pcb.xMm,
     placementY: pcb.yMm,
@@ -80,7 +84,7 @@ export function normalizeProjectComponent(bc: Record<string, unknown>): BoardCom
     lockedPlacement: pcb.locked,
     placementStatus: pcb.placementStatus,
     supplier: (bc.supplier as string) || '',
-    datasheetUrl: (bc.datasheetUrl as string) || '',
+    datasheetUrl: (bc.datasheetUrl as string) || sourceDefinition?.datasheetUrl || '',
     placementCriticality: (bc.placementCriticality as BoardComponent['placementCriticality']) || 'Low'
   };
 }

--- a/src/lib/projectMigrations.ts
+++ b/src/lib/projectMigrations.ts
@@ -1,27 +1,36 @@
 // projectMigrations.ts — Phase 23 Project Import/Export Correctness and Schema Migrations
 import { Project, BoardComponent } from '../types';
 
-export const CURRENT_SCHEMA_VERSION = 4;export function normalizeProjectComponent(bc: Record<string, unknown>): BoardComponent {
+export const CURRENT_SCHEMA_VERSION = 4;
+
+export function normalizeProjectComponent(bc: Record<string, unknown>): BoardComponent {
   const compId = (bc.id as string) || `cmp_${Date.now()}_${Math.random()}`;
 
-  // Pins normalization
+  // Accept canonical project-pin fields and reusable library-definition fields.
+  // Every downstream editor must receive the same BoardComponentPin shape.
   const rawPins = (bc.pins as Record<string, unknown>[]) || [];
-  const pins = rawPins.map((p) => ({
-    id: (p.id as string) || `pin_${compId}_${p.pinNumber}`,
-    componentId: compId,
-    pinNumber: String(p.pinNumber),
-    pinName: (p.pinName as string) || `PIN${p.pinNumber}`,
-    electricalType: (p.electricalType as string) || 'Passive',
-    netId: (p.netId as string) || undefined,
-    netName: (p.netName as string) || '',
-    noConnect: !!p.noConnect,
-    required: !!p.required
-  }));
+  const pins = rawPins.map((pin, index) => {
+    const pinNumber = String(pin.pinNumber ?? pin.number ?? index + 1);
+    const pinName = String(pin.pinName ?? pin.name ?? `PIN${pinNumber}`);
+    return {
+      id: (pin.id as string) || `pin_${compId}_${pinNumber}`,
+      componentId: compId,
+      pinNumber,
+      pinName,
+      electricalType: (pin.electricalType as string) || 'Passive',
+      netId: (pin.netId as string) || undefined,
+      netName: (pin.netName as string) || '',
+      noConnect: !!pin.noConnect,
+      required: !!pin.required,
+      voltage: typeof pin.voltage === 'number' ? pin.voltage : undefined,
+      protocol: (pin.protocol as string) || undefined,
+      notes: (pin.notes as string) || undefined,
+    };
+  });
 
   const bcSchematic = bc.schematic as Record<string, unknown> | undefined;
   const bcPcb = bc.pcb as Record<string, unknown> | undefined;
 
-  // Schematic placement initialization
   const schematic = {
     placed: (bcSchematic?.placed as boolean) ?? (bc.placementX != null),
     x: (bcSchematic?.x as number) ?? (bc.placementX as number) ?? 150,
@@ -30,47 +39,45 @@ export const CURRENT_SCHEMA_VERSION = 4;export function normalizeProjectComponen
     locked: (bcSchematic?.locked as boolean) ?? false,
   };
 
-  // PCB placement initialization
   const pcb = {
     placed: (bcPcb?.placed as boolean) ?? (bc.placementX != null),
     xMm: (bcPcb?.xMm as number) ?? (bc.placementX as number) ?? 0,
     yMm: (bcPcb?.yMm as number) ?? (bc.placementY as number) ?? 0,
     rotationDeg: (bcPcb?.rotationDeg as number) ?? (bc.rotationDeg as number) ?? 0,
-    side: ((bcPcb?.side as string) || (bc.side as string) || "Top") as 'Top' | 'Bottom',
+    side: ((bcPcb?.side as string) || (bc.side as string) || 'Top') as 'Top' | 'Bottom',
     locked: (bcPcb?.locked as boolean) ?? (bc.lockedPlacement as boolean) ?? false,
-    placementStatus: ((bcPcb?.placementStatus as BoardComponent['placementStatus']) || (bc.placementStatus as BoardComponent['placementStatus']) || (bc.placementX != null ? "Placed" : "Unplaced")),
+    placementStatus: ((bcPcb?.placementStatus as BoardComponent['placementStatus']) || (bc.placementStatus as BoardComponent['placementStatus']) || (bc.placementX != null ? 'Placed' : 'Unplaced')),
   };
 
   return {
     id: compId,
-    libraryId: (bc.libraryId as string) || "",
-    referenceDesignator: (bc.referenceDesignator as string) || "U1",
-    componentName: (bc.componentName as string) || "",
-    componentType: (bc.componentType as string) || "",
-    value: (bc.value as string) || "",
-    packageName: (bc.packageName as string) || "",
-    footprint: (bc.footprint as string) || "",
-    partNumber: (bc.partNumber as string) || "",
+    libraryId: (bc.libraryId as string) || '',
+    referenceDesignator: (bc.referenceDesignator as string) || 'U1',
+    componentName: (bc.componentName as string) || '',
+    componentType: (bc.componentType as string) || '',
+    value: (bc.value as string) || '',
+    packageName: (bc.packageName as string) || '',
+    footprint: (bc.footprint as string) || '',
+    partNumber: (bc.partNumber as string) || '',
     pins,
-    boardId: (bc.boardId as string) || "board_0",
-    circuitBlockId: (bc.circuitBlockId as string) || "block_0",
-    bomItemId: (bc.bomItemId as string) || "",
+    boardId: (bc.boardId as string) || 'board_0',
+    circuitBlockId: (bc.circuitBlockId as string) || 'block_0',
+    bomItemId: (bc.bomItemId as string) || '',
     quantity: Number(bc.quantity) || 1,
     schematic,
     pcb,
-    status: (bc.status as BoardComponent['status']) || "Draft",
-    notes: (bc.notes as string) || "",
-    
-    // Synchronize flat fields
+    status: (bc.status as BoardComponent['status']) || 'Draft',
+    notes: (bc.notes as string) || '',
+
     placementX: pcb.xMm,
     placementY: pcb.yMm,
     rotationDeg: pcb.rotationDeg,
     side: pcb.side,
     lockedPlacement: pcb.locked,
     placementStatus: pcb.placementStatus,
-    supplier: (bc.supplier as string) || "",
-    datasheetUrl: (bc.datasheetUrl as string) || "",
-    placementCriticality: (bc.placementCriticality as BoardComponent['placementCriticality']) || "Low"
+    supplier: (bc.supplier as string) || '',
+    datasheetUrl: (bc.datasheetUrl as string) || '',
+    placementCriticality: (bc.placementCriticality as BoardComponent['placementCriticality']) || 'Low'
   };
 }
 
@@ -116,7 +123,6 @@ export function migrateProjectSchema(project: unknown): Project {
     migrated.schemaVersion = 1;
   }
 
-  // Ensure arrays are initialized
   if (!migrated.boards) migrated.boards = [];
   if (!migrated.circuitBlocks) migrated.circuitBlocks = [];
   if (!migrated.boardComponents) migrated.boardComponents = [];
@@ -144,12 +150,10 @@ export function migrateProjectSchema(project: unknown): Project {
   if (!migrated.firmwareModules) migrated.firmwareModules = [];
   if (!migrated.validationTests) migrated.validationTests = [];
 
-  // Migrate boardComponents pins, pcb & schematic objects if missing
-  migrated.boardComponents = (migrated.boardComponents as BoardComponent[]).map((c) => {
-    return normalizeProjectComponent(c as unknown as Record<string, unknown>);
+  migrated.boardComponents = (migrated.boardComponents as BoardComponent[]).map((component) => {
+    return normalizeProjectComponent(component as unknown as Record<string, unknown>);
   });
 
-  // Make sure version is bumped
   migrated.schemaVersion = CURRENT_SCHEMA_VERSION;
 
   return migrated;

--- a/src/lib/projectMigrations.ts
+++ b/src/lib/projectMigrations.ts
@@ -5,6 +5,7 @@ export const CURRENT_SCHEMA_VERSION = 4;
 
 export function normalizeProjectComponent(bc: Record<string, unknown>): BoardComponent {
   const compId = (bc.id as string) || `cmp_${Date.now()}_${Math.random()}`;
+  const preserved = bc as unknown as Partial<BoardComponent>;
 
   // Accept canonical project-pin fields and reusable library-definition fields.
   // Every downstream editor must receive the same BoardComponentPin shape.
@@ -50,6 +51,9 @@ export function normalizeProjectComponent(bc: Record<string, unknown>): BoardCom
   };
 
   return {
+    // Preserve reviewed representation, sourcing, qualification, and provenance
+    // fields that are not rewritten by migration. Canonical fields below win.
+    ...preserved,
     id: compId,
     libraryId: (bc.libraryId as string) || '',
     referenceDesignator: (bc.referenceDesignator as string) || 'U1',

--- a/src/store/studioContextStore.ts
+++ b/src/store/studioContextStore.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+
+export type StudioContextEntity =
+  | 'board'
+  | 'component-definition'
+  | 'component-instance'
+  | 'net'
+  | 'wire'
+  | 'trace'
+  | 'mechanical-object'
+  | 'validation-item';
+
+export interface StudioSelection {
+  entity: StudioContextEntity;
+  id: string;
+  label?: string;
+}
+
+interface StudioContextState {
+  activeBoardId: string | null;
+  activeComponentDefinitionId: string | null;
+  activeComponentId: string | null;
+  activeNetName: string | null;
+  selected: StudioSelection | null;
+  originView: string | null;
+  returnView: string | null;
+  setActiveBoard: (boardId: string | null) => void;
+  setActiveComponentDefinition: (definitionId: string | null) => void;
+  setActiveComponent: (componentId: string | null) => void;
+  setActiveNet: (netName: string | null) => void;
+  select: (selection: StudioSelection | null) => void;
+  beginHandoff: (originView: string, returnView?: string | null) => void;
+  clearContext: () => void;
+}
+
+export const useStudioContextStore = create<StudioContextState>((set) => ({
+  activeBoardId: null,
+  activeComponentDefinitionId: null,
+  activeComponentId: null,
+  activeNetName: null,
+  selected: null,
+  originView: null,
+  returnView: null,
+
+  setActiveBoard: (activeBoardId) => set({
+    activeBoardId,
+    selected: activeBoardId ? { entity: 'board', id: activeBoardId } : null,
+  }),
+  setActiveComponentDefinition: (activeComponentDefinitionId) => set({
+    activeComponentDefinitionId,
+    selected: activeComponentDefinitionId
+      ? { entity: 'component-definition', id: activeComponentDefinitionId }
+      : null,
+  }),
+  setActiveComponent: (activeComponentId) => set({
+    activeComponentId,
+    selected: activeComponentId
+      ? { entity: 'component-instance', id: activeComponentId }
+      : null,
+  }),
+  setActiveNet: (activeNetName) => set({
+    activeNetName,
+    selected: activeNetName ? { entity: 'net', id: activeNetName, label: activeNetName } : null,
+  }),
+  select: (selected) => set({ selected }),
+  beginHandoff: (originView, returnView = originView) => set({ originView, returnView }),
+  clearContext: () => set({
+    activeBoardId: null,
+    activeComponentDefinitionId: null,
+    activeComponentId: null,
+    activeNetName: null,
+    selected: null,
+    originView: null,
+    returnView: null,
+  }),
+}));

--- a/src/store/studioContextStore.ts
+++ b/src/store/studioContextStore.ts
@@ -10,6 +10,8 @@ export type StudioContextEntity =
   | 'mechanical-object'
   | 'validation-item';
 
+export type MechanicalWorkbenchMode = 'canvas' | 'assembly' | '3d-preview' | 'webgl-3d';
+
 export interface StudioSelection {
   entity: StudioContextEntity;
   id: string;
@@ -24,12 +26,14 @@ interface StudioContextState {
   selected: StudioSelection | null;
   originView: string | null;
   returnView: string | null;
+  requestedMechanicalMode: MechanicalWorkbenchMode | null;
   setActiveBoard: (boardId: string | null) => void;
   setActiveComponentDefinition: (definitionId: string | null) => void;
   setActiveComponent: (componentId: string | null) => void;
   setActiveNet: (netName: string | null) => void;
   select: (selection: StudioSelection | null) => void;
   beginHandoff: (originView: string, returnView?: string | null) => void;
+  requestMechanicalMode: (mode: MechanicalWorkbenchMode | null) => void;
   clearContext: () => void;
 }
 
@@ -41,6 +45,7 @@ export const useStudioContextStore = create<StudioContextState>((set) => ({
   selected: null,
   originView: null,
   returnView: null,
+  requestedMechanicalMode: null,
 
   setActiveBoard: (activeBoardId) => set({
     activeBoardId,
@@ -64,6 +69,7 @@ export const useStudioContextStore = create<StudioContextState>((set) => ({
   }),
   select: (selected) => set({ selected }),
   beginHandoff: (originView, returnView = originView) => set({ originView, returnView }),
+  requestMechanicalMode: (requestedMechanicalMode) => set({ requestedMechanicalMode }),
   clearContext: () => set({
     activeBoardId: null,
     activeComponentDefinitionId: null,
@@ -72,5 +78,6 @@ export const useStudioContextStore = create<StudioContextState>((set) => ({
     selected: null,
     originView: null,
     returnView: null,
+    requestedMechanicalMode: null,
   }),
 }));


### PR DESCRIPTION
## Status

Draft implementation for #64. **Do not close #64 until the exact final head passes GitHub CI, Vercel preview, acceptance review, merge, and production verification.**

## Why this PR exists

Hardware Studio had many individually implemented workbenches, but the real product journey was fragmented. PCB existed in source yet its empty state referenced a removed Dashboard generator. Schematic could create parallel component instances. Selection disappeared across editors. The earlier 3D view used the first board, provisional geometry, permanent auto-rotation, and no selected-object continuity. BOM and Validation were separate tables rather than downstream views of the same component.

This PR rebuilds the first production golden path around one canonical identity:

`Component definition → project component instance → Schematic → pins/nets → PCB → lightweight board 3D → BOM → Validation → Checks`

## Persistent Studio frame

- complete Product → Mechanical → Electronics → PCB → Firmware → Validation → Outputs build map remains visible inside Studio;
- workflow profiles control focus and emphasis instead of removing major domains from discoverability;
- connected Components → Schematic → Board setup → PCB layout → Assembly/3D → Checks path;
- shared board/component/net context bar across participating workbenches;
- context is UI-only and separate from canonical project persistence.

## Canonical object continuity

The shared Studio context carries:

- selected component-definition ID;
- selected project component-instance ID;
- active board ID;
- active net name;
- origin/return workbench;
- requested 3D mode.

Canonical engineering state remains in `boardComponents`, `boards`, `schematicWires`, `nets`, `padNetAssignments`, PCB geometry, `bom`, and `validationTests`.

## Component Library

- newly created project instances preserve source `libraryId` provenance;
- shared context records both definition and instance identity;
- downstream editors consume the same instance rather than creating parallel records.

## Unified Schematic

The live Schematic route now:

- places existing canonical project components;
- connects their actual pins and canonical nets;
- exposes the shared component inspector;
- cross-probes ERC findings;
- opens PCB or Board Settings with the same context;
- removes the duplicate in-editor component-creation path;
- replaces `window.confirm` with an in-app Radix dependency review for whole-product deletion.

## PCB recovery and context

Board Designer now:

- creates a real starter board/outline or routes to Board Settings, Component Library, and Schematic;
- no longer references the removed Dashboard generator;
- initializes from shared board/component/net context;
- scopes auto-placement and rough autorouting to the active board;
- preserves selection through the context-keyed adapter.

## Central pin and migration fix

The golden-path integration test exposed a real canonical bug: reusable library pins use `{number, name}`, while project editors require `{pinNumber, pinName}`. Central normalization now converts them and preserves electrical metadata, allowing the same pin/net truth to appear in component records, Schematic wires, pad assignments, PCB, and Validation.

Migration normalization also preserves optional reviewed representation, package, sourcing, and CAD provenance fields instead of silently dropping them.

## Selected-board lightweight 3D

The connected 3D route:

- renders only the selected board;
- highlights the selected canonical component;
- uses board outline and package dimensions when available;
- labels provisional envelopes when dimensions are missing;
- lists unplaced components instead of fabricating positions;
- requests a low-power WebGL context;
- renders only on interaction, resize, or visibility return;
- has no permanent animation loop or auto-rotation;
- releases controls, geometry, materials, renderer, and WebGL context on close;
- remains explicitly preview-only, not exact CAD authority.

## BOM continuity

- selected component’s `bomItemId` links its sourcing record;
- linked row is shown first;
- creating a record updates the same canonical component;
- part, package, supplier, datasheet, quantity, and cost remain editable;
- unqualified electrical values stay blank rather than being inferred.

## Validation continuity

- selected component and active net remain visible above the existing Validation Studio;
- creating a linked test stores the same `linkedComponentIds`, canonical `linkedNetIds`, and architecture link when available;
- generic requirement and factory validation remain available.

## Real Checks workbench

The connected-path Checks step now opens a dedicated board-context DRC workbench rather than opening PCB Inspector:

- runs current `runBoardDRC` checks;
- scopes findings to the active board;
- shows blocker/error/warning/info counts;
- component findings select the responsible component;
- net and trace findings restore the responsible net;
- findings route back to Board Designer with shared context.

## Tests

Contract and integration coverage enforce:

- all seven product domains remain discoverable;
- the connected Electronics/PCB/3D/Checks path remains stable;
- shared definition/instance/board/net context survives handoffs;
- clearing UI context cannot mutate project engineering records;
- the dead Dashboard PCB instruction cannot return;
- live routes use unified Schematic, PCB, 3D, BOM, Validation, and Checks surfaces;
- touched Schematic flow contains no native browser confirmation;
- 3D remains selected-board, event-driven, low-power, and non-authoritative;
- one real store-level journey preserves the same definition IDs, project instance IDs, pins, wire, net, board, Schematic placement, PCB placement, BOM link, and Validation links;
- migration normalizes legacy/library pins and preserves optional representation/CAD metadata.

## Architecture record

`docs/architecture/UNIFIED_STUDIO_GOLDEN_PATH.md` defines canonical ownership, UI-only context, trust boundaries, editor handoffs, and empty-state rules.

## Required before leaving draft

- exact final GitHub Actions head passes clean install, lint, TypeScript, full tests, and production build;
- exact final Vercel preview is READY and `/studio` is healthy;
- no unresolved review feedback;
- acceptance audit confirms all handoffs use the same object identity;
- PR is marked ready and squash-merged;
- merged `master` production deployment is READY;
- public `hardware-studio.vercel.app/studio` returns HTTP 200;
- #64 receives full completion evidence.

## Explicit boundaries

This PR completes the first unified product golden path. It does **not** claim that all of Hardware Studio is finished, that exact CAD/STEP/B-Rep infrastructure is complete, or that every workbench has reached mature commercial-tool depth. Parent shell, visual-import, CAD-kernel, and broader editor-depth issues remain open.