### PR TITLE
Build the end-to-end Product Design workbench

### DIFF
--- a/docs/research/PRODUCT_DESIGN_EDITOR.md
+++ b/docs/research/PRODUCT_DESIGN_EDITOR.md
@@ -1,0 +1,229 @@
+# Product Design editor research and product decisions
+
+Status: active implementation research for issue #67.
+Date: 2026-08-04.
+
+## Purpose
+
+Hardware Studio needs a useful early product-design workbench, not another architecture dashboard and not a false mechanical CAD claim. This research identifies patterns worth adopting from mature open-source tools and deliberately reduces them into a beginner-readable workflow.
+
+The first Product Design journey is:
+
+`Document → layers → objects → dimensions/notes → concept part → lightweight 3D → checkpoint → reload/export`
+
+## Penpot
+
+Official sources:
+
+- https://github.com/penpot/penpot
+- https://help.penpot.app/technical-guide/developer/architecture/
+- https://help.penpot.app/user-guide/first-steps/the-interface/
+- https://help.penpot.app/user-guide/design-systems/components/
+- https://help.penpot.app/user-guide/export-import/penpot-file-format/
+
+License: Mozilla Public License 2.0.
+
+Patterns adopted:
+
+- one workspace with a viewport, layers, properties, history and visible file status;
+- reusable definition/instance thinking rather than copied names;
+- explicit separation between structured design data and binary media assets;
+- document export with a manifest/version and referenced objects;
+- contextual properties instead of one universal form.
+
+Patterns intentionally not copied:
+
+- the complete design-system, prototyping, inspect and collaboration surface;
+- Penpot source code or internal Clojure/ClojureScript architecture;
+- UI density intended for expert interface designers.
+
+Hardware Studio simplification:
+
+- Product Design begins with layers and common concept objects;
+- advanced libraries and variants do not appear until reusable concept definitions exist;
+- engineering authority is shown directly in the inspector.
+
+## Excalidraw
+
+Official source:
+
+- https://github.com/excalidraw/excalidraw
+
+License: MIT for the open-source editor repository; verify each bundled asset separately before reuse.
+
+Patterns adopted:
+
+- approachable direct manipulation;
+- clear select/draw/pan modes;
+- useful keyboard shortcuts;
+- low-friction object creation;
+- exportable document state;
+- beginner-friendly empty canvas behavior.
+
+Patterns intentionally not copied:
+
+- hand-drawn visual identity as the default engineering language;
+- collaboration implementation;
+- application source code or bundled assets.
+
+Hardware Studio simplification:
+
+- direct manipulation remains simple, but object dimensions, units, materials and authority are first-class;
+- visual playfulness cannot obscure whether geometry is provisional.
+
+## Konva and layered canvas architecture
+
+Official sources:
+
+- https://konvajs.org/docs/overview.html
+- https://konvajs.org/docs/performance/All_Performance_Tips.html
+
+License: MIT.
+
+Patterns adopted:
+
+- explicit stage/layer/group/shape hierarchy;
+- keep rendering layers few;
+- avoid event listeners on non-interactive content;
+- isolate high-frequency drag rendering from persisted commands;
+- render only changed content.
+
+Implementation decision:
+
+The first slice uses a dependency-free SVG editor because the repository does not currently include Konva and adding a new canvas runtime plus lockfile churn would delay the usable vertical slice. The domain and command model are renderer-independent. Konva remains a valid later renderer if SVG performance measurements show a real need.
+
+## FreeCAD Sketcher and Part Design
+
+Official sources:
+
+- https://github.com/FreeCAD/FreeCAD-documentation/blob/main/wiki/Sketcher_Workbench.md
+- https://github.com/FreeCAD/FreeCAD-documentation/blob/main/wiki/PartDesign_Workbench.md
+- https://www.freecad.org/features.php
+
+License: FreeCAD is LGPL-2.1-or-later; documentation licensing must be checked separately before reuse.
+
+Patterns adopted:
+
+- separate a 2D sketch/concept from later solid features;
+- keep simple sketches manageable rather than creating one giant sketch;
+- distinguish snapping from actual geometric constraints;
+- expose dimensions and degrees of authority clearly;
+- later exact mechanical work should consume product concepts rather than silently replacing their identity.
+
+Patterns intentionally not copied:
+
+- full constraint solving;
+- feature-history CAD;
+- exact B-Rep/STEP authority;
+- desktop workbench complexity.
+
+Hardware Studio simplification:
+
+- Product Design dimensions document intent but do not claim a solved parametric sketch;
+- concept parts contain explicit width, height and depth for derived lightweight 3D;
+- exact CAD is a later Mechanical responsibility.
+
+## Persistence research
+
+Official sources:
+
+- https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB
+- https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/transaction
+- https://pglite.dev/docs/
+- https://pglite.dev/docs/filesystems
+- https://supabase.com/docs/guides/database/postgres/row-level-security
+- https://supabase.com/docs/guides/storage/security/access-control
+
+### Decision: native IndexedDB for the first production slice
+
+Reasons:
+
+- no new runtime dependency or large WebAssembly database bundle;
+- transactional object stores are sufficient for documents, assets and named checkpoints;
+- binary `Blob` assets can be stored directly;
+- the editor remains usable offline without credentials;
+- repository interfaces keep a later PGlite/PostgreSQL implementation possible.
+
+PGlite remains a strong later option when Hardware Studio needs local PostgreSQL query compatibility across multiple mature domains. It is not required to prove the first Product Design product journey.
+
+### Cloud boundary
+
+Supabase remains the intended authenticated cloud target because PostgreSQL rows and Storage assets can be protected with row-level security. Cloud sync is not claimed in issue #67 until a real environment, policies and failure handling are verified.
+
+## Canonical product model
+
+Persisted:
+
+- Product Design documents;
+- layers;
+- design objects;
+- reference assets;
+- concept-part properties;
+- named checkpoints;
+- document schema version and timestamps.
+
+Session-only:
+
+- active tool;
+- hover state;
+- current selection;
+- marquee rectangle;
+- drag/resize preview;
+- pan and zoom;
+- open panel state;
+- temporary asset object URLs.
+
+Derived:
+
+- selection bounds;
+- visible ordered objects;
+- SVG rendering nodes;
+- lightweight 3D meshes;
+- missing-asset findings;
+- save-status labels.
+
+## Simplicity rules
+
+1. A user sees no more than the tools needed for the current task.
+2. The layer tree controls organisation; the inspector controls selected-object properties.
+3. Drawing creates a real object immediately; pointer movement is transient and one command is committed on completion.
+4. Dimensions are labelled `intent` until an exact Mechanical model owns them.
+5. A concept part is created from selected design objects and keeps one stable ID in 2D and 3D.
+6. Advanced operations are available through contextual controls rather than permanent toolbars.
+7. Save, error and checkpoint state remain visible.
+8. No native browser alert, confirm or prompt is used.
+9. The editor must remain useful without sign-in.
+10. The product map remains visible so Product Design never becomes another isolated application.
+
+## Performance rules
+
+- keep the SVG DOM proportional to visible objects;
+- do not persist pointer-move frames;
+- one logical drag/resize becomes one undoable command;
+- use a single SVG grid definition;
+- lazy-mount Three.js only when 3D preview opens;
+- render Three.js on interaction and scene changes, not through a permanent loop;
+- revoke object URLs and dispose WebGL resources;
+- keep reference-image files in the asset store rather than base64 inside document JSON.
+
+## Trust boundary
+
+Product Design is authoritative for:
+
+- product intent;
+- visual arrangement;
+- concept dimensions and annotations;
+- reference provenance;
+- concept-part identity;
+- appearance intent.
+
+Product Design is not authoritative for:
+
+- exact manufacturable geometry;
+- tolerance stacks;
+- interference clearance;
+- mass properties;
+- STEP/B-Rep output;
+- tooling or fabrication release.
+
+Those claims require later Mechanical/CAD qualification.

--- a/src/__tests__/productDesignImportPolicy.test.ts
+++ b/src/__tests__/productDesignImportPolicy.test.ts
@@ -86,9 +86,19 @@ describe('Product Design import policy', () => {
     expect(imported.document.name).toContain('imported copy');
     expect([...newObjectIds].every((id) => !oldObjectIds.has(id))).toBe(true);
     expect(imported.document.layers[0].id).not.toBe(bundle.document.layers[0].id);
+
     expect(importedReference?.type).toBe('reference-image');
-    expect(importedReference?.type === 'reference-image' && imported.assets[0].id).toBe(importedReference.assetId);
-    expect(importedConcept?.type === 'concept-part' && importedConcept.sourceObjectIds.every((id) => newObjectIds.has(id))).toBe(true);
+    if (!importedReference || importedReference.type !== 'reference-image') {
+      throw new Error('Expected a remapped reference image.');
+    }
+    expect(imported.assets[0].id).toBe(importedReference.assetId);
+
+    expect(importedConcept?.type).toBe('concept-part');
+    if (!importedConcept || importedConcept.type !== 'concept-part') {
+      throw new Error('Expected a remapped concept part.');
+    }
+    expect(importedConcept.sourceObjectIds.every((id) => newObjectIds.has(id))).toBe(true);
+
     expect(imported.checkpoints[0].documentId).toBe(imported.document.id);
     expect(imported.checkpoints[0].document.id).toBe(imported.document.id);
   });

--- a/src/__tests__/productDesignImportPolicy.test.ts
+++ b/src/__tests__/productDesignImportPolicy.test.ts
@@ -11,12 +11,17 @@ function exportedBundle(): ProductDesignExportBundle {
   const document = createProductDesignDocument('source-project', 'Wearable concept');
   const layerId = document.layers[0].id;
   const rectangle = createProductDesignObject(document, 'rectangle', layerId, 80, 90);
+  const referenceBase = createProductDesignObject(document, 'reference-image', layerId, 260, 90);
+  const conceptBase = createProductDesignObject(document, 'concept-part', layerId, 80, 260);
+  if (referenceBase.type !== 'reference-image' || conceptBase.type !== 'concept-part') {
+    throw new Error('Product Design fixture creation returned an unexpected object type.');
+  }
   const reference = {
-    ...createProductDesignObject(document, 'reference-image', layerId, 260, 90),
+    ...referenceBase,
     assetId: createProductDesignId('asset'),
   };
   const concept = {
-    ...createProductDesignObject(document, 'concept-part', layerId, 80, 260),
+    ...conceptBase,
     sourceObjectIds: [rectangle.id, reference.id],
   };
   document.objects = [rectangle, reference, concept];

--- a/src/__tests__/productDesignImportPolicy.test.ts
+++ b/src/__tests__/productDesignImportPolicy.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createProductDesignDocument,
+  createProductDesignId,
+  createProductDesignObject,
+} from '../lib/product-design/model';
+import { prepareProductDesignImport } from '../lib/product-design/importPolicy';
+import type { ProductDesignExportBundle } from '../lib/product-design/types';
+
+function exportedBundle(): ProductDesignExportBundle {
+  const document = createProductDesignDocument('source-project', 'Wearable concept');
+  const layerId = document.layers[0].id;
+  const rectangle = createProductDesignObject(document, 'rectangle', layerId, 80, 90);
+  const reference = {
+    ...createProductDesignObject(document, 'reference-image', layerId, 260, 90),
+    assetId: createProductDesignId('asset'),
+  };
+  const concept = {
+    ...createProductDesignObject(document, 'concept-part', layerId, 80, 260),
+    sourceObjectIds: [rectangle.id, reference.id],
+  };
+  document.objects = [rectangle, reference, concept];
+
+  return {
+    format: 'hardware-studio-product-design',
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    document,
+    assets: [{
+      id: reference.assetId,
+      documentId: document.id,
+      fileName: 'reference.png',
+      mimeType: 'image/png',
+      size: 4,
+      sourceUrl: '',
+      attribution: 'User supplied',
+      license: 'User owned',
+      altText: 'Reference',
+      createdAt: new Date().toISOString(),
+      dataUrl: 'data:image/png;base64,AQIDBA==',
+    }],
+    checkpoints: [{
+      id: createProductDesignId('checkpoint'),
+      documentId: document.id,
+      name: 'First direction',
+      description: '',
+      createdAt: new Date().toISOString(),
+      document,
+    }],
+  };
+}
+
+describe('Product Design import policy', () => {
+  it('preserves original document and object identities in an empty target project', () => {
+    const bundle = exportedBundle();
+    const plan = prepareProductDesignImport(
+      JSON.stringify(bundle),
+      [],
+      bundle.document.projectId,
+    );
+    const imported = JSON.parse(plan.serializedBundle) as ProductDesignExportBundle;
+
+    expect(plan.mode).toBe('preserve-identities');
+    expect(imported.document.id).toBe(bundle.document.id);
+    expect(imported.document.objects.map((object) => object.id)).toEqual(
+      bundle.document.objects.map((object) => object.id),
+    );
+  });
+
+  it('creates a fully remapped copy instead of overwriting an existing document', () => {
+    const bundle = exportedBundle();
+    const plan = prepareProductDesignImport(
+      JSON.stringify(bundle),
+      [bundle.document],
+      'target-project',
+    );
+    const imported = JSON.parse(plan.serializedBundle) as ProductDesignExportBundle;
+    const oldObjectIds = new Set(bundle.document.objects.map((object) => object.id));
+    const newObjectIds = new Set(imported.document.objects.map((object) => object.id));
+    const importedReference = imported.document.objects.find((object) => object.type === 'reference-image');
+    const importedConcept = imported.document.objects.find((object) => object.type === 'concept-part');
+
+    expect(plan.mode).toBe('create-conflict-safe-copy');
+    expect(imported.document.id).not.toBe(bundle.document.id);
+    expect(imported.document.projectId).toBe('target-project');
+    expect(imported.document.name).toContain('imported copy');
+    expect([...newObjectIds].every((id) => !oldObjectIds.has(id))).toBe(true);
+    expect(imported.document.layers[0].id).not.toBe(bundle.document.layers[0].id);
+    expect(importedReference?.type).toBe('reference-image');
+    expect(importedReference?.type === 'reference-image' && imported.assets[0].id).toBe(importedReference.assetId);
+    expect(importedConcept?.type === 'concept-part' && importedConcept.sourceObjectIds.every((id) => newObjectIds.has(id))).toBe(true);
+    expect(imported.checkpoints[0].documentId).toBe(imported.document.id);
+    expect(imported.checkpoints[0].document.id).toBe(imported.document.id);
+  });
+
+  it('rebases a document from another project even when its ID does not collide', () => {
+    const bundle = exportedBundle();
+    const plan = prepareProductDesignImport(
+      JSON.stringify(bundle),
+      [],
+      'different-project',
+    );
+    const imported = JSON.parse(plan.serializedBundle) as ProductDesignExportBundle;
+
+    expect(plan.mode).toBe('create-conflict-safe-copy');
+    expect(imported.document.projectId).toBe('different-project');
+    expect(imported.document.id).not.toBe(bundle.document.id);
+  });
+});

--- a/src/__tests__/productDesignIntegration.test.ts
+++ b/src/__tests__/productDesignIntegration.test.ts
@@ -17,11 +17,12 @@ describe('Product Design Studio integration contracts', () => {
     expect(getNavigationItem('product-architecture')?.id).toBe('product-architecture');
   });
 
-  it('routes the active Product view into the correct ProductStudio mode', () => {
+  it('routes the active Product view into the correct ProductStudio mode and recovery boundary', () => {
     const appShell = source('../components/AppShell.tsx');
     const productStudio = source('../components/product/ProductStudio.tsx');
     expect(appShell).toContain('<ProductStudio initialMode={viewId} />');
     expect(productStudio).toContain("activeMode === 'product-design'");
+    expect(productStudio).toContain('<ProductDesignSafetyBoundary />');
     expect(productStudio).toContain('<ProductDesignStudio />');
     expect(productStudio).toContain("activeMode === 'requirements'");
     expect(productStudio).toContain("activeMode === 'product-architecture'");
@@ -35,6 +36,8 @@ describe('Product Design Studio integration contracts', () => {
     expect(repository).toContain("const ASSETS_STORE = 'assets'");
     expect(repository).toContain("const CHECKPOINTS_STORE = 'checkpoints'");
     expect(repository).toContain("database.transaction(DOCUMENTS_STORE, 'readwrite')");
+    expect(repository).toContain('deleteRecordsByIndex');
+    expect(repository).toContain('openCursor(IDBKeyRange.only(value))');
     expect(store).not.toContain('localStorage.setItem');
     expect(store).not.toContain('localStorage.getItem');
   });
@@ -49,6 +52,18 @@ describe('Product Design Studio integration contracts', () => {
     expect(canvas).not.toContain('saveDocument(');
   });
 
+  it('uses a conflict-safe import policy and repairs the existing reference identity', () => {
+    const importPolicy = source('../lib/product-design/importPolicy.ts');
+    const safetyBoundary = source('../components/product-design/ProductDesignSafetyBoundary.tsx');
+    expect(importPolicy).toContain("mode: 'create-conflict-safe-copy'");
+    expect(importPolicy).toContain('objectIdMap');
+    expect(importPolicy).toContain('assetIdMap');
+    expect(safetyBoundary).toContain('prepareProductDesignImport');
+    expect(safetyBoundary).toContain('repository.saveAsset(asset)');
+    expect(safetyBoundary).toContain('id: reference.assetId');
+    expect(safetyBoundary).toContain("'Relink reference image'");
+  });
+
   it('uses an event-driven low-power 3D preview and releases WebGL resources', () => {
     const view3d = source('../components/product-design/ProductDesign3DPreview.tsx');
     expect(view3d).toContain("powerPreference: 'low-power'");
@@ -61,9 +76,10 @@ describe('Product Design Studio integration contracts', () => {
 
   it('does not use native blocking dialogs in the touched Product Design flow', () => {
     const studio = source('../components/product-design/ProductDesignStudio.tsx');
+    const safetyBoundary = source('../components/product-design/ProductDesignSafetyBoundary.tsx');
     const canvas = source('../components/product-design/ProductDesignCanvas.tsx');
     const view3d = source('../components/product-design/ProductDesign3DPreview.tsx');
-    for (const file of [studio, canvas, view3d]) {
+    for (const file of [studio, safetyBoundary, canvas, view3d]) {
       expect(file).not.toContain('window.alert');
       expect(file).not.toContain('window.confirm');
       expect(file).not.toContain('window.prompt');

--- a/src/__tests__/productDesignIntegration.test.ts
+++ b/src/__tests__/productDesignIntegration.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { getNavigationItem } from '../lib/navigationRegistry';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('Product Design Studio integration contracts', () => {
+  it('registers Product Design as a distinct connected workbench', () => {
+    expect(getNavigationItem('product-design')).toMatchObject({
+      label: 'Product Design',
+      surface: 'product-studio',
+      badge: 'DESIGN',
+    });
+    expect(getNavigationItem('requirements')?.id).toBe('requirements');
+    expect(getNavigationItem('product-architecture')?.id).toBe('product-architecture');
+  });
+
+  it('routes the active Product view into the correct ProductStudio mode', () => {
+    const appShell = source('../components/AppShell.tsx');
+    const productStudio = source('../components/product/ProductStudio.tsx');
+    expect(appShell).toContain('<ProductStudio initialMode={viewId} />');
+    expect(productStudio).toContain("activeMode === 'product-design'");
+    expect(productStudio).toContain('<ProductDesignStudio />');
+    expect(productStudio).toContain("activeMode === 'requirements'");
+    expect(productStudio).toContain("activeMode === 'product-architecture'");
+  });
+
+  it('uses IndexedDB repositories instead of placing Product Design documents in localStorage', () => {
+    const repository = source('../lib/product-design/repository.ts');
+    const store = source('../store/productDesignStore.ts');
+    expect(repository).toContain("const DATABASE_NAME = 'hardware-studio-product-design'");
+    expect(repository).toContain("const DOCUMENTS_STORE = 'documents'");
+    expect(repository).toContain("const ASSETS_STORE = 'assets'");
+    expect(repository).toContain("const CHECKPOINTS_STORE = 'checkpoints'");
+    expect(repository).toContain("database.transaction(DOCUMENTS_STORE, 'readwrite')");
+    expect(store).not.toContain('localStorage.setItem');
+    expect(store).not.toContain('localStorage.getItem');
+  });
+
+  it('keeps pointer previews separate and commits one logical persisted command', () => {
+    const store = source('../store/productDesignStore.ts');
+    const canvas = source('../components/product-design/ProductDesignCanvas.tsx');
+    expect(store).toContain('previewPatches');
+    expect(store).toContain('commitPreviewPatches');
+    expect(canvas).toContain("commitPreviewPatches('Move design objects')");
+    expect(canvas).toContain("commitPreviewPatches('Resize design object')");
+    expect(canvas).not.toContain('saveDocument(');
+  });
+
+  it('uses an event-driven low-power 3D preview and releases WebGL resources', () => {
+    const view3d = source('../components/product-design/ProductDesign3DPreview.tsx');
+    expect(view3d).toContain("powerPreference: 'low-power'");
+    expect(view3d).toContain("controls.addEventListener('change', render)");
+    expect(view3d).toContain("window.document.addEventListener('visibilitychange'");
+    expect(view3d).toContain('renderer.forceContextLoss()');
+    expect(view3d).not.toContain('requestAnimationFrame');
+    expect(view3d).toContain('not exact CAD');
+  });
+
+  it('does not use native blocking dialogs in the touched Product Design flow', () => {
+    const studio = source('../components/product-design/ProductDesignStudio.tsx');
+    const canvas = source('../components/product-design/ProductDesignCanvas.tsx');
+    const view3d = source('../components/product-design/ProductDesign3DPreview.tsx');
+    for (const file of [studio, canvas, view3d]) {
+      expect(file).not.toContain('window.alert');
+      expect(file).not.toContain('window.confirm');
+      expect(file).not.toContain('window.prompt');
+    }
+  });
+});

--- a/src/__tests__/productDesignModel.test.ts
+++ b/src/__tests__/productDesignModel.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createProductDesignDocument,
+  createProductDesignLayer,
+  createProductDesignObject,
+  getProductDesignSelectionBounds,
+  normalizeProductDesignDocument,
+  snapProductDesignValue,
+} from '../lib/product-design/model';
+
+describe('Product Design document model', () => {
+  it('creates a beginner-ready document with stable IDs and one usable layer', () => {
+    const document = createProductDesignDocument('project-alpha', 'Portable device concept', 'mm');
+
+    expect(document).toMatchObject({
+      projectId: 'project-alpha',
+      name: 'Portable device concept',
+      units: 'mm',
+      schemaVersion: 1,
+      revision: 1,
+      canvas: expect.objectContaining({ gridVisible: true, snapToGrid: true, gridSize: 10 }),
+    });
+    expect(document.id).toMatch(/^design_/);
+    expect(document.layers).toHaveLength(1);
+    expect(document.layers[0]).toMatchObject({ documentId: document.id, name: 'Concept', visible: true, locked: false });
+  });
+
+  it('creates truthful defaults for design objects and concept parts', () => {
+    const document = createProductDesignDocument('project-alpha');
+    const layerId = document.layers[0].id;
+    const rectangle = createProductDesignObject(document, 'rectangle', layerId, 100, 120);
+    const dimension = createProductDesignObject(document, 'dimension', layerId, 100, 280);
+    const concept = createProductDesignObject(document, 'concept-part', layerId, 320, 120);
+
+    expect(rectangle).toMatchObject({ type: 'rectangle', authority: 'concept', x: 100, y: 120 });
+    expect(dimension).toMatchObject({ type: 'dimension', authority: 'intent', units: 'mm', suffix: ' intent' });
+    expect(concept).toMatchObject({
+      type: 'concept-part',
+      authority: 'concept',
+      material: 'Unspecified polymer',
+      finish: 'Concept finish',
+      sourceObjectIds: [],
+    });
+    expect(new Set([rectangle.id, dimension.id, concept.id]).size).toBe(3);
+  });
+
+  it('calculates selection bounds and grid snapping without persisting pointer frames', () => {
+    const document = createProductDesignDocument('project-alpha');
+    const layerId = document.layers[0].id;
+    const first = { ...createProductDesignObject(document, 'rectangle', layerId, 20, 30), width: 100, height: 80 };
+    const second = { ...createProductDesignObject(document, 'ellipse', layerId, 150, 100), width: 60, height: 40 };
+
+    expect(getProductDesignSelectionBounds([first, second], [first.id, second.id])).toEqual({
+      x: 20,
+      y: 30,
+      width: 190,
+      height: 110,
+    });
+    expect(snapProductDesignValue(47, 10, true)).toBe(50);
+    expect(snapProductDesignValue(47, 10, false)).toBe(47);
+  });
+
+  it('normalizes imported documents while preserving valid identities and repairing missing layer links', () => {
+    const original = createProductDesignDocument('project-alpha', 'Imported concept');
+    const secondLayer = createProductDesignLayer(original.id, 'Annotations', 1);
+    const object = createProductDesignObject(original, 'note', 'missing-layer', 50, 60);
+
+    const normalized = normalizeProductDesignDocument({
+      ...original,
+      layers: [original.layers[0], secondLayer],
+      objects: [{ ...object, name: '', opacity: undefined }],
+      schemaVersion: 99,
+    });
+
+    expect(normalized.id).toBe(original.id);
+    expect(normalized.schemaVersion).toBe(1);
+    expect(normalized.objects[0].id).toBe(object.id);
+    expect(normalized.objects[0].layerId).toBe(original.layers[0].id);
+    expect(normalized.objects[0].name).toContain('note');
+    expect(normalized.objects[0].opacity).toBe(1);
+  });
+});

--- a/src/__tests__/productDesignRepository.test.ts
+++ b/src/__tests__/productDesignRepository.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { createProductDesignDocument, createProductDesignId } from '../lib/product-design/model';
+import { MemoryProductDesignRepository } from '../lib/product-design/repository';
+import type { ProductDesignAsset, ProductDesignCheckpoint } from '../lib/product-design/types';
+
+describe('Product Design repository contract', () => {
+  it('stores independent project documents and returns defensive clones', async () => {
+    const repository = new MemoryProductDesignRepository();
+    const first = createProductDesignDocument('project-a', 'First concept');
+    const second = createProductDesignDocument('project-b', 'Other project');
+
+    await repository.saveDocument(first);
+    await repository.saveDocument(second);
+
+    const documents = await repository.listDocuments('project-a');
+    expect(documents).toHaveLength(1);
+    expect(documents[0].id).toBe(first.id);
+
+    documents[0].name = 'Mutated outside repository';
+    expect((await repository.getDocument(first.id))?.name).toBe('First concept');
+  });
+
+  it('stores binary reference assets separately from document JSON', async () => {
+    const repository = new MemoryProductDesignRepository();
+    const document = createProductDesignDocument('project-a');
+    const asset: ProductDesignAsset = {
+      id: createProductDesignId('asset'),
+      documentId: document.id,
+      fileName: 'reference.png',
+      mimeType: 'image/png',
+      size: 4,
+      sourceUrl: '',
+      attribution: 'Original concept photo',
+      license: 'User-owned',
+      altText: 'Product reference',
+      blob: new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/png' }),
+      createdAt: new Date().toISOString(),
+    };
+
+    await repository.saveDocument(document);
+    await repository.saveAsset(asset);
+
+    expect((await repository.getAsset(asset.id))?.blob.size).toBe(4);
+    expect(await repository.listAssets(document.id)).toHaveLength(1);
+    expect(JSON.stringify(document)).not.toContain('data:image');
+  });
+
+  it('stores named checkpoints and removes dependent records with a document', async () => {
+    const repository = new MemoryProductDesignRepository();
+    const document = createProductDesignDocument('project-a');
+    const checkpoint: ProductDesignCheckpoint = {
+      id: createProductDesignId('checkpoint'),
+      documentId: document.id,
+      name: 'Initial direction',
+      description: '',
+      createdAt: new Date().toISOString(),
+      document,
+    };
+    const asset: ProductDesignAsset = {
+      id: createProductDesignId('asset'),
+      documentId: document.id,
+      fileName: 'reference.png',
+      mimeType: 'image/png',
+      size: 1,
+      sourceUrl: '',
+      attribution: '',
+      license: '',
+      altText: '',
+      blob: new Blob(['x'], { type: 'image/png' }),
+      createdAt: new Date().toISOString(),
+    };
+
+    await repository.saveDocument(document);
+    await repository.saveCheckpoint(checkpoint);
+    await repository.saveAsset(asset);
+    expect(await repository.listCheckpoints(document.id)).toHaveLength(1);
+
+    await repository.deleteDocument(document.id);
+
+    expect(await repository.getDocument(document.id)).toBeNull();
+    expect(await repository.listCheckpoints(document.id)).toEqual([]);
+    expect(await repository.listAssets(document.id)).toEqual([]);
+  });
+});

--- a/src/__tests__/productDesignStore.test.ts
+++ b/src/__tests__/productDesignStore.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MemoryProductDesignRepository } from '../lib/product-design/repository';
+import { useProductDesignStore } from '../store/productDesignStore';
+
+async function flushPersistence(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('Product Design command store', () => {
+  beforeEach(() => {
+    useProductDesignStore.getState().resetForTests();
+    useProductDesignStore.getState().setRepository(new MemoryProductDesignRepository());
+  });
+
+  afterEach(() => {
+    useProductDesignStore.getState().resetForTests();
+  });
+
+  it('creates a local document, layers, objects, and one undoable movement command', async () => {
+    const store = useProductDesignStore.getState();
+    await store.initialize('project-a');
+    store.addLayer('Annotations');
+
+    const rectangleId = store.addObject('rectangle', 103, 117);
+    expect(rectangleId).toBeTruthy();
+    expect(useProductDesignStore.getState().document?.objects[0]).toMatchObject({ x: 103, y: 117 });
+
+    store.selectObject(rectangleId);
+    store.moveSelected(7, 3);
+    expect(useProductDesignStore.getState().document?.objects[0]).toMatchObject({ x: 110, y: 120 });
+
+    useProductDesignStore.getState().undo();
+    expect(useProductDesignStore.getState().document?.objects[0]).toMatchObject({ x: 103, y: 117 });
+
+    useProductDesignStore.getState().redo();
+    expect(useProductDesignStore.getState().document?.objects[0]).toMatchObject({ x: 110, y: 120 });
+    await flushPersistence();
+    expect(useProductDesignStore.getState().persistenceStatus).toBe('saved');
+  });
+
+  it('groups selected objects and promotes the same source identities into a concept part', async () => {
+    const store = useProductDesignStore.getState();
+    await store.initialize('project-a');
+    const rectangleId = store.addObject('rectangle', 100, 100);
+    const ellipseId = store.addObject('ellipse', 260, 120);
+    expect(rectangleId && ellipseId).toBeTruthy();
+
+    store.selectObjects([rectangleId as string, ellipseId as string]);
+    store.groupSelected();
+    const grouped = useProductDesignStore.getState().document?.objects.filter((object) => [rectangleId, ellipseId].includes(object.id));
+    expect(grouped?.[0].groupId).toBeTruthy();
+    expect(grouped?.[0].groupId).toBe(grouped?.[1].groupId);
+
+    const conceptId = useProductDesignStore.getState().createConceptPartFromSelection();
+    const concept = useProductDesignStore.getState().document?.objects.find((object) => object.id === conceptId);
+    expect(concept).toMatchObject({
+      type: 'concept-part',
+      sourceObjectIds: [rectangleId, ellipseId],
+    });
+    expect(useProductDesignStore.getState().selectedObjectIds).toEqual([conceptId]);
+    expect(useProductDesignStore.getState().is3DOpen).toBe(true);
+  });
+
+  it('creates and restores a named checkpoint as a new revision', async () => {
+    const store = useProductDesignStore.getState();
+    await store.initialize('project-a');
+    const objectId = store.addObject('note', 80, 90);
+    const checkpoint = await useProductDesignStore.getState().createCheckpoint('First direction');
+    expect(checkpoint?.name).toBe('First direction');
+
+    useProductDesignStore.getState().updateObjectById(objectId as string, { name: 'Changed note' }, 'Rename note');
+    expect(useProductDesignStore.getState().document?.objects[0].name).toBe('Changed note');
+
+    useProductDesignStore.getState().restoreCheckpoint(checkpoint!.id);
+    expect(useProductDesignStore.getState().document?.objects[0].name).not.toBe('Changed note');
+    expect(useProductDesignStore.getState().undoStack.at(-1)?.type).toBe('RESTORE_CHECKPOINT');
+  });
+
+  it('exports and imports the document without replacing object identities', async () => {
+    const store = useProductDesignStore.getState();
+    await store.initialize('project-a');
+    const rectangleId = store.addObject('rectangle', 100, 100);
+    const dimensionId = store.addObject('dimension', 100, 260);
+    await flushPersistence();
+
+    const exported = await useProductDesignStore.getState().exportDocument();
+    expect(exported).toContain('hardware-studio-product-design');
+
+    const repository = new MemoryProductDesignRepository();
+    useProductDesignStore.getState().resetForTests();
+    useProductDesignStore.getState().setRepository(repository);
+    const imported = await useProductDesignStore.getState().importDocument(exported as string);
+
+    expect(imported.objects.map((object) => object.id)).toEqual([rectangleId, dimensionId]);
+    expect((await repository.getDocument(imported.id))?.objects.map((object) => object.id)).toEqual([rectangleId, dimensionId]);
+  });
+});

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -43,7 +43,7 @@ function renderSurface(surface: NavigationSurface, viewId: string): React.ReactN
   switch (surface) {
     case 'dashboard': return <ProjectDashboard />;
     case 'legacy-blueprint': return <BlueprintCanvas />;
-    case 'product-studio': return <ProductStudio />;
+    case 'product-studio': return <ProductStudio initialMode={viewId} />;
     case 'readiness': return <ReadinessDashboard />;
     case 'mechanical-canvas': return <UnifiedMechanicalWorkbench defaultMode="canvas" />;
     case 'mechanical-assembly': return <UnifiedMechanicalWorkbench defaultMode="assembly" />;

--- a/src/components/product-design/ProductDesign3DPreview.tsx
+++ b/src/components/product-design/ProductDesign3DPreview.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Box, Eye, Rotate3D, X } from 'lucide-react';
+import { useProductDesignStore } from '../../store/productDesignStore';
+
+const views = [
+  { label: 'Iso', position: [2.2, 1.8, 2.2] as const },
+  { label: 'Front', position: [0, 0, 3] as const },
+  { label: 'Top', position: [0, 3, 0.001] as const },
+  { label: 'Right', position: [3, 0, 0] as const },
+];
+
+export const ProductDesign3DPreview: React.FC = () => {
+  const open = useProductDesignStore((state) => state.is3DOpen);
+  const setOpen = useProductDesignStore((state) => state.set3DOpen);
+  const document = useProductDesignStore((state) => state.document);
+  const selectedObjectIds = useProductDesignStore((state) => state.selectedObjectIds);
+  const updateObjectById = useProductDesignStore((state) => state.updateObjectById);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const setCameraViewRef = useRef<((position: readonly [number, number, number]) => void) | null>(null);
+
+  const conceptPart = useMemo(() => {
+    const selected = document?.objects.find((object) => selectedObjectIds.includes(object.id) && object.type === 'concept-part');
+    return selected?.type === 'concept-part' ? selected : document?.objects.find((object) => object.type === 'concept-part');
+  }, [document, selectedObjectIds]);
+
+  useEffect(() => {
+    if (!open || !conceptPart || !canvasRef.current) return;
+    let disposed = false;
+    let cleanup: (() => void) | undefined;
+
+    const mount = async () => {
+      const THREE = await import('three');
+      const { OrbitControls } = await import('three/examples/jsm/controls/OrbitControls.js');
+      if (disposed || !canvasRef.current) return;
+
+      const canvas = canvasRef.current;
+      const renderer = new THREE.WebGLRenderer({
+        canvas,
+        antialias: true,
+        alpha: false,
+        powerPreference: 'low-power',
+      });
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
+      renderer.setClearColor(0xf8fafc, 1);
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(38, 1, 0.01, 100);
+      camera.position.set(2.2, 1.8, 2.2);
+
+      const controls = new OrbitControls(camera, canvas);
+      controls.enableDamping = false;
+      controls.target.set(0, 0, 0);
+      controls.minDistance = 0.8;
+      controls.maxDistance = 12;
+
+      const ambient = new THREE.HemisphereLight(0xffffff, 0x64748b, 2.1);
+      scene.add(ambient);
+      const keyLight = new THREE.DirectionalLight(0xffffff, 2.6);
+      keyLight.position.set(3, 4, 5);
+      scene.add(keyLight);
+      const fillLight = new THREE.DirectionalLight(0xbfd7ff, 1.1);
+      fillLight.position.set(-4, 2, -2);
+      scene.add(fillLight);
+
+      const scale = 1 / Math.max(conceptPart.width, conceptPart.height, conceptPart.depth, 1);
+      const width = Math.max(0.08, conceptPart.width * scale * 1.7);
+      const height = Math.max(0.08, conceptPart.depth * scale * 1.7);
+      const depth = Math.max(0.08, conceptPart.height * scale * 1.7);
+      const geometry = new THREE.BoxGeometry(width, height, depth, 4, 2, 4);
+      const material = new THREE.MeshStandardMaterial({
+        color: new THREE.Color(conceptPart.appearance || '#94a3b8'),
+        roughness: 0.55,
+        metalness: conceptPart.material.toLowerCase().includes('metal') ? 0.55 : 0.08,
+      });
+      const mesh = new THREE.Mesh(geometry, material);
+      scene.add(mesh);
+
+      const edges = new THREE.LineSegments(
+        new THREE.EdgesGeometry(geometry),
+        new THREE.LineBasicMaterial({ color: 0x334155, transparent: true, opacity: 0.55 }),
+      );
+      scene.add(edges);
+
+      const platformGeometry = new THREE.CylinderGeometry(1.35, 1.35, 0.035, 64);
+      const platformMaterial = new THREE.MeshStandardMaterial({ color: 0xe2e8f0, roughness: 0.9 });
+      const platform = new THREE.Mesh(platformGeometry, platformMaterial);
+      platform.position.y = -height / 2 - 0.04;
+      scene.add(platform);
+
+      const grid = new THREE.GridHelper(3.5, 20, 0x94a3b8, 0xcbd5e1);
+      grid.position.y = platform.position.y - 0.025;
+      scene.add(grid);
+
+      const render = () => renderer.render(scene, camera);
+      controls.addEventListener('change', render);
+
+      const resize = () => {
+        const parent = canvas.parentElement;
+        const widthPx = Math.max(1, parent?.clientWidth || 1);
+        const heightPx = Math.max(1, parent?.clientHeight || 1);
+        renderer.setSize(widthPx, heightPx, false);
+        camera.aspect = widthPx / heightPx;
+        camera.updateProjectionMatrix();
+        render();
+      };
+      const observer = new ResizeObserver(resize);
+      if (canvas.parentElement) observer.observe(canvas.parentElement);
+
+      const handleVisibility = () => {
+        if (document.visibilityState === 'visible') render();
+      };
+      document.addEventListener('visibilitychange', handleVisibility);
+
+      setCameraViewRef.current = (position) => {
+        camera.position.set(...position);
+        camera.lookAt(0, 0, 0);
+        controls.target.set(0, 0, 0);
+        controls.update();
+        render();
+      };
+
+      resize();
+
+      cleanup = () => {
+        observer.disconnect();
+        document.removeEventListener('visibilitychange', handleVisibility);
+        controls.removeEventListener('change', render);
+        controls.dispose();
+        geometry.dispose();
+        material.dispose();
+        (edges.geometry as THREE.BufferGeometry).dispose();
+        (edges.material as THREE.Material).dispose();
+        platformGeometry.dispose();
+        platformMaterial.dispose();
+        renderer.dispose();
+        renderer.forceContextLoss();
+        setCameraViewRef.current = null;
+      };
+    };
+
+    void mount();
+    return () => {
+      disposed = true;
+      cleanup?.();
+    };
+  }, [conceptPart, open]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[180] bg-slate-950/65 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[190] flex h-[min(760px,calc(100vh-2rem))] w-[min(1180px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-3xl border border-slate-300 bg-white shadow-2xl outline-none">
+          <header className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-indigo-50 text-indigo-700"><Box className="h-4 w-4" /></span>
+              <div className="min-w-0">
+                <Dialog.Title className="truncate text-sm font-bold text-slate-950">{conceptPart?.name || 'No concept part selected'}</Dialog.Title>
+                <Dialog.Description className="mt-0.5 text-[10px] text-amber-700">Concept preview · derived dimensions · not exact CAD</Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close asChild>
+              <button type="button" aria-label="Close 3D concept preview" className="grid h-9 w-9 place-items-center rounded-xl text-slate-500 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"><X className="h-4 w-4" /></button>
+            </Dialog.Close>
+          </header>
+
+          {conceptPart ? (
+            <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+              <div className="relative min-h-[320px] min-w-0 flex-1 bg-slate-100">
+                <canvas ref={canvasRef} className="h-full w-full" aria-label={`3D preview of ${conceptPart.name}`} />
+                <div className="absolute left-3 top-3 flex flex-wrap gap-1.5">
+                  {views.map((view) => (
+                    <button key={view.label} type="button" onClick={() => setCameraViewRef.current?.(view.position)} className="rounded-lg border border-slate-300 bg-white/90 px-2.5 py-1.5 text-[10px] font-bold text-slate-700 shadow-sm backdrop-blur hover:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500">{view.label}</button>
+                  ))}
+                </div>
+                <div className="pointer-events-none absolute bottom-3 left-3 flex items-center gap-2 rounded-lg border border-slate-300 bg-white/90 px-2.5 py-1.5 text-[10px] text-slate-600 shadow-sm backdrop-blur"><Rotate3D className="h-3.5 w-3.5" /> Drag to orbit · wheel to zoom</div>
+              </div>
+
+              <aside className="w-full shrink-0 overflow-y-auto border-t border-slate-200 bg-white p-4 lg:w-80 lg:border-l lg:border-t-0">
+                <div className="flex items-center gap-2"><Eye className="h-4 w-4 text-indigo-600" /><h2 className="text-xs font-extrabold uppercase tracking-[0.12em] text-slate-700">Concept properties</h2></div>
+                <dl className="mt-3 grid grid-cols-3 gap-2 text-center text-[10px]">
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-2"><dt className="text-slate-500">Width</dt><dd className="mt-1 font-mono font-bold text-slate-900">{conceptPart.width}</dd></div>
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-2"><dt className="text-slate-500">Height</dt><dd className="mt-1 font-mono font-bold text-slate-900">{conceptPart.height}</dd></div>
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-2"><dt className="text-slate-500">Depth</dt><dd className="mt-1 font-mono font-bold text-slate-900">{conceptPart.depth}</dd></div>
+                </dl>
+
+                <label className="mt-4 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Depth</label>
+                <input type="number" min={1} value={conceptPart.depth} onChange={(event) => updateObjectById(conceptPart.id, { depth: Math.max(1, Number(event.target.value) || 1) } as never, 'Update concept depth')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
+
+                <label className="mt-3 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Material intent</label>
+                <input value={conceptPart.material} onChange={(event) => updateObjectById(conceptPart.id, { material: event.target.value } as never, 'Update concept material')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
+
+                <label className="mt-3 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Finish intent</label>
+                <input value={conceptPart.finish} onChange={(event) => updateObjectById(conceptPart.id, { finish: event.target.value } as never, 'Update concept finish')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
+
+                <label className="mt-3 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Appearance</label>
+                <div className="mt-1 flex items-center gap-2">
+                  <input type="color" value={conceptPart.appearance} onChange={(event) => updateObjectById(conceptPart.id, { appearance: event.target.value } as never, 'Update concept appearance')} className="h-9 w-12 rounded-lg border border-slate-300 bg-white p-1" />
+                  <input value={conceptPart.appearance} onChange={(event) => updateObjectById(conceptPart.id, { appearance: event.target.value } as never, 'Update concept appearance')} className="h-9 min-w-0 flex-1 rounded-lg border border-slate-300 px-3 font-mono text-xs outline-none focus:border-indigo-500" />
+                </div>
+
+                <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-[10px] leading-5 text-amber-900">
+                  This view communicates form and appearance intent. It does not authorize clearances, mass, tolerances, STEP geometry, tooling, or manufacturing release.
+                </div>
+              </aside>
+            </div>
+          ) : (
+            <div className="grid flex-1 place-items-center p-8 text-center"><div><Box className="mx-auto h-9 w-9 text-slate-400" /><p className="mt-3 text-sm font-bold text-slate-800">Create or select a concept part first</p><p className="mt-1 text-xs text-slate-500">Select design objects and use “Create concept part” in the Product Design toolbar.</p></div></div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/components/product-design/ProductDesign3DPreview.tsx
+++ b/src/components/product-design/ProductDesign3DPreview.tsx
@@ -15,16 +15,16 @@ const views = [
 export const ProductDesign3DPreview: React.FC = () => {
   const open = useProductDesignStore((state) => state.is3DOpen);
   const setOpen = useProductDesignStore((state) => state.set3DOpen);
-  const document = useProductDesignStore((state) => state.document);
+  const designDocument = useProductDesignStore((state) => state.document);
   const selectedObjectIds = useProductDesignStore((state) => state.selectedObjectIds);
   const updateObjectById = useProductDesignStore((state) => state.updateObjectById);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const setCameraViewRef = useRef<((position: readonly [number, number, number]) => void) | null>(null);
 
   const conceptPart = useMemo(() => {
-    const selected = document?.objects.find((object) => selectedObjectIds.includes(object.id) && object.type === 'concept-part');
-    return selected?.type === 'concept-part' ? selected : document?.objects.find((object) => object.type === 'concept-part');
-  }, [document, selectedObjectIds]);
+    const selected = designDocument?.objects.find((object) => selectedObjectIds.includes(object.id) && object.type === 'concept-part');
+    return selected?.type === 'concept-part' ? selected : designDocument?.objects.find((object) => object.type === 'concept-part');
+  }, [designDocument, selectedObjectIds]);
 
   useEffect(() => {
     if (!open || !conceptPart || !canvasRef.current) return;
@@ -110,9 +110,9 @@ export const ProductDesign3DPreview: React.FC = () => {
       if (canvas.parentElement) observer.observe(canvas.parentElement);
 
       const handleVisibility = () => {
-        if (document.visibilityState === 'visible') render();
+        if (window.document.visibilityState === 'visible') render();
       };
-      document.addEventListener('visibilitychange', handleVisibility);
+      window.document.addEventListener('visibilitychange', handleVisibility);
 
       setCameraViewRef.current = (position) => {
         camera.position.set(...position);
@@ -126,7 +126,7 @@ export const ProductDesign3DPreview: React.FC = () => {
 
       cleanup = () => {
         observer.disconnect();
-        document.removeEventListener('visibilitychange', handleVisibility);
+        window.document.removeEventListener('visibilitychange', handleVisibility);
         controls.removeEventListener('change', render);
         controls.dispose();
         geometry.dispose();
@@ -147,6 +147,11 @@ export const ProductDesign3DPreview: React.FC = () => {
       cleanup?.();
     };
   }, [conceptPart, open]);
+
+  const updateConceptPart = (patch: Partial<typeof conceptPart>, label: string) => {
+    if (!conceptPart) return;
+    updateObjectById(conceptPart.id, { ...conceptPart, ...patch }, label);
+  };
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
@@ -187,18 +192,18 @@ export const ProductDesign3DPreview: React.FC = () => {
                 </dl>
 
                 <label className="mt-4 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Depth</label>
-                <input type="number" min={1} value={conceptPart.depth} onChange={(event) => updateObjectById(conceptPart.id, { depth: Math.max(1, Number(event.target.value) || 1) } as never, 'Update concept depth')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
+                <input type="number" min={1} value={conceptPart.depth} onChange={(event) => updateConceptPart({ depth: Math.max(1, Number(event.target.value) || 1) }, 'Update concept depth')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
 
                 <label className="mt-3 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Material intent</label>
-                <input value={conceptPart.material} onChange={(event) => updateObjectById(conceptPart.id, { material: event.target.value } as never, 'Update concept material')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
+                <input value={conceptPart.material} onChange={(event) => updateConceptPart({ material: event.target.value }, 'Update concept material')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
 
                 <label className="mt-3 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Finish intent</label>
-                <input value={conceptPart.finish} onChange={(event) => updateObjectById(conceptPart.id, { finish: event.target.value } as never, 'Update concept finish')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
+                <input value={conceptPart.finish} onChange={(event) => updateConceptPart({ finish: event.target.value }, 'Update concept finish')} className="mt-1 h-9 w-full rounded-lg border border-slate-300 px-3 text-sm outline-none focus:border-indigo-500" />
 
                 <label className="mt-3 block text-[10px] font-bold uppercase tracking-wide text-slate-500">Appearance</label>
                 <div className="mt-1 flex items-center gap-2">
-                  <input type="color" value={conceptPart.appearance} onChange={(event) => updateObjectById(conceptPart.id, { appearance: event.target.value } as never, 'Update concept appearance')} className="h-9 w-12 rounded-lg border border-slate-300 bg-white p-1" />
-                  <input value={conceptPart.appearance} onChange={(event) => updateObjectById(conceptPart.id, { appearance: event.target.value } as never, 'Update concept appearance')} className="h-9 min-w-0 flex-1 rounded-lg border border-slate-300 px-3 font-mono text-xs outline-none focus:border-indigo-500" />
+                  <input type="color" value={conceptPart.appearance} onChange={(event) => updateConceptPart({ appearance: event.target.value }, 'Update concept appearance')} className="h-9 w-12 rounded-lg border border-slate-300 bg-white p-1" />
+                  <input value={conceptPart.appearance} onChange={(event) => updateConceptPart({ appearance: event.target.value }, 'Update concept appearance')} className="h-9 min-w-0 flex-1 rounded-lg border border-slate-300 px-3 font-mono text-xs outline-none focus:border-indigo-500" />
                 </div>
 
                 <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-[10px] leading-5 text-amber-900">

--- a/src/components/product-design/ProductDesign3DPreview.tsx
+++ b/src/components/product-design/ProductDesign3DPreview.tsx
@@ -131,8 +131,9 @@ export const ProductDesign3DPreview: React.FC = () => {
         controls.dispose();
         geometry.dispose();
         material.dispose();
-        (edges.geometry as THREE.BufferGeometry).dispose();
-        (edges.material as THREE.Material).dispose();
+        edges.geometry.dispose();
+        if (Array.isArray(edges.material)) edges.material.forEach((edgeMaterial) => edgeMaterial.dispose());
+        else edges.material.dispose();
         platformGeometry.dispose();
         platformMaterial.dispose();
         renderer.dispose();

--- a/src/components/product-design/ProductDesignCanvas.tsx
+++ b/src/components/product-design/ProductDesignCanvas.tsx
@@ -1,0 +1,484 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useProductDesignStore } from '../../store/productDesignStore';
+import { objectTypeFromTool, snapProductDesignValue } from '../../lib/product-design/model';
+import type { ProductDesignObject } from '../../lib/product-design/types';
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface DragState {
+  start: Point;
+  objectOrigins: Record<string, Point>;
+}
+
+interface ResizeState {
+  objectId: string;
+  start: Point;
+  width: number;
+  height: number;
+}
+
+interface PanState {
+  startClient: Point;
+  panX: number;
+  panY: number;
+}
+
+interface MarqueeState {
+  start: Point;
+  current: Point;
+}
+
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLInputElement
+    || target instanceof HTMLTextAreaElement
+    || target instanceof HTMLSelectElement
+    || (target instanceof HTMLElement && target.isContentEditable);
+}
+
+function intersects(object: ProductDesignObject, marquee: MarqueeState): boolean {
+  const left = Math.min(marquee.start.x, marquee.current.x);
+  const top = Math.min(marquee.start.y, marquee.current.y);
+  const right = Math.max(marquee.start.x, marquee.current.x);
+  const bottom = Math.max(marquee.start.y, marquee.current.y);
+  const objectLeft = Math.min(object.x, object.x + object.width);
+  const objectTop = Math.min(object.y, object.y + object.height);
+  const objectRight = Math.max(object.x, object.x + object.width);
+  const objectBottom = Math.max(object.y, object.y + object.height);
+  return objectLeft <= right && objectRight >= left && objectTop <= bottom && objectBottom >= top;
+}
+
+function renderObjectShape(
+  object: ProductDesignObject,
+  assetUrl: string | undefined,
+  missing: boolean,
+): React.ReactNode {
+  const common = {
+    opacity: object.opacity,
+    stroke: object.stroke,
+    strokeWidth: object.strokeWidth,
+    fill: object.fill,
+    vectorEffect: 'non-scaling-stroke' as const,
+  };
+
+  if (object.type === 'rectangle') {
+    return <rect width={object.width} height={object.height} rx={object.cornerRadius} {...common} />;
+  }
+  if (object.type === 'ellipse') {
+    return <ellipse cx={object.width / 2} cy={object.height / 2} rx={Math.abs(object.width / 2)} ry={Math.abs(object.height / 2)} {...common} />;
+  }
+  if (object.type === 'line' || object.type === 'arrow') {
+    return (
+      <line
+        x1={0}
+        y1={0}
+        x2={object.width}
+        y2={object.height}
+        stroke={object.stroke}
+        strokeWidth={object.strokeWidth}
+        opacity={object.opacity}
+        markerEnd={object.type === 'arrow' ? 'url(#product-design-arrow)' : undefined}
+        vectorEffect="non-scaling-stroke"
+      />
+    );
+  }
+  if (object.type === 'text' || object.type === 'note') {
+    return (
+      <>
+        {object.type === 'note' && <rect width={object.width} height={object.height} rx={10} {...common} />}
+        <foreignObject width={Math.max(20, object.width)} height={Math.max(20, object.height)}>
+          <div
+            xmlns="http://www.w3.org/1999/xhtml"
+            style={{
+              boxSizing: 'border-box',
+              width: '100%',
+              height: '100%',
+              padding: object.type === 'note' ? 12 : 2,
+              color: object.type === 'note' ? '#78350f' : object.stroke,
+              fontSize: object.fontSize,
+              fontWeight: object.fontWeight,
+              textAlign: object.textAlign,
+              lineHeight: 1.25,
+              overflow: 'hidden',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              pointerEvents: 'none',
+            }}
+          >
+            {object.text}
+          </div>
+        </foreignObject>
+      </>
+    );
+  }
+  if (object.type === 'dimension') {
+    const y = object.height / 2;
+    return (
+      <g opacity={object.opacity} stroke={object.stroke} fill="none" vectorEffect="non-scaling-stroke">
+        <line x1={0} y1={y} x2={object.width} y2={y} strokeWidth={object.strokeWidth} />
+        <line x1={0} y1={y - 9} x2={0} y2={y + 9} strokeWidth={object.strokeWidth} />
+        <line x1={object.width} y1={y - 9} x2={object.width} y2={y + 9} strokeWidth={object.strokeWidth} />
+        <rect x={object.width / 2 - 52} y={y - 14} width={104} height={24} rx={6} fill="#ffffff" stroke="#ccfbf1" />
+        <text x={object.width / 2} y={y + 3} textAnchor="middle" fill={object.stroke} stroke="none" fontSize={11} fontWeight={700}>
+          {object.prefix}{object.value} {object.units}{object.suffix}
+        </text>
+      </g>
+    );
+  }
+  if (object.type === 'reference-image') {
+    if (assetUrl && !missing) {
+      return (
+        <>
+          <rect width={object.width} height={object.height} fill="#f8fafc" stroke={object.stroke} strokeWidth={object.strokeWidth} />
+          <image
+            href={assetUrl}
+            width={object.width}
+            height={object.height}
+            preserveAspectRatio={object.fit === 'cover' ? 'xMidYMid slice' : 'xMidYMid meet'}
+            opacity={object.opacity}
+          />
+        </>
+      );
+    }
+    return (
+      <g>
+        <rect width={object.width} height={object.height} fill="#fff7ed" stroke="#f97316" strokeDasharray="7 5" />
+        <text x={object.width / 2} y={object.height / 2 - 6} textAnchor="middle" fill="#9a3412" fontSize={13} fontWeight={700}>Reference unavailable</text>
+        <text x={object.width / 2} y={object.height / 2 + 14} textAnchor="middle" fill="#c2410c" fontSize={10}>Relink the missing local asset</text>
+      </g>
+    );
+  }
+  if (object.type === 'concept-part') {
+    return (
+      <g opacity={object.opacity}>
+        <rect width={object.width} height={object.height} rx={14} fill={object.appearance} stroke={object.stroke} strokeWidth={object.strokeWidth} />
+        <path d={`M 0 22 H ${object.width} M 22 0 V ${object.height}`} stroke="rgba(255,255,255,0.35)" strokeWidth={1} />
+        <text x={12} y={22} fill="#0f172a" fontSize={12} fontWeight={800}>{object.name}</text>
+        <text x={12} y={40} fill="#334155" fontSize={9}>{object.width} × {object.height} × {object.depth}</text>
+        <text x={12} y={object.height - 12} fill="#334155" fontSize={9}>CONCEPT · not exact CAD</text>
+      </g>
+    );
+  }
+  return null;
+}
+
+export const ProductDesignCanvas: React.FC = () => {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const document = useProductDesignStore((state) => state.document);
+  const activeTool = useProductDesignStore((state) => state.activeTool);
+  const selectedObjectIds = useProductDesignStore((state) => state.selectedObjectIds);
+  const previewPatches = useProductDesignStore((state) => state.previewPatches);
+  const assetUrls = useProductDesignStore((state) => state.assetUrls);
+  const missingAssetIds = useProductDesignStore((state) => state.missingAssetIds);
+  const zoom = useProductDesignStore((state) => state.zoom);
+  const panX = useProductDesignStore((state) => state.panX);
+  const panY = useProductDesignStore((state) => state.panY);
+  const addObject = useProductDesignStore((state) => state.addObject);
+  const selectObject = useProductDesignStore((state) => state.selectObject);
+  const selectObjects = useProductDesignStore((state) => state.selectObjects);
+  const setPreviewPatch = useProductDesignStore((state) => state.setPreviewPatch);
+  const clearPreviewPatches = useProductDesignStore((state) => state.clearPreviewPatches);
+  const commitPreviewPatches = useProductDesignStore((state) => state.commitPreviewPatches);
+  const setViewport = useProductDesignStore((state) => state.setViewport);
+  const deleteSelected = useProductDesignStore((state) => state.deleteSelected);
+  const duplicateSelected = useProductDesignStore((state) => state.duplicateSelected);
+  const groupSelected = useProductDesignStore((state) => state.groupSelected);
+  const ungroupSelected = useProductDesignStore((state) => state.ungroupSelected);
+  const moveSelected = useProductDesignStore((state) => state.moveSelected);
+  const undo = useProductDesignStore((state) => state.undo);
+  const redo = useProductDesignStore((state) => state.redo);
+  const setActiveTool = useProductDesignStore((state) => state.setActiveTool);
+
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [resizeState, setResizeState] = useState<ResizeState | null>(null);
+  const [panState, setPanState] = useState<PanState | null>(null);
+  const [marquee, setMarquee] = useState<MarqueeState | null>(null);
+
+  const visibleObjects = useMemo(() => {
+    if (!document) return [];
+    const layerById = new Map(document.layers.map((layer) => [layer.id, layer]));
+    return document.objects
+      .filter((object) => object.visible && layerById.get(object.layerId)?.visible !== false)
+      .map((object) => ({ ...object, ...previewPatches[object.id] } as ProductDesignObject))
+      .sort((a, b) => a.order - b.order);
+  }, [document, previewPatches]);
+
+  const pointFromClient = useCallback((clientX: number, clientY: number): Point => {
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect) return { x: 0, y: 0 };
+    return {
+      x: (clientX - rect.left - panX) / zoom,
+      y: (clientY - rect.top - panY) / zoom,
+    };
+  }, [panX, panY, zoom]);
+
+  const handleCanvasPointerDown = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (!document) return;
+    const point = pointFromClient(event.clientX, event.clientY);
+    if (activeTool === 'pan' || event.button === 1 || event.altKey) {
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setPanState({ startClient: { x: event.clientX, y: event.clientY }, panX, panY });
+      return;
+    }
+
+    const objectType = objectTypeFromTool(activeTool);
+    if (objectType && objectType !== 'reference-image') {
+      const x = snapProductDesignValue(point.x, document.canvas.gridSize, document.canvas.snapToGrid);
+      const y = snapProductDesignValue(point.y, document.canvas.gridSize, document.canvas.snapToGrid);
+      addObject(objectType, x, y);
+      return;
+    }
+
+    if (activeTool === 'select') {
+      event.currentTarget.setPointerCapture(event.pointerId);
+      if (!event.shiftKey) selectObject(null);
+      setMarquee({ start: point, current: point });
+    }
+  };
+
+  const handleObjectPointerDown = (event: React.PointerEvent<SVGGElement>, object: ProductDesignObject) => {
+    event.stopPropagation();
+    if (activeTool !== 'select' || object.locked) {
+      selectObject(object.id, event.shiftKey);
+      return;
+    }
+    const groupIds = object.groupId
+      ? visibleObjects.filter((candidate) => candidate.groupId === object.groupId).map((candidate) => candidate.id)
+      : [object.id];
+    const nextSelection = event.shiftKey
+      ? Array.from(new Set([...selectedObjectIds, ...groupIds]))
+      : selectedObjectIds.includes(object.id) ? selectedObjectIds : groupIds;
+    selectObjects(nextSelection);
+
+    const start = pointFromClient(event.clientX, event.clientY);
+    const objectOrigins = Object.fromEntries(
+      visibleObjects.filter((candidate) => nextSelection.includes(candidate.id)).map((candidate) => [candidate.id, { x: candidate.x, y: candidate.y }]),
+    );
+    svgRef.current?.setPointerCapture(event.pointerId);
+    setDragState({ start, objectOrigins });
+  };
+
+  const handleResizePointerDown = (event: React.PointerEvent<SVGRectElement>, object: ProductDesignObject) => {
+    event.stopPropagation();
+    svgRef.current?.setPointerCapture(event.pointerId);
+    setResizeState({
+      objectId: object.id,
+      start: pointFromClient(event.clientX, event.clientY),
+      width: object.width,
+      height: object.height,
+    });
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (!document) return;
+    if (panState) {
+      setViewport({
+        panX: panState.panX + event.clientX - panState.startClient.x,
+        panY: panState.panY + event.clientY - panState.startClient.y,
+      });
+      return;
+    }
+    const point = pointFromClient(event.clientX, event.clientY);
+    if (dragState) {
+      const dx = point.x - dragState.start.x;
+      const dy = point.y - dragState.start.y;
+      Object.entries(dragState.objectOrigins).forEach(([objectId, origin]) => {
+        setPreviewPatch(objectId, {
+          x: snapProductDesignValue(origin.x + dx, document.canvas.gridSize, document.canvas.snapToGrid),
+          y: snapProductDesignValue(origin.y + dy, document.canvas.gridSize, document.canvas.snapToGrid),
+        });
+      });
+      return;
+    }
+    if (resizeState) {
+      setPreviewPatch(resizeState.objectId, {
+        width: Math.max(10, snapProductDesignValue(resizeState.width + point.x - resizeState.start.x, document.canvas.gridSize, document.canvas.snapToGrid)),
+        height: Math.max(10, snapProductDesignValue(resizeState.height + point.y - resizeState.start.y, document.canvas.gridSize, document.canvas.snapToGrid)),
+      });
+      return;
+    }
+    if (marquee) setMarquee({ ...marquee, current: point });
+  };
+
+  const finishPointerInteraction = () => {
+    if (dragState) commitPreviewPatches('Move design objects');
+    if (resizeState) commitPreviewPatches('Resize design object');
+    if (marquee) {
+      const ids = visibleObjects.filter((object) => !object.locked && intersects(object, marquee)).map((object) => object.id);
+      selectObjects(ids);
+    }
+    setDragState(null);
+    setResizeState(null);
+    setPanState(null);
+    setMarquee(null);
+    if (!dragState && !resizeState) clearPreviewPatches();
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isTextEntryTarget(event.target)) return;
+      const modifier = event.ctrlKey || event.metaKey;
+      if (modifier && event.key.toLowerCase() === 'z') {
+        event.preventDefault();
+        if (event.shiftKey) redo(); else undo();
+        return;
+      }
+      if (modifier && event.key.toLowerCase() === 'y') {
+        event.preventDefault();
+        redo();
+        return;
+      }
+      if (modifier && event.key.toLowerCase() === 'd') {
+        event.preventDefault();
+        duplicateSelected();
+        return;
+      }
+      if (modifier && event.key.toLowerCase() === 'g') {
+        event.preventDefault();
+        if (event.shiftKey) ungroupSelected(); else groupSelected();
+        return;
+      }
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        event.preventDefault();
+        deleteSelected();
+        return;
+      }
+      if (event.key === 'Escape') {
+        clearPreviewPatches();
+        setDragState(null);
+        setResizeState(null);
+        setMarquee(null);
+        setActiveTool('select');
+        return;
+      }
+      const amount = event.shiftKey ? 10 : 1;
+      if (event.key === 'ArrowLeft') moveSelected(-amount, 0);
+      if (event.key === 'ArrowRight') moveSelected(amount, 0);
+      if (event.key === 'ArrowUp') moveSelected(0, -amount);
+      if (event.key === 'ArrowDown') moveSelected(0, amount);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [clearPreviewPatches, deleteSelected, duplicateSelected, groupSelected, moveSelected, redo, setActiveTool, undo, ungroupSelected]);
+
+  if (!document) {
+    return <div className="grid h-full place-items-center bg-slate-100 text-sm text-slate-500">Opening Product Design…</div>;
+  }
+
+  const selectedObjects = visibleObjects.filter((object) => selectedObjectIds.includes(object.id));
+  const singleSelected = selectedObjects.length === 1 ? selectedObjects[0] : null;
+  const marqueeLeft = marquee ? Math.min(marquee.start.x, marquee.current.x) : 0;
+  const marqueeTop = marquee ? Math.min(marquee.start.y, marquee.current.y) : 0;
+  const marqueeWidth = marquee ? Math.abs(marquee.current.x - marquee.start.x) : 0;
+  const marqueeHeight = marquee ? Math.abs(marquee.current.y - marquee.start.y) : 0;
+
+  return (
+    <div className="relative h-full min-h-0 overflow-hidden bg-slate-200">
+      <svg
+        ref={svgRef}
+        className={`h-full w-full touch-none ${activeTool === 'pan' ? 'cursor-grab active:cursor-grabbing' : activeTool === 'select' ? 'cursor-default' : 'cursor-crosshair'}`}
+        onPointerDown={handleCanvasPointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={finishPointerInteraction}
+        onPointerCancel={finishPointerInteraction}
+        onWheel={(event) => {
+          event.preventDefault();
+          const nextZoom = Math.min(3, Math.max(0.2, zoom * (event.deltaY > 0 ? 0.9 : 1.1)));
+          setViewport({ zoom: nextZoom });
+        }}
+        aria-label="Product Design canvas"
+      >
+        <defs>
+          <pattern id="product-design-grid-small" width={document.canvas.gridSize} height={document.canvas.gridSize} patternUnits="userSpaceOnUse">
+            <path d={`M ${document.canvas.gridSize} 0 L 0 0 0 ${document.canvas.gridSize}`} fill="none" stroke="#e2e8f0" strokeWidth={0.7} />
+          </pattern>
+          <pattern id="product-design-grid-major" width={document.canvas.gridSize * 5} height={document.canvas.gridSize * 5} patternUnits="userSpaceOnUse">
+            <rect width={document.canvas.gridSize * 5} height={document.canvas.gridSize * 5} fill="url(#product-design-grid-small)" />
+            <path d={`M ${document.canvas.gridSize * 5} 0 L 0 0 0 ${document.canvas.gridSize * 5}`} fill="none" stroke="#cbd5e1" strokeWidth={1} />
+          </pattern>
+          <marker id="product-design-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke" />
+          </marker>
+          <filter id="product-design-shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="0" dy="3" stdDeviation="5" floodOpacity="0.16" />
+          </filter>
+        </defs>
+
+        <g transform={`translate(${panX} ${panY}) scale(${zoom})`}>
+          <rect x={0} y={0} width={document.canvas.width} height={document.canvas.height} fill={document.canvas.background} filter="url(#product-design-shadow)" />
+          {document.canvas.gridVisible && (
+            <rect x={0} y={0} width={document.canvas.width} height={document.canvas.height} fill="url(#product-design-grid-major)" pointerEvents="none" />
+          )}
+          {visibleObjects.map((object) => {
+            const selected = selectedObjectIds.includes(object.id);
+            const centerX = object.width / 2;
+            const centerY = object.height / 2;
+            const missing = object.type === 'reference-image' && missingAssetIds.includes(object.assetId);
+            return (
+              <g
+                key={object.id}
+                transform={`translate(${object.x} ${object.y}) rotate(${object.rotation} ${centerX} ${centerY})`}
+                onPointerDown={(event) => handleObjectPointerDown(event, object)}
+                className={object.locked ? 'cursor-not-allowed' : 'cursor-move'}
+                aria-label={object.name}
+              >
+                {renderObjectShape(object, object.type === 'reference-image' ? assetUrls[object.assetId] : undefined, missing)}
+                {selected && (
+                  <rect
+                    x={-4}
+                    y={-4}
+                    width={Math.max(8, object.width + 8)}
+                    height={Math.max(8, object.height + 8)}
+                    fill="none"
+                    stroke="#4f46e5"
+                    strokeWidth={1.5 / zoom}
+                    strokeDasharray={`${5 / zoom} ${3 / zoom}`}
+                    pointerEvents="none"
+                    vectorEffect="non-scaling-stroke"
+                  />
+                )}
+              </g>
+            );
+          })}
+
+          {singleSelected && !singleSelected.locked && (
+            <rect
+              x={singleSelected.x + singleSelected.width - 6 / zoom}
+              y={singleSelected.y + singleSelected.height - 6 / zoom}
+              width={12 / zoom}
+              height={12 / zoom}
+              rx={2 / zoom}
+              fill="#ffffff"
+              stroke="#4f46e5"
+              strokeWidth={1.5 / zoom}
+              className="cursor-nwse-resize"
+              onPointerDown={(event) => handleResizePointerDown(event, singleSelected)}
+            />
+          )}
+
+          {marquee && (
+            <rect
+              x={marqueeLeft}
+              y={marqueeTop}
+              width={marqueeWidth}
+              height={marqueeHeight}
+              fill="rgba(79,70,229,0.1)"
+              stroke="#4f46e5"
+              strokeWidth={1 / zoom}
+              strokeDasharray={`${5 / zoom} ${3 / zoom}`}
+              pointerEvents="none"
+            />
+          )}
+        </g>
+      </svg>
+
+      <div className="pointer-events-none absolute bottom-3 left-3 rounded-lg border border-slate-300 bg-white/90 px-2.5 py-1.5 text-[10px] font-semibold text-slate-600 shadow-sm backdrop-blur">
+        {Math.round(zoom * 100)}% · {document.units} · {document.canvas.snapToGrid ? `snap ${document.canvas.gridSize}` : 'snap off'}
+      </div>
+    </div>
+  );
+};

--- a/src/components/product-design/ProductDesignCanvas.tsx
+++ b/src/components/product-design/ProductDesignCanvas.tsx
@@ -92,7 +92,6 @@ function renderObjectShape(
         {object.type === 'note' && <rect width={object.width} height={object.height} rx={10} {...common} />}
         <foreignObject width={Math.max(20, object.width)} height={Math.max(20, object.height)}>
           <div
-            xmlns="http://www.w3.org/1999/xhtml"
             style={{
               boxSizing: 'border-box',
               width: '100%',

--- a/src/components/product-design/ProductDesignSafetyBoundary.tsx
+++ b/src/components/product-design/ProductDesignSafetyBoundary.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { AlertTriangle, FileImage, Upload } from 'lucide-react';
+import { prepareProductDesignImport } from '../../lib/product-design/importPolicy';
+import type { ProductDesignAsset, ProductDesignReferenceImage } from '../../lib/product-design/types';
+import { useProductDesignStore } from '../../store/productDesignStore';
+
+let importPolicyInstalled = false;
+
+function installSafeImportPolicy(): void {
+  if (importPolicyInstalled) return;
+  importPolicyInstalled = true;
+  const originalImport = useProductDesignStore.getState().importDocument;
+
+  useProductDesignStore.setState({
+    importDocument: async (raw: string) => {
+      const state = useProductDesignStore.getState();
+      const plan = prepareProductDesignImport(
+        raw,
+        state.documents,
+        state.projectId || 'local-project',
+      );
+      const document = await originalImport(plan.serializedBundle);
+      useProductDesignStore.setState({
+        persistenceMessage: plan.mode === 'create-conflict-safe-copy'
+          ? 'Imported as a new conflict-safe copy; existing work was not overwritten'
+          : 'Imported with original identities',
+      });
+      return document;
+    },
+  });
+}
+
+installSafeImportPolicy();
+
+export const ProductDesignSafetyBoundary: React.FC = () => {
+  const document = useProductDesignStore((state) => state.document);
+  const missingAssetIds = useProductDesignStore((state) => state.missingAssetIds);
+  const repository = useProductDesignStore((state) => state.repository);
+  const updateObjectById = useProductDesignStore((state) => state.updateObjectById);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [targetObjectId, setTargetObjectId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  const missingReferences = (document?.objects || []).filter(
+    (object): object is ProductDesignReferenceImage =>
+      object.type === 'reference-image' && missingAssetIds.includes(object.assetId),
+  );
+
+  const requestRelink = (objectId: string) => {
+    setTargetObjectId(objectId);
+    setError('');
+    fileInputRef.current?.click();
+  };
+
+  const relink = async (file: File | undefined) => {
+    const reference = document?.objects.find(
+      (object): object is ProductDesignReferenceImage => object.id === targetObjectId && object.type === 'reference-image',
+    );
+    if (!file || !reference || !document) return;
+    if (!file.type.startsWith('image/')) {
+      setError('Choose an image file to repair this reference.');
+      return;
+    }
+
+    const asset: ProductDesignAsset = {
+      id: reference.assetId,
+      documentId: document.id,
+      fileName: file.name,
+      mimeType: file.type || 'application/octet-stream',
+      size: file.size,
+      sourceUrl: reference.sourceUrl,
+      attribution: reference.attribution,
+      license: reference.license,
+      altText: reference.altText || file.name,
+      blob: file,
+      createdAt: new Date().toISOString(),
+    };
+
+    try {
+      await repository.saveAsset(asset);
+      const state = useProductDesignStore.getState();
+      const previousUrl = state.assetUrls[asset.id];
+      if (previousUrl && typeof URL !== 'undefined') URL.revokeObjectURL(previousUrl);
+      useProductDesignStore.setState({
+        assetUrls: {
+          ...state.assetUrls,
+          [asset.id]: typeof URL !== 'undefined' ? URL.createObjectURL(file) : '',
+        },
+        missingAssetIds: state.missingAssetIds.filter((assetId) => assetId !== asset.id),
+        persistenceStatus: 'saved',
+        persistenceMessage: `Relinked ${file.name}`,
+      });
+      updateObjectById(reference.id, {
+        ...reference,
+        name: file.name,
+        altText: reference.altText || file.name,
+      }, 'Relink reference image');
+      setTargetObjectId(null);
+      setError('');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'The reference image could not be relinked.');
+    }
+  };
+
+  if (missingReferences.length === 0 && !error) return null;
+
+  return (
+    <div className="shrink-0 border-b border-amber-200 bg-amber-50 px-3 py-2 text-amber-950">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(event) => {
+          void relink(event.target.files?.[0]);
+          event.currentTarget.value = '';
+        }}
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <AlertTriangle className="h-4 w-4 shrink-0 text-amber-700" aria-hidden="true" />
+        <p className="min-w-0 flex-1 text-[10px] leading-5">
+          {error || `${missingReferences.length} reference image${missingReferences.length === 1 ? '' : 's'} is missing from local storage. The design geometry and asset identity are preserved.`}
+        </p>
+        {missingReferences.map((reference) => (
+          <button
+            key={reference.id}
+            type="button"
+            onClick={() => requestRelink(reference.id)}
+            className="inline-flex h-8 max-w-52 items-center gap-1.5 rounded-lg border border-amber-300 bg-white px-2.5 text-[10px] font-bold text-amber-900 hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-500"
+            title={`Relink ${reference.name}`}
+          >
+            <FileImage className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{reference.name}</span>
+            <Upload className="h-3.5 w-3.5 shrink-0" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/product-design/ProductDesignStudio.tsx
+++ b/src/components/product-design/ProductDesignStudio.tsx
@@ -1,0 +1,494 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlignCenterHorizontal,
+  AlignCenterVertical,
+  AlignEndHorizontal,
+  AlignEndVertical,
+  AlignStartHorizontal,
+  AlignStartVertical,
+  ArrowRight,
+  Box,
+  BringToFront,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Download,
+  Eye,
+  EyeOff,
+  FileImage,
+  Focus,
+  Group,
+  ImagePlus,
+  Import,
+  Layers3,
+  Lock,
+  MousePointer2,
+  Move,
+  PanelLeftClose,
+  PanelLeftOpen,
+  PanelRightClose,
+  PanelRightOpen,
+  Plus,
+  Redo2,
+  RectangleHorizontal,
+  Ruler,
+  Save,
+  SendToBack,
+  Shapes,
+  SquareMousePointer,
+  StickyNote,
+  TextCursorInput,
+  Trash2,
+  Undo2,
+  Ungroup,
+  Unlock,
+  Upload,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import { useProductDesignStore } from '../../store/productDesignStore';
+import type {
+  ProductDesignConceptPart,
+  ProductDesignDimension,
+  ProductDesignObject,
+  ProductDesignReferenceImage,
+  ProductDesignText,
+  ProductDesignTool,
+} from '../../lib/product-design/types';
+import { ProductDesignCanvas } from './ProductDesignCanvas';
+import { ProductDesign3DPreview } from './ProductDesign3DPreview';
+
+const toolItems: Array<{
+  id: ProductDesignTool;
+  label: string;
+  shortcut: string;
+  icon: React.ComponentType<{ className?: string }>;
+}> = [
+  { id: 'select', label: 'Select', shortcut: 'V', icon: MousePointer2 },
+  { id: 'pan', label: 'Pan', shortcut: 'H / Alt', icon: Move },
+  { id: 'rectangle', label: 'Rectangle', shortcut: 'R', icon: RectangleHorizontal },
+  { id: 'ellipse', label: 'Ellipse', shortcut: 'O', icon: Circle },
+  { id: 'line', label: 'Line', shortcut: 'L', icon: Shapes },
+  { id: 'arrow', label: 'Arrow', shortcut: 'A', icon: ArrowRight },
+  { id: 'text', label: 'Text', shortcut: 'T', icon: TextCursorInput },
+  { id: 'note', label: 'Note', shortcut: 'N', icon: StickyNote },
+  { id: 'dimension', label: 'Dimension', shortcut: 'D', icon: Ruler },
+  { id: 'reference-image', label: 'Reference image', shortcut: 'I', icon: ImagePlus },
+];
+
+function downloadTextFile(fileName: string, content: string, type = 'application/json'): void {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const anchor = window.document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function NumberField({
+  label,
+  value,
+  onChange,
+  min,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+}) {
+  return (
+    <label className="block min-w-0">
+      <span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">{label}</span>
+      <input
+        type="number"
+        min={min}
+        value={Number.isFinite(value) ? Math.round(value * 100) / 100 : 0}
+        onChange={(event) => onChange(Number(event.target.value) || 0)}
+        className="mt-1 h-8 w-full rounded-lg border border-slate-300 bg-white px-2 font-mono text-[11px] text-slate-800 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+      />
+    </label>
+  );
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h3 className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">{children}</h3>;
+}
+
+export const ProductDesignStudio: React.FC = () => {
+  const project = useProjectStore();
+  const initialize = useProductDesignStore((state) => state.initialize);
+  const documents = useProductDesignStore((state) => state.documents);
+  const document = useProductDesignStore((state) => state.document);
+  const checkpoints = useProductDesignStore((state) => state.checkpoints);
+  const activeLayerId = useProductDesignStore((state) => state.activeLayerId);
+  const selectedObjectIds = useProductDesignStore((state) => state.selectedObjectIds);
+  const activeTool = useProductDesignStore((state) => state.activeTool);
+  const zoom = useProductDesignStore((state) => state.zoom);
+  const persistenceStatus = useProductDesignStore((state) => state.persistenceStatus);
+  const persistenceMessage = useProductDesignStore((state) => state.persistenceMessage);
+  const undoStack = useProductDesignStore((state) => state.undoStack);
+  const redoStack = useProductDesignStore((state) => state.redoStack);
+  const missingAssetIds = useProductDesignStore((state) => state.missingAssetIds);
+  const createDocument = useProductDesignStore((state) => state.createDocument);
+  const openDocument = useProductDesignStore((state) => state.openDocument);
+  const updateDocument = useProductDesignStore((state) => state.updateDocument);
+  const addLayer = useProductDesignStore((state) => state.addLayer);
+  const updateLayer = useProductDesignStore((state) => state.updateLayer);
+  const deleteLayer = useProductDesignStore((state) => state.deleteLayer);
+  const setActiveLayer = useProductDesignStore((state) => state.setActiveLayer);
+  const selectObject = useProductDesignStore((state) => state.selectObject);
+  const updateObjectById = useProductDesignStore((state) => state.updateObjectById);
+  const deleteSelected = useProductDesignStore((state) => state.deleteSelected);
+  const duplicateSelected = useProductDesignStore((state) => state.duplicateSelected);
+  const groupSelected = useProductDesignStore((state) => state.groupSelected);
+  const ungroupSelected = useProductDesignStore((state) => state.ungroupSelected);
+  const bringSelectedForward = useProductDesignStore((state) => state.bringSelectedForward);
+  const sendSelectedBackward = useProductDesignStore((state) => state.sendSelectedBackward);
+  const alignSelected = useProductDesignStore((state) => state.alignSelected);
+  const createConceptPartFromSelection = useProductDesignStore((state) => state.createConceptPartFromSelection);
+  const addReferenceImage = useProductDesignStore((state) => state.addReferenceImage);
+  const createCheckpoint = useProductDesignStore((state) => state.createCheckpoint);
+  const restoreCheckpoint = useProductDesignStore((state) => state.restoreCheckpoint);
+  const deleteCheckpoint = useProductDesignStore((state) => state.deleteCheckpoint);
+  const undo = useProductDesignStore((state) => state.undo);
+  const redo = useProductDesignStore((state) => state.redo);
+  const setActiveTool = useProductDesignStore((state) => state.setActiveTool);
+  const setViewport = useProductDesignStore((state) => state.setViewport);
+  const fitDocument = useProductDesignStore((state) => state.fitDocument);
+  const set3DOpen = useProductDesignStore((state) => state.set3DOpen);
+  const exportDocument = useProductDesignStore((state) => state.exportDocument);
+  const importDocument = useProductDesignStore((state) => state.importDocument);
+
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const importInputRef = useRef<HTMLInputElement | null>(null);
+  const [leftPanelOpen, setLeftPanelOpen] = useState(true);
+  const [rightPanelOpen, setRightPanelOpen] = useState(true);
+  const [historyOpen, setHistoryOpen] = useState(true);
+  const [checkpointName, setCheckpointName] = useState('');
+  const [newLayerName, setNewLayerName] = useState('');
+  const [expandedLayers, setExpandedLayers] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    void initialize(project.id || 'local-project');
+  }, [initialize, project.id]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) return;
+      const key = event.key.toLowerCase();
+      const tool = toolItems.find((item) => item.shortcut.toLowerCase().startsWith(key));
+      if (tool && !event.ctrlKey && !event.metaKey && !event.altKey) setActiveTool(tool.id);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [setActiveTool]);
+
+  useEffect(() => {
+    if (!document) return;
+    setExpandedLayers((current) => {
+      const next = { ...current };
+      document.layers.forEach((layer) => {
+        if (next[layer.id] === undefined) next[layer.id] = true;
+      });
+      return next;
+    });
+  }, [document]);
+
+  const selectedObjects = useMemo(
+    () => document?.objects.filter((object) => selectedObjectIds.includes(object.id)) || [],
+    [document, selectedObjectIds],
+  );
+  const selectedObject = selectedObjects.length === 1 ? selectedObjects[0] : null;
+  const selectedConceptPart = selectedObject?.type === 'concept-part' ? selectedObject : null;
+
+  const objectByLayer = useMemo(() => {
+    const result = new Map<string, ProductDesignObject[]>();
+    document?.layers.forEach((layer) => result.set(layer.id, []));
+    document?.objects
+      .slice()
+      .sort((a, b) => b.order - a.order)
+      .forEach((object) => result.get(object.layerId)?.push(object));
+    return result;
+  }, [document]);
+
+  const updateSelected = (patch: Partial<ProductDesignObject>, label: string) => {
+    if (!selectedObject) return;
+    updateObjectById(selectedObject.id, { ...selectedObject, ...patch }, label);
+  };
+
+  const handleTool = (tool: ProductDesignTool) => {
+    if (tool === 'reference-image') {
+      imageInputRef.current?.click();
+      return;
+    }
+    setActiveTool(tool);
+  };
+
+  const handleReferenceFile = async (file: File | undefined) => {
+    if (!file) return;
+    if (!file.type.startsWith('image/')) return;
+    await addReferenceImage(file, { altText: file.name });
+  };
+
+  const handleExport = async () => {
+    const content = await exportDocument();
+    if (!content || !document) return;
+    downloadTextFile(`${document.name.replace(/[^a-z0-9]+/gi, '-').toLowerCase() || 'product-design'}.hardware-design.json`, content);
+  };
+
+  const handleImportFile = async (file: File | undefined) => {
+    if (!file) return;
+    await importDocument(await file.text());
+    if (importInputRef.current) importInputRef.current.value = '';
+  };
+
+  const handleCreateCheckpoint = async () => {
+    if (!checkpointName.trim()) return;
+    await createCheckpoint(checkpointName.trim());
+    setCheckpointName('');
+  };
+
+  if (!document) {
+    return (
+      <section className="grid h-full min-h-0 place-items-center bg-slate-100 p-6">
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+          <div className="mx-auto grid h-11 w-11 place-items-center rounded-xl bg-indigo-50 text-indigo-700"><Shapes className="h-5 w-5" /></div>
+          <p className="mt-3 text-sm font-bold text-slate-900">Opening Product Design</p>
+          <p className="mt-1 text-xs text-slate-500">{persistenceMessage}</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-100 text-slate-900" aria-label="Product Design Studio">
+      <input ref={imageInputRef} type="file" accept="image/*" className="hidden" onChange={(event) => void handleReferenceFile(event.target.files?.[0])} />
+      <input ref={importInputRef} type="file" accept="application/json,.json" className="hidden" onChange={(event) => void handleImportFile(event.target.files?.[0])} />
+
+      <header className="shrink-0 border-b border-slate-200 bg-white">
+        <div className="flex min-h-12 flex-wrap items-center gap-2 px-3 py-2">
+          <button type="button" onClick={() => setLeftPanelOpen((open) => !open)} className="grid h-8 w-8 place-items-center rounded-lg text-slate-500 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label={leftPanelOpen ? 'Hide layer panel' : 'Show layer panel'}>{leftPanelOpen ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}</button>
+
+          <div className="min-w-[180px] max-w-[280px] flex-1 sm:flex-none">
+            <input value={document.name} onChange={(event) => updateDocument({ name: event.target.value })} aria-label="Product Design document name" className="h-8 w-full rounded-lg border border-transparent px-2 text-sm font-bold text-slate-950 outline-none hover:border-slate-200 focus:border-indigo-400 focus:bg-white" />
+            <p className="truncate px-2 text-[9px] font-semibold text-slate-500">Product Design · revision {document.revision}</p>
+          </div>
+
+          <select value={document.id} onChange={(event) => void openDocument(event.target.value)} aria-label="Open Product Design document" className="h-8 max-w-48 rounded-lg border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 outline-none focus:border-indigo-500">
+            {documents.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.name}</option>)}
+          </select>
+          <button type="button" onClick={() => void createDocument(`Product concept ${documents.length + 1}`, document.units)} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-2.5 text-[10px] font-bold text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"><Plus className="h-3.5 w-3.5" /> New</button>
+
+          <div className="hidden h-5 w-px bg-slate-200 md:block" />
+          <button type="button" onClick={undo} disabled={undoStack.length === 0} title="Undo · Ctrl/Cmd+Z" className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-slate-100 disabled:opacity-30"><Undo2 className="h-4 w-4" /></button>
+          <button type="button" onClick={redo} disabled={redoStack.length === 0} title="Redo · Ctrl/Cmd+Shift+Z" className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-slate-100 disabled:opacity-30"><Redo2 className="h-4 w-4" /></button>
+
+          <div className="ml-auto flex items-center gap-1.5">
+            <span className={`hidden items-center gap-1.5 rounded-full border px-2.5 py-1 text-[9px] font-bold sm:inline-flex ${persistenceStatus === 'error' ? 'border-red-200 bg-red-50 text-red-800' : persistenceStatus === 'saving' ? 'border-amber-200 bg-amber-50 text-amber-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`} title={persistenceMessage}>
+              {persistenceStatus === 'saved' ? <Check className="h-3 w-3" /> : <Save className="h-3 w-3" />}{persistenceStatus === 'error' ? 'Save error' : persistenceStatus === 'saving' ? 'Saving' : 'Local'}
+            </span>
+            <button type="button" onClick={() => importInputRef.current?.click()} className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-slate-100" title="Import Product Design"><Import className="h-4 w-4" /></button>
+            <button type="button" onClick={() => void handleExport()} className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-slate-100" title="Export Product Design"><Download className="h-4 w-4" /></button>
+            <button type="button" onClick={() => setRightPanelOpen((open) => !open)} className="grid h-8 w-8 place-items-center rounded-lg text-slate-500 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label={rightPanelOpen ? 'Hide inspector' : 'Show inspector'}>{rightPanelOpen ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}</button>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 overflow-x-auto border-t border-slate-100 bg-slate-50 px-3 py-1.5">
+          {toolItems.map(({ id, label, shortcut, icon: Icon }) => (
+            <button key={id} type="button" onClick={() => handleTool(id)} aria-pressed={activeTool === id} title={`${label} · ${shortcut}`} className={`inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg px-2.5 text-[10px] font-bold transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${activeTool === id ? 'bg-slate-950 text-white shadow-sm' : 'text-slate-600 hover:bg-white hover:text-slate-950'}`}><Icon className="h-3.5 w-3.5" /><span className="hidden xl:inline">{label}</span></button>
+          ))}
+          <div className="mx-1 h-5 w-px shrink-0 bg-slate-200" />
+          <button type="button" onClick={duplicateSelected} disabled={selectedObjectIds.length === 0} className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg px-2.5 text-[10px] font-bold text-slate-600 hover:bg-white disabled:opacity-30" title="Duplicate · Ctrl/Cmd+D"><SquareMousePointer className="h-3.5 w-3.5" /> Duplicate</button>
+          <button type="button" onClick={groupSelected} disabled={selectedObjectIds.length < 2} className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-slate-600 hover:bg-white disabled:opacity-30" title="Group · Ctrl/Cmd+G"><Group className="h-3.5 w-3.5" /></button>
+          <button type="button" onClick={ungroupSelected} disabled={selectedObjectIds.length === 0} className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-slate-600 hover:bg-white disabled:opacity-30" title="Ungroup · Ctrl/Cmd+Shift+G"><Ungroup className="h-3.5 w-3.5" /></button>
+          <button type="button" onClick={deleteSelected} disabled={selectedObjectIds.length === 0} className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-red-600 hover:bg-red-50 disabled:opacity-30" title="Delete selected"><Trash2 className="h-3.5 w-3.5" /></button>
+          <div className="ml-auto flex shrink-0 items-center gap-1">
+            <button type="button" onClick={() => setViewport({ zoom: Math.max(0.2, zoom - 0.1) })} className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-white" title="Zoom out"><ZoomOut className="h-3.5 w-3.5" /></button>
+            <button type="button" onClick={fitDocument} className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-white" title="Fit document"><Focus className="h-3.5 w-3.5" /></button>
+            <button type="button" onClick={() => setViewport({ zoom: Math.min(3, zoom + 0.1) })} className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-white" title="Zoom in"><ZoomIn className="h-3.5 w-3.5" /></button>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        {leftPanelOpen && (
+          <aside className="flex w-64 shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white max-lg:absolute max-lg:bottom-0 max-lg:left-0 max-lg:top-[96px] max-lg:z-30 max-lg:shadow-xl">
+            <div className="flex items-center justify-between border-b border-slate-200 px-3 py-2.5">
+              <div><SectionTitle>Layers & objects</SectionTitle><p className="mt-1 text-[10px] text-slate-500">Organise intent without changing identity.</p></div>
+              <button type="button" onClick={() => addLayer(newLayerName.trim() || undefined)} className="grid h-8 w-8 place-items-center rounded-lg text-indigo-700 hover:bg-indigo-50" title="Add layer"><Plus className="h-4 w-4" /></button>
+            </div>
+            <div className="border-b border-slate-100 p-2">
+              <input value={newLayerName} onChange={(event) => setNewLayerName(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter') { addLayer(newLayerName.trim() || undefined); setNewLayerName(''); } }} placeholder="New layer name" className="h-8 w-full rounded-lg border border-slate-200 bg-slate-50 px-2.5 text-[11px] outline-none focus:border-indigo-500 focus:bg-white" />
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-2">
+              {document.layers.slice().sort((a, b) => a.order - b.order).map((layer) => {
+                const objects = objectByLayer.get(layer.id) || [];
+                const expanded = expandedLayers[layer.id] !== false;
+                return (
+                  <div key={layer.id} className={`mb-1 rounded-xl border ${activeLayerId === layer.id ? 'border-indigo-200 bg-indigo-50/50' : 'border-transparent'}`}>
+                    <div className="flex items-center gap-1 p-1">
+                      <button type="button" onClick={() => setExpandedLayers((current) => ({ ...current, [layer.id]: !expanded }))} className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white">{expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}</button>
+                      <button type="button" onClick={() => setActiveLayer(layer.id)} className="min-w-0 flex-1 truncate text-left text-[11px] font-bold text-slate-800">{layer.name}</button>
+                      <button type="button" onClick={() => updateLayer(layer.id, { visible: !layer.visible })} className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white" title={layer.visible ? 'Hide layer' : 'Show layer'}>{layer.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}</button>
+                      <button type="button" onClick={() => updateLayer(layer.id, { locked: !layer.locked })} className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white" title={layer.locked ? 'Unlock layer' : 'Lock layer'}>{layer.locked ? <Lock className="h-3.5 w-3.5" /> : <Unlock className="h-3.5 w-3.5" />}</button>
+                    </div>
+                    {expanded && (
+                      <div className="space-y-0.5 px-1 pb-1 pl-8">
+                        {objects.map((object) => (
+                          <button key={object.id} type="button" onClick={(event) => selectObject(object.id, event.shiftKey)} className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[10px] ${selectedObjectIds.includes(object.id) ? 'bg-indigo-100 text-indigo-950' : 'text-slate-600 hover:bg-white hover:text-slate-950'}`}>
+                            {object.type === 'reference-image' ? <FileImage className="h-3.5 w-3.5 shrink-0" /> : object.type === 'concept-part' ? <Box className="h-3.5 w-3.5 shrink-0" /> : <Shapes className="h-3.5 w-3.5 shrink-0" />}
+                            <span className="min-w-0 flex-1 truncate">{object.name}</span>
+                            {object.locked && <Lock className="h-3 w-3 shrink-0 text-slate-400" />}
+                          </button>
+                        ))}
+                        {objects.length === 0 && <p className="px-2 py-2 text-[9px] text-slate-400">Empty layer</p>}
+                      </div>
+                    )}
+                    {document.layers.length > 1 && activeLayerId === layer.id && (
+                      <button type="button" onClick={() => deleteLayer(layer.id)} className="mx-2 mb-2 text-[9px] font-semibold text-red-600 hover:text-red-800">Delete layer · objects move safely</button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </aside>
+        )}
+
+        <div className="relative min-w-0 flex-1">
+          <ProductDesignCanvas />
+          {missingAssetIds.length > 0 && (
+            <div className="absolute right-3 top-3 max-w-xs rounded-xl border border-amber-300 bg-amber-50 p-3 text-[10px] leading-5 text-amber-900 shadow-lg">
+              <strong>{missingAssetIds.length} reference asset{missingAssetIds.length === 1 ? '' : 's'} missing.</strong> The design objects remain intact. Relink local files through Reference image.
+            </div>
+          )}
+        </div>
+
+        {rightPanelOpen && (
+          <aside className="flex w-72 shrink-0 flex-col overflow-hidden border-l border-slate-200 bg-white max-xl:absolute max-xl:bottom-0 max-xl:right-0 max-xl:top-[96px] max-xl:z-30 max-xl:shadow-xl">
+            <div className="border-b border-slate-200 px-3 py-2.5"><SectionTitle>Inspector</SectionTitle><p className="mt-1 text-[10px] text-slate-500">{selectedObject ? selectedObject.type.replace('-', ' ') : selectedObjects.length > 1 ? `${selectedObjects.length} objects selected` : 'Select an object to edit it.'}</p></div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-3">
+              {!selectedObject && selectedObjects.length === 0 && (
+                <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-4 text-center"><MousePointer2 className="mx-auto h-6 w-6 text-slate-400" /><p className="mt-2 text-[11px] font-bold text-slate-700">Nothing selected</p><p className="mt-1 text-[10px] leading-5 text-slate-500">Draw a shape or choose an object from the layer tree. Only relevant properties appear here.</p></div>
+              )}
+
+              {selectedObjects.length > 1 && (
+                <div className="space-y-3">
+                  <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-3 text-[10px] leading-5 text-indigo-900">Edit shared position through alignment or group these objects into one movable set.</div>
+                  <SectionTitle>Align</SectionTitle>
+                  <div className="grid grid-cols-3 gap-1.5">
+                    <button type="button" onClick={() => alignSelected('left')} className="grid h-9 place-items-center rounded-lg border border-slate-200 hover:bg-slate-50" title="Align left"><AlignStartVertical className="h-4 w-4" /></button>
+                    <button type="button" onClick={() => alignSelected('center-x')} className="grid h-9 place-items-center rounded-lg border border-slate-200 hover:bg-slate-50" title="Align horizontal centre"><AlignCenterVertical className="h-4 w-4" /></button>
+                    <button type="button" onClick={() => alignSelected('right')} className="grid h-9 place-items-center rounded-lg border border-slate-200 hover:bg-slate-50" title="Align right"><AlignEndVertical className="h-4 w-4" /></button>
+                    <button type="button" onClick={() => alignSelected('top')} className="grid h-9 place-items-center rounded-lg border border-slate-200 hover:bg-slate-50" title="Align top"><AlignStartHorizontal className="h-4 w-4" /></button>
+                    <button type="button" onClick={() => alignSelected('center-y')} className="grid h-9 place-items-center rounded-lg border border-slate-200 hover:bg-slate-50" title="Align vertical centre"><AlignCenterHorizontal className="h-4 w-4" /></button>
+                    <button type="button" onClick={() => alignSelected('bottom')} className="grid h-9 place-items-center rounded-lg border border-slate-200 hover:bg-slate-50" title="Align bottom"><AlignEndHorizontal className="h-4 w-4" /></button>
+                  </div>
+                  <button type="button" onClick={groupSelected} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-lg bg-slate-950 text-[11px] font-bold text-white hover:bg-slate-800"><Group className="h-4 w-4" /> Group selection</button>
+                  <button type="button" onClick={createConceptPartFromSelection} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-lg bg-indigo-600 text-[11px] font-bold text-white hover:bg-indigo-500"><Box className="h-4 w-4" /> Create concept part</button>
+                </div>
+              )}
+
+              {selectedObject && (
+                <div className="space-y-4">
+                  <div>
+                    <SectionTitle>Identity</SectionTitle>
+                    <label className="mt-2 block text-[9px] font-bold uppercase tracking-wide text-slate-500">Name</label>
+                    <input value={selectedObject.name} onChange={(event) => updateSelected({ name: event.target.value }, 'Rename design object')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 px-2.5 text-[11px] outline-none focus:border-indigo-500" />
+                    <div className="mt-2 flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-2 text-[9px]"><span className="font-mono text-slate-500">{selectedObject.id}</span><span className={`rounded-full px-2 py-0.5 font-bold uppercase ${selectedObject.authority === 'qualified' ? 'bg-emerald-100 text-emerald-800' : selectedObject.authority === 'reference' ? 'bg-sky-100 text-sky-800' : 'bg-amber-100 text-amber-800'}`}>{selectedObject.authority}</span></div>
+                  </div>
+
+                  <div>
+                    <SectionTitle>Transform</SectionTitle>
+                    <div className="mt-2 grid grid-cols-2 gap-2">
+                      <NumberField label="X" value={selectedObject.x} onChange={(x) => updateSelected({ x }, 'Update object X')} />
+                      <NumberField label="Y" value={selectedObject.y} onChange={(y) => updateSelected({ y }, 'Update object Y')} />
+                      <NumberField label="Width" value={selectedObject.width} min={1} onChange={(width) => updateSelected({ width: Math.max(1, width) }, 'Update object width')} />
+                      <NumberField label="Height" value={selectedObject.height} min={1} onChange={(height) => updateSelected({ height: Math.max(1, height) }, 'Update object height')} />
+                      <NumberField label="Rotation" value={selectedObject.rotation} onChange={(rotation) => updateSelected({ rotation }, 'Rotate design object')} />
+                      <label className="block"><span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Layer</span><select value={selectedObject.layerId} onChange={(event) => updateSelected({ layerId: event.target.value }, 'Move object to layer')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 bg-white px-2 text-[10px] outline-none focus:border-indigo-500">{document.layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.name}</option>)}</select></label>
+                    </div>
+                  </div>
+
+                  <div>
+                    <SectionTitle>Appearance</SectionTitle>
+                    <div className="mt-2 grid grid-cols-2 gap-2">
+                      <label><span className="text-[9px] font-bold uppercase text-slate-500">Fill</span><input type="color" value={selectedObject.fill === 'transparent' ? '#ffffff' : selectedObject.fill} onChange={(event) => updateSelected({ fill: event.target.value }, 'Update fill')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 bg-white p-1" /></label>
+                      <label><span className="text-[9px] font-bold uppercase text-slate-500">Stroke</span><input type="color" value={selectedObject.stroke === 'transparent' ? '#ffffff' : selectedObject.stroke} onChange={(event) => updateSelected({ stroke: event.target.value }, 'Update stroke')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 bg-white p-1" /></label>
+                      <NumberField label="Stroke" value={selectedObject.strokeWidth} min={0} onChange={(strokeWidth) => updateSelected({ strokeWidth: Math.max(0, strokeWidth) }, 'Update stroke width')} />
+                      <NumberField label="Opacity %" value={selectedObject.opacity * 100} min={0} onChange={(opacity) => updateSelected({ opacity: Math.min(1, Math.max(0, opacity / 100)) }, 'Update opacity')} />
+                    </div>
+                  </div>
+
+                  {selectedObject.type === 'rectangle' && (
+                    <div><SectionTitle>Rectangle</SectionTitle><div className="mt-2"><NumberField label="Corner radius" value={selectedObject.cornerRadius} min={0} onChange={(cornerRadius) => updateObjectById(selectedObject.id, { ...selectedObject, cornerRadius: Math.max(0, cornerRadius) }, 'Update corner radius')} /></div></div>
+                  )}
+
+                  {(selectedObject.type === 'text' || selectedObject.type === 'note') && (() => {
+                    const textObject = selectedObject as ProductDesignText;
+                    return <div><SectionTitle>Text</SectionTitle><textarea value={textObject.text} onChange={(event) => updateObjectById(textObject.id, { ...textObject, text: event.target.value }, 'Update text')} rows={4} className="mt-2 w-full rounded-lg border border-slate-300 p-2 text-[11px] outline-none focus:border-indigo-500" /><div className="mt-2 grid grid-cols-2 gap-2"><NumberField label="Font size" value={textObject.fontSize} min={6} onChange={(fontSize) => updateObjectById(textObject.id, { ...textObject, fontSize: Math.max(6, fontSize) }, 'Update font size')} /><label><span className="text-[9px] font-bold uppercase text-slate-500">Align</span><select value={textObject.textAlign} onChange={(event) => updateObjectById(textObject.id, { ...textObject, textAlign: event.target.value as ProductDesignText['textAlign'] }, 'Update text alignment')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 px-2 text-[10px]"><option value="left">Left</option><option value="center">Centre</option><option value="right">Right</option></select></label></div></div>;
+                  })()}
+
+                  {selectedObject.type === 'dimension' && (() => {
+                    const dimension = selectedObject as ProductDesignDimension;
+                    return <div><SectionTitle>Dimension intent</SectionTitle><div className="mt-2 grid grid-cols-2 gap-2"><NumberField label="Value" value={dimension.value} min={0} onChange={(value) => updateObjectById(dimension.id, { ...dimension, value: Math.max(0, value) }, 'Update dimension intent')} /><label><span className="text-[9px] font-bold uppercase text-slate-500">Units</span><select value={dimension.units} onChange={(event) => updateObjectById(dimension.id, { ...dimension, units: event.target.value as ProductDesignDimension['units'] }, 'Update dimension units')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 px-2 text-[10px]"><option value="mm">mm</option><option value="cm">cm</option><option value="in">in</option></select></label></div><p className="mt-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-[9px] leading-4 text-amber-800">This records product intent. It is not a solved CAD constraint.</p></div>;
+                  })()}
+
+                  {selectedObject.type === 'reference-image' && (() => {
+                    const reference = selectedObject as ProductDesignReferenceImage;
+                    return <div><SectionTitle>Reference provenance</SectionTitle><label className="mt-2 block text-[9px] font-bold uppercase text-slate-500">Fit</label><select value={reference.fit} onChange={(event) => updateObjectById(reference.id, { ...reference, fit: event.target.value as ProductDesignReferenceImage['fit'] }, 'Update image fit')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 px-2 text-[10px]"><option value="contain">Contain</option><option value="cover">Cover</option></select><label className="mt-2 block text-[9px] font-bold uppercase text-slate-500">Attribution</label><input value={reference.attribution} onChange={(event) => updateObjectById(reference.id, { ...reference, attribution: event.target.value }, 'Update image attribution')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 px-2 text-[10px]" /><label className="mt-2 block text-[9px] font-bold uppercase text-slate-500">License</label><input value={reference.license} onChange={(event) => updateObjectById(reference.id, { ...reference, license: event.target.value }, 'Update image license')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 px-2 text-[10px]" /><label className="mt-2 block text-[9px] font-bold uppercase text-slate-500">Alt text</label><textarea value={reference.altText} onChange={(event) => updateObjectById(reference.id, { ...reference, altText: event.target.value }, 'Update image alt text')} rows={2} className="mt-1 w-full rounded-lg border border-slate-300 p-2 text-[10px]" /></div>;
+                  })()}
+
+                  {selectedObject.type === 'concept-part' && (() => {
+                    const concept = selectedObject as ProductDesignConceptPart;
+                    return <div className="space-y-2"><SectionTitle>Concept part</SectionTitle><NumberField label="Depth intent" value={concept.depth} min={1} onChange={(depth) => updateObjectById(concept.id, { ...concept, depth: Math.max(1, depth) }, 'Update concept depth')} /><label className="block text-[9px] font-bold uppercase text-slate-500">Material</label><input value={concept.material} onChange={(event) => updateObjectById(concept.id, { ...concept, material: event.target.value }, 'Update concept material')} className="h-8 w-full rounded-lg border border-slate-300 px-2 text-[10px]" /><label className="block text-[9px] font-bold uppercase text-slate-500">Finish</label><input value={concept.finish} onChange={(event) => updateObjectById(concept.id, { ...concept, finish: event.target.value }, 'Update concept finish')} className="h-8 w-full rounded-lg border border-slate-300 px-2 text-[10px]" /><button type="button" onClick={() => set3DOpen(true)} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-lg bg-indigo-600 text-[11px] font-bold text-white hover:bg-indigo-500"><Layers3 className="h-4 w-4" /> Inspect same part in 3D</button></div>;
+                  })()}
+
+                  <div>
+                    <SectionTitle>Object state</SectionTitle>
+                    <div className="mt-2 grid grid-cols-2 gap-2">
+                      <button type="button" onClick={() => updateSelected({ visible: !selectedObject.visible }, 'Toggle object visibility')} className="inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border border-slate-300 text-[10px] font-bold text-slate-700 hover:bg-slate-50">{selectedObject.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}{selectedObject.visible ? 'Visible' : 'Hidden'}</button>
+                      <button type="button" onClick={() => updateSelected({ locked: !selectedObject.locked }, 'Toggle object lock')} className="inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border border-slate-300 text-[10px] font-bold text-slate-700 hover:bg-slate-50">{selectedObject.locked ? <Lock className="h-3.5 w-3.5" /> : <Unlock className="h-3.5 w-3.5" />}{selectedObject.locked ? 'Locked' : 'Editable'}</button>
+                      <button type="button" onClick={bringSelectedForward} className="inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border border-slate-300 text-[10px] font-bold text-slate-700 hover:bg-slate-50"><BringToFront className="h-3.5 w-3.5" /> Forward</button>
+                      <button type="button" onClick={sendSelectedBackward} className="inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border border-slate-300 text-[10px] font-bold text-slate-700 hover:bg-slate-50"><SendToBack className="h-3.5 w-3.5" /> Backward</button>
+                    </div>
+                    <label className="mt-2 block text-[9px] font-bold uppercase text-slate-500">Notes</label><textarea value={selectedObject.notes} onChange={(event) => updateSelected({ notes: event.target.value }, 'Update design notes')} rows={3} className="mt-1 w-full rounded-lg border border-slate-300 p-2 text-[10px] outline-none focus:border-indigo-500" />
+                  </div>
+                </div>
+              )}
+            </div>
+          </aside>
+        )}
+      </div>
+
+      <footer className="shrink-0 border-t border-slate-200 bg-white">
+        <button type="button" onClick={() => setHistoryOpen((open) => !open)} className="flex h-8 w-full items-center justify-between px-3 text-[10px] font-bold text-slate-600 hover:bg-slate-50"><span>History & checkpoints · {undoStack.length} local commands · {checkpoints.length} checkpoints</span>{historyOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}</button>
+        {historyOpen && (
+          <div className="flex max-h-36 flex-col gap-2 overflow-y-auto border-t border-slate-100 bg-slate-50 p-2 md:flex-row md:items-start">
+            <div className="flex min-w-0 flex-1 gap-1.5 overflow-x-auto">
+              {undoStack.slice(-8).reverse().map((command) => <button key={command.id} type="button" className="min-w-40 rounded-lg border border-slate-200 bg-white p-2 text-left"><span className="block truncate text-[10px] font-bold text-slate-700">{command.label}</span><span className="mt-1 block text-[8px] text-slate-400">{new Date(command.timestamp).toLocaleTimeString()}</span></button>)}
+              {undoStack.length === 0 && <p className="p-2 text-[10px] text-slate-400">Actions appear here after the first edit.</p>}
+            </div>
+            <div className="flex shrink-0 gap-1.5">
+              <input value={checkpointName} onChange={(event) => setCheckpointName(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter') void handleCreateCheckpoint(); }} placeholder="Checkpoint name" className="h-8 w-40 rounded-lg border border-slate-300 bg-white px-2.5 text-[10px] outline-none focus:border-indigo-500" />
+              <button type="button" onClick={() => void handleCreateCheckpoint()} disabled={!checkpointName.trim()} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-slate-950 px-2.5 text-[10px] font-bold text-white hover:bg-slate-800 disabled:opacity-40"><Save className="h-3.5 w-3.5" /> Checkpoint</button>
+            </div>
+            <div className="flex shrink-0 gap-1.5 overflow-x-auto">
+              {checkpoints.slice(0, 4).map((checkpoint) => <div key={checkpoint.id} className="flex min-w-40 items-center gap-1 rounded-lg border border-emerald-200 bg-emerald-50 p-1"><button type="button" onClick={() => restoreCheckpoint(checkpoint.id)} className="min-w-0 flex-1 px-1.5 py-1 text-left"><span className="block truncate text-[9px] font-bold text-emerald-900">{checkpoint.name}</span><span className="block text-[8px] text-emerald-700">rev {checkpoint.document.revision}</span></button><button type="button" onClick={() => void deleteCheckpoint(checkpoint.id)} className="grid h-6 w-6 place-items-center rounded-md text-emerald-700 hover:bg-emerald-100" title="Delete checkpoint"><Trash2 className="h-3 w-3" /></button></div>)}
+            </div>
+          </div>
+        )}
+        <div className="flex h-7 items-center gap-3 border-t border-slate-100 px-3 text-[9px] font-semibold text-slate-500">
+          <span className="truncate">{persistenceMessage}</span><span>{document.objects.length} objects</span><span>{document.layers.length} layers</span><span>{selectedObjectIds.length} selected</span><span className="ml-auto hidden text-amber-700 sm:inline">Concept design · exact engineering continues in Mechanical</span><button type="button" onClick={() => project.setActiveView('mechanical-studio')} className="inline-flex items-center gap-1 font-bold text-indigo-700 hover:text-indigo-900">Mechanical <ArrowRight className="h-3 w-3" /></button>
+        </div>
+      </footer>
+
+      <ProductDesign3DPreview />
+    </section>
+  );
+};

--- a/src/components/product-design/ProductDesignStudio.tsx
+++ b/src/components/product-design/ProductDesignStudio.tsx
@@ -45,7 +45,6 @@ import {
   Undo2,
   Ungroup,
   Unlock,
-  Upload,
   ZoomIn,
   ZoomOut,
 } from 'lucide-react';
@@ -123,7 +122,7 @@ export const ProductDesignStudio: React.FC = () => {
   const project = useProjectStore();
   const initialize = useProductDesignStore((state) => state.initialize);
   const documents = useProductDesignStore((state) => state.documents);
-  const document = useProductDesignStore((state) => state.document);
+  const designDocument = useProductDesignStore((state) => state.document);
   const checkpoints = useProductDesignStore((state) => state.checkpoints);
   const activeLayerId = useProductDesignStore((state) => state.activeLayerId);
   const selectedObjectIds = useProductDesignStore((state) => state.selectedObjectIds);
@@ -171,7 +170,7 @@ export const ProductDesignStudio: React.FC = () => {
   const [historyOpen, setHistoryOpen] = useState(true);
   const [checkpointName, setCheckpointName] = useState('');
   const [newLayerName, setNewLayerName] = useState('');
-  const [expandedLayers, setExpandedLayers] = useState<Record<string, boolean>>({});
+  const [collapsedLayers, setCollapsedLayers] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     void initialize(project.id || 'local-project');
@@ -189,33 +188,21 @@ export const ProductDesignStudio: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [setActiveTool]);
 
-  useEffect(() => {
-    if (!document) return;
-    setExpandedLayers((current) => {
-      const next = { ...current };
-      document.layers.forEach((layer) => {
-        if (next[layer.id] === undefined) next[layer.id] = true;
-      });
-      return next;
-    });
-  }, [document]);
-
   const selectedObjects = useMemo(
-    () => document?.objects.filter((object) => selectedObjectIds.includes(object.id)) || [],
-    [document, selectedObjectIds],
+    () => designDocument?.objects.filter((object) => selectedObjectIds.includes(object.id)) || [],
+    [designDocument, selectedObjectIds],
   );
   const selectedObject = selectedObjects.length === 1 ? selectedObjects[0] : null;
-  const selectedConceptPart = selectedObject?.type === 'concept-part' ? selectedObject : null;
 
   const objectByLayer = useMemo(() => {
     const result = new Map<string, ProductDesignObject[]>();
-    document?.layers.forEach((layer) => result.set(layer.id, []));
-    document?.objects
+    designDocument?.layers.forEach((layer) => result.set(layer.id, []));
+    designDocument?.objects
       .slice()
       .sort((a, b) => b.order - a.order)
       .forEach((object) => result.get(object.layerId)?.push(object));
     return result;
-  }, [document]);
+  }, [designDocument]);
 
   const updateSelected = (patch: Partial<ProductDesignObject>, label: string) => {
     if (!selectedObject) return;
@@ -231,15 +218,14 @@ export const ProductDesignStudio: React.FC = () => {
   };
 
   const handleReferenceFile = async (file: File | undefined) => {
-    if (!file) return;
-    if (!file.type.startsWith('image/')) return;
+    if (!file || !file.type.startsWith('image/')) return;
     await addReferenceImage(file, { altText: file.name });
   };
 
   const handleExport = async () => {
     const content = await exportDocument();
-    if (!content || !document) return;
-    downloadTextFile(`${document.name.replace(/[^a-z0-9]+/gi, '-').toLowerCase() || 'product-design'}.hardware-design.json`, content);
+    if (!content || !designDocument) return;
+    downloadTextFile(`${designDocument.name.replace(/[^a-z0-9]+/gi, '-').toLowerCase() || 'product-design'}.hardware-design.json`, content);
   };
 
   const handleImportFile = async (file: File | undefined) => {
@@ -254,7 +240,7 @@ export const ProductDesignStudio: React.FC = () => {
     setCheckpointName('');
   };
 
-  if (!document) {
+  if (!designDocument) {
     return (
       <section className="grid h-full min-h-0 place-items-center bg-slate-100 p-6">
         <div className="rounded-2xl border border-slate-200 bg-white p-6 text-center shadow-sm">
@@ -276,14 +262,14 @@ export const ProductDesignStudio: React.FC = () => {
           <button type="button" onClick={() => setLeftPanelOpen((open) => !open)} className="grid h-8 w-8 place-items-center rounded-lg text-slate-500 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label={leftPanelOpen ? 'Hide layer panel' : 'Show layer panel'}>{leftPanelOpen ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}</button>
 
           <div className="min-w-[180px] max-w-[280px] flex-1 sm:flex-none">
-            <input value={document.name} onChange={(event) => updateDocument({ name: event.target.value })} aria-label="Product Design document name" className="h-8 w-full rounded-lg border border-transparent px-2 text-sm font-bold text-slate-950 outline-none hover:border-slate-200 focus:border-indigo-400 focus:bg-white" />
-            <p className="truncate px-2 text-[9px] font-semibold text-slate-500">Product Design · revision {document.revision}</p>
+            <input value={designDocument.name} onChange={(event) => updateDocument({ name: event.target.value })} aria-label="Product Design document name" className="h-8 w-full rounded-lg border border-transparent px-2 text-sm font-bold text-slate-950 outline-none hover:border-slate-200 focus:border-indigo-400 focus:bg-white" />
+            <p className="truncate px-2 text-[9px] font-semibold text-slate-500">Product Design · revision {designDocument.revision}</p>
           </div>
 
-          <select value={document.id} onChange={(event) => void openDocument(event.target.value)} aria-label="Open Product Design document" className="h-8 max-w-48 rounded-lg border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 outline-none focus:border-indigo-500">
+          <select value={designDocument.id} onChange={(event) => void openDocument(event.target.value)} aria-label="Open Product Design document" className="h-8 max-w-48 rounded-lg border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 outline-none focus:border-indigo-500">
             {documents.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.name}</option>)}
           </select>
-          <button type="button" onClick={() => void createDocument(`Product concept ${documents.length + 1}`, document.units)} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-2.5 text-[10px] font-bold text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"><Plus className="h-3.5 w-3.5" /> New</button>
+          <button type="button" onClick={() => void createDocument(`Product concept ${documents.length + 1}`, designDocument.units)} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-2.5 text-[10px] font-bold text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"><Plus className="h-3.5 w-3.5" /> New</button>
 
           <div className="hidden h-5 w-px bg-slate-200 md:block" />
           <button type="button" onClick={undo} disabled={undoStack.length === 0} title="Undo · Ctrl/Cmd+Z" className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-slate-100 disabled:opacity-30"><Undo2 className="h-4 w-4" /></button>
@@ -327,13 +313,13 @@ export const ProductDesignStudio: React.FC = () => {
               <input value={newLayerName} onChange={(event) => setNewLayerName(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter') { addLayer(newLayerName.trim() || undefined); setNewLayerName(''); } }} placeholder="New layer name" className="h-8 w-full rounded-lg border border-slate-200 bg-slate-50 px-2.5 text-[11px] outline-none focus:border-indigo-500 focus:bg-white" />
             </div>
             <div className="min-h-0 flex-1 overflow-y-auto p-2">
-              {document.layers.slice().sort((a, b) => a.order - b.order).map((layer) => {
+              {designDocument.layers.slice().sort((a, b) => a.order - b.order).map((layer) => {
                 const objects = objectByLayer.get(layer.id) || [];
-                const expanded = expandedLayers[layer.id] !== false;
+                const expanded = !collapsedLayers[layer.id];
                 return (
                   <div key={layer.id} className={`mb-1 rounded-xl border ${activeLayerId === layer.id ? 'border-indigo-200 bg-indigo-50/50' : 'border-transparent'}`}>
                     <div className="flex items-center gap-1 p-1">
-                      <button type="button" onClick={() => setExpandedLayers((current) => ({ ...current, [layer.id]: !expanded }))} className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white">{expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}</button>
+                      <button type="button" onClick={() => setCollapsedLayers((current) => ({ ...current, [layer.id]: expanded }))} className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white">{expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}</button>
                       <button type="button" onClick={() => setActiveLayer(layer.id)} className="min-w-0 flex-1 truncate text-left text-[11px] font-bold text-slate-800">{layer.name}</button>
                       <button type="button" onClick={() => updateLayer(layer.id, { visible: !layer.visible })} className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white" title={layer.visible ? 'Hide layer' : 'Show layer'}>{layer.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}</button>
                       <button type="button" onClick={() => updateLayer(layer.id, { locked: !layer.locked })} className="grid h-7 w-7 place-items-center rounded-md text-slate-400 hover:bg-white" title={layer.locked ? 'Unlock layer' : 'Lock layer'}>{layer.locked ? <Lock className="h-3.5 w-3.5" /> : <Unlock className="h-3.5 w-3.5" />}</button>
@@ -350,7 +336,7 @@ export const ProductDesignStudio: React.FC = () => {
                         {objects.length === 0 && <p className="px-2 py-2 text-[9px] text-slate-400">Empty layer</p>}
                       </div>
                     )}
-                    {document.layers.length > 1 && activeLayerId === layer.id && (
+                    {designDocument.layers.length > 1 && activeLayerId === layer.id && (
                       <button type="button" onClick={() => deleteLayer(layer.id)} className="mx-2 mb-2 text-[9px] font-semibold text-red-600 hover:text-red-800">Delete layer · objects move safely</button>
                     )}
                   </div>
@@ -411,7 +397,7 @@ export const ProductDesignStudio: React.FC = () => {
                       <NumberField label="Width" value={selectedObject.width} min={1} onChange={(width) => updateSelected({ width: Math.max(1, width) }, 'Update object width')} />
                       <NumberField label="Height" value={selectedObject.height} min={1} onChange={(height) => updateSelected({ height: Math.max(1, height) }, 'Update object height')} />
                       <NumberField label="Rotation" value={selectedObject.rotation} onChange={(rotation) => updateSelected({ rotation }, 'Rotate design object')} />
-                      <label className="block"><span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Layer</span><select value={selectedObject.layerId} onChange={(event) => updateSelected({ layerId: event.target.value }, 'Move object to layer')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 bg-white px-2 text-[10px] outline-none focus:border-indigo-500">{document.layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.name}</option>)}</select></label>
+                      <label className="block"><span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Layer</span><select value={selectedObject.layerId} onChange={(event) => updateSelected({ layerId: event.target.value }, 'Move object to layer')} className="mt-1 h-8 w-full rounded-lg border border-slate-300 bg-white px-2 text-[10px] outline-none focus:border-indigo-500">{designDocument.layers.map((layer) => <option key={layer.id} value={layer.id}>{layer.name}</option>)}</select></label>
                     </div>
                   </div>
 
@@ -484,7 +470,7 @@ export const ProductDesignStudio: React.FC = () => {
           </div>
         )}
         <div className="flex h-7 items-center gap-3 border-t border-slate-100 px-3 text-[9px] font-semibold text-slate-500">
-          <span className="truncate">{persistenceMessage}</span><span>{document.objects.length} objects</span><span>{document.layers.length} layers</span><span>{selectedObjectIds.length} selected</span><span className="ml-auto hidden text-amber-700 sm:inline">Concept design · exact engineering continues in Mechanical</span><button type="button" onClick={() => project.setActiveView('mechanical-studio')} className="inline-flex items-center gap-1 font-bold text-indigo-700 hover:text-indigo-900">Mechanical <ArrowRight className="h-3 w-3" /></button>
+          <span className="truncate">{persistenceMessage}</span><span>{designDocument.objects.length} objects</span><span>{designDocument.layers.length} layers</span><span>{selectedObjectIds.length} selected</span><span className="ml-auto hidden text-amber-700 sm:inline">Concept design · exact engineering continues in Mechanical</span><button type="button" onClick={() => project.setActiveView('mechanical-studio')} className="inline-flex items-center gap-1 font-bold text-indigo-700 hover:text-indigo-900">Mechanical <ArrowRight className="h-3 w-3" /></button>
         </div>
       </footer>
 

--- a/src/components/product/ProductStudio.tsx
+++ b/src/components/product/ProductStudio.tsx
@@ -1,27 +1,47 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
+import {
+  AlertTriangle,
+  Boxes,
+  Plus,
+  Redo2,
+  ShieldAlert,
+  Trash2,
+  Undo2,
+} from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
+import { ProductDesignStudio } from '../product-design/ProductDesignStudio';
 import { ProductArchitectureCanvas } from './ProductArchitectureCanvas';
 import { ProductInspector } from './ProductInspector';
 import { ProductRequirementsPanel } from './ProductRequirementsPanel';
 import { validateArchitectureGraph } from '../../lib/product/productGraph';
-import { Plus, Undo2, Redo2, ZoomIn, ShieldAlert, Trash2 } from 'lucide-react';
 
 interface ProductStudioProps {
   initialMode?: string;
 }
 
-export const ProductStudio: React.FC<ProductStudioProps> = ({ initialMode }) => {
+const productViews = [
+  { id: 'product-design', label: 'Product Design', description: 'Explore form, references, dimensions, concept parts, and appearance.' },
+  { id: 'requirements', label: 'Requirements', description: 'Define measurable product needs and acceptance intent.' },
+  { id: 'product-architecture', label: 'Architecture', description: 'Connect functions, interfaces, and downstream engineering objects.' },
+] as const;
+
+export const ProductStudio: React.FC<ProductStudioProps> = ({ initialMode = 'product-design' }) => {
   const store = useProjectStore();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
   const [showWarnings, setShowWarnings] = useState(false);
 
+  const activeMode = initialMode === 'requirements'
+    ? 'requirements'
+    : initialMode === 'product-architecture' || initialMode === 'risks-interfaces'
+      ? 'product-architecture'
+      : 'product-design';
+
   const architectureNodes = store.architectureNodes || [];
   const architectureConnections = store.architectureConnections || [];
   const requirements = store.requirements || [];
-
   const warnings = validateArchitectureGraph(architectureNodes, architectureConnections, requirements);
 
   const handleAddBlock = useCallback(() => {
@@ -42,107 +62,104 @@ export const ProductStudio: React.FC<ProductStudioProps> = ({ initialMode }) => 
         linkedTestIds: [],
       })
     );
-  }, [store, architectureNodes.length]);
+  }, [architectureNodes.length, store]);
 
   const handleDeleteSelected = useCallback(() => {
     if (selectedNodeId) {
       store.executeProjectCommand('DELETE_NODE', 'Delete architecture block', () => {
-        // Remove connections referencing this node
-        const conns = store.architectureConnections || [];
-        conns.filter(c => c.sourceNodeId === selectedNodeId || c.targetNodeId === selectedNodeId)
-          .forEach(c => store.deleteArchitectureConnection(c.id));
+        const connections = store.architectureConnections || [];
+        connections
+          .filter((connection) => connection.sourceNodeId === selectedNodeId || connection.targetNodeId === selectedNodeId)
+          .forEach((connection) => store.deleteArchitectureConnection(connection.id));
         store.deleteArchitectureNode(selectedNodeId);
       });
       setSelectedNodeId(null);
-    } else if (selectedConnectionId) {
-      store.executeProjectCommand('DELETE_CONN', 'Delete connection', () =>
+      return;
+    }
+    if (selectedConnectionId) {
+      store.executeProjectCommand('DELETE_CONN', 'Delete architecture connection', () =>
         store.deleteArchitectureConnection(selectedConnectionId)
       );
       setSelectedConnectionId(null);
     }
-  }, [selectedNodeId, selectedConnectionId, store]);
+  }, [selectedConnectionId, selectedNodeId, store]);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      {/* Toolbar */}
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px',
-        borderBottom: '1px solid #e2e8f0', background: 'white', flexShrink: 0
-      }}>
-        <button onClick={handleAddBlock} style={toolBtnStyle} title="Add Block">
-          <Plus size={14} /> <span style={{ fontSize: 11 }}>Add Block</span>
-        </button>
-        <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
-        <button onClick={handleDeleteSelected} style={toolBtnStyle} title="Delete Selected"
-          disabled={!selectedNodeId && !selectedConnectionId}>
-          <Trash2 size={14} />
-        </button>
-        <div style={{ width: 1, height: 20, background: '#e2e8f0' }} />
-        <button onClick={() => store.undoProjectCommand()} style={toolBtnStyle} title="Undo">
-          <Undo2 size={14} />
-        </button>
-        <button onClick={() => store.redoProjectCommand()} style={toolBtnStyle} title="Redo">
-          <Redo2 size={14} />
-        </button>
-        <div style={{ flex: 1 }} />
-        <button onClick={() => setShowWarnings(!showWarnings)} style={{
-          ...toolBtnStyle,
-          color: warnings.length > 0 ? '#f59e0b' : '#94a3b8',
-        }}>
-          <ShieldAlert size={14} />
-          <span style={{ fontSize: 11 }}>{warnings.length}</span>
-        </button>
-      </div>
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-100" aria-label="Product workbenches">
+      <nav className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-slate-200 bg-white px-3 py-1.5" aria-label="Product workbench views">
+        <span className="mr-2 shrink-0 text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Product</span>
+        {productViews.map((view) => (
+          <button
+            key={view.id}
+            type="button"
+            onClick={() => store.setActiveView(view.id)}
+            aria-current={activeMode === view.id ? 'page' : undefined}
+            title={view.description}
+            className={`h-8 shrink-0 rounded-lg px-3 text-[10px] font-bold transition focus:outline-none focus:ring-2 focus:ring-indigo-500 ${activeMode === view.id ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100 hover:text-slate-950'}`}
+          >
+            {view.label}
+          </button>
+        ))}
+        <p className="ml-auto hidden truncate text-[9px] text-slate-500 xl:block">{productViews.find((view) => view.id === activeMode)?.description}</p>
+      </nav>
 
-      {/* Main content */}
-      <div style={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
-        {/* Left: Requirements */}
-        <div style={{ width: 240, borderRight: '1px solid #e2e8f0', overflow: 'auto', flexShrink: 0, background: '#fafbfc' }}>
-          <ProductRequirementsPanel />
-        </div>
+      <div className="min-h-0 flex-1">
+        {activeMode === 'product-design' && <ProductDesignStudio />}
 
-        {/* Center: Canvas */}
-        <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
-          <ProductArchitectureCanvas
-            onNodeSelect={setSelectedNodeId}
-            onConnectionSelect={setSelectedConnectionId}
-            selectedNodeId={selectedNodeId}
-          />
-
-          {/* Warnings overlay */}
-          {showWarnings && warnings.length > 0 && (
-            <div style={{
-              position: 'absolute', bottom: 12, left: 12, right: 12,
-              maxHeight: 200, overflow: 'auto', background: 'white',
-              border: '1px solid #fbbf24', borderRadius: 8, padding: 12,
-              boxShadow: '0 4px 12px rgba(0,0,0,0.1)', zIndex: 10
-            }}>
-              <div style={{ fontWeight: 700, fontSize: 12, color: '#92400e', marginBottom: 6 }}>
-                Architecture Warnings ({warnings.length})
-              </div>
-              {warnings.map((w, i) => (
-                <div key={i} style={{ fontSize: 11, color: w.severity === 'Error' ? '#dc2626' : '#d97706', padding: '3px 0', borderBottom: '1px solid #fef3c7' }}>
-                  [{w.severity}] {w.message}
+        {activeMode === 'requirements' && (
+          <div className="flex h-full min-h-0 overflow-hidden bg-slate-50">
+            <div className="min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">
+              <div className="mx-auto max-w-5xl rounded-2xl border border-slate-200 bg-white shadow-sm">
+                <div className="border-b border-slate-200 px-5 py-4">
+                  <p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">Product intent</p>
+                  <h1 className="mt-1 text-xl font-bold tracking-tight text-slate-950">Requirements</h1>
+                  <p className="mt-1 text-sm leading-6 text-slate-600">Define measurable needs here, then link them to architecture, concept parts, engineering objects, and validation evidence.</p>
                 </div>
-              ))}
+                <ProductRequirementsPanel />
+              </div>
             </div>
-          )}
-        </div>
+            <aside className="hidden w-72 shrink-0 border-l border-slate-200 bg-white p-4 xl:block">
+              <div className="flex items-center gap-2"><AlertTriangle className="h-4 w-4 text-amber-600" /><h2 className="text-xs font-bold text-slate-900">Requirement quality</h2></div>
+              <p className="mt-2 text-[10px] leading-5 text-slate-600">A useful requirement states what must be true, how it will be measured, and what evidence will verify it. Avoid hiding design solutions inside needs unless the constraint is deliberate.</p>
+              <dl className="mt-4 space-y-2 text-[10px]"><div className="rounded-xl border border-slate-200 bg-slate-50 p-3"><dt className="font-bold text-slate-800">Current records</dt><dd className="mt-1 text-slate-500">{requirements.length} requirements</dd></div><div className="rounded-xl border border-slate-200 bg-slate-50 p-3"><dt className="font-bold text-slate-800">Next connection</dt><dd className="mt-1 text-slate-500">Link requirements to Product Design concept parts or Architecture blocks rather than copying their text.</dd></div></dl>
+            </aside>
+          </div>
+        )}
 
-        {/* Right: Inspector */}
-        <div style={{ width: 260, borderLeft: '1px solid #e2e8f0', overflow: 'auto', flexShrink: 0, background: '#fafbfc' }}>
-          <ProductInspector
-            selectedNodeId={selectedNodeId}
-            selectedConnectionId={selectedConnectionId}
-          />
-        </div>
+        {activeMode === 'product-architecture' && (
+          <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white">
+            <div className="flex min-h-11 shrink-0 items-center gap-1.5 border-b border-slate-200 px-3 py-2">
+              <button type="button" onClick={handleAddBlock} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-slate-950 px-3 text-[10px] font-bold text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500"><Plus className="h-3.5 w-3.5" /> Add block</button>
+              <button type="button" onClick={handleDeleteSelected} disabled={!selectedNodeId && !selectedConnectionId} className="grid h-8 w-8 place-items-center rounded-lg text-red-600 hover:bg-red-50 disabled:opacity-30" title="Delete selected"><Trash2 className="h-3.5 w-3.5" /></button>
+              <div className="mx-1 h-5 w-px bg-slate-200" />
+              <button type="button" onClick={() => store.undoProjectCommand()} className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-slate-100" title="Undo"><Undo2 className="h-3.5 w-3.5" /></button>
+              <button type="button" onClick={() => store.redoProjectCommand()} className="grid h-8 w-8 place-items-center rounded-lg text-slate-600 hover:bg-slate-100" title="Redo"><Redo2 className="h-3.5 w-3.5" /></button>
+              <div className="ml-auto" />
+              <button type="button" onClick={() => setShowWarnings((visible) => !visible)} className={`inline-flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-[10px] font-bold ${warnings.length > 0 ? 'border-amber-200 bg-amber-50 text-amber-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}><ShieldAlert className="h-3.5 w-3.5" /> {warnings.length} findings</button>
+            </div>
+
+            <div className="flex min-h-0 flex-1 overflow-hidden">
+              <aside className="hidden w-60 shrink-0 overflow-y-auto border-r border-slate-200 bg-slate-50 lg:block"><ProductRequirementsPanel /></aside>
+              <div className="relative min-w-0 flex-1">
+                <ProductArchitectureCanvas
+                  onNodeSelect={setSelectedNodeId}
+                  onConnectionSelect={setSelectedConnectionId}
+                  selectedNodeId={selectedNodeId}
+                />
+                {showWarnings && warnings.length > 0 && (
+                  <div className="absolute bottom-3 left-3 right-3 z-20 max-h-52 overflow-y-auto rounded-xl border border-amber-300 bg-white p-3 shadow-xl">
+                    <div className="mb-2 flex items-center gap-2 text-xs font-bold text-amber-900"><ShieldAlert className="h-4 w-4" /> Architecture findings ({warnings.length})</div>
+                    <div className="space-y-1.5">{warnings.map((warning, index) => <div key={`${warning.message}-${index}`} className={`rounded-lg border p-2 text-[10px] leading-5 ${warning.severity === 'Error' ? 'border-red-200 bg-red-50 text-red-900' : 'border-amber-200 bg-amber-50 text-amber-900'}`}><strong>[{warning.severity}]</strong> {warning.message}</div>)}</div>
+                  </div>
+                )}
+              </div>
+              <aside className="hidden w-72 shrink-0 overflow-y-auto border-l border-slate-200 bg-slate-50 xl:block"><ProductInspector selectedNodeId={selectedNodeId} selectedConnectionId={selectedConnectionId} /></aside>
+            </div>
+
+            <div className="flex h-7 shrink-0 items-center gap-3 border-t border-slate-200 bg-white px-3 text-[9px] font-semibold text-slate-500"><Boxes className="h-3.5 w-3.5" /><span>{architectureNodes.length} architecture blocks</span><span>{architectureConnections.length} connections</span><span>{requirements.length} requirements</span><span className="ml-auto">Architecture describes function and interfaces—not visual product form.</span></div>
+          </div>
+        )}
       </div>
-    </div>
+    </section>
   );
-};
-
-const toolBtnStyle: React.CSSProperties = {
-  display: 'flex', alignItems: 'center', gap: 4, padding: '4px 8px',
-  background: 'none', border: '1px solid #e2e8f0', borderRadius: 4,
-  cursor: 'pointer', color: '#475569', fontSize: 12
 };

--- a/src/components/product/ProductStudio.tsx
+++ b/src/components/product/ProductStudio.tsx
@@ -11,6 +11,7 @@ import {
   Undo2,
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
+import { ProductDesignSafetyBoundary } from '../product-design/ProductDesignSafetyBoundary';
 import { ProductDesignStudio } from '../product-design/ProductDesignStudio';
 import { ProductArchitectureCanvas } from './ProductArchitectureCanvas';
 import { ProductInspector } from './ProductInspector';
@@ -104,7 +105,12 @@ export const ProductStudio: React.FC<ProductStudioProps> = ({ initialMode = 'pro
       </nav>
 
       <div className="min-h-0 flex-1">
-        {activeMode === 'product-design' && <ProductDesignStudio />}
+        {activeMode === 'product-design' && (
+          <div className="flex h-full min-h-0 flex-col overflow-hidden">
+            <ProductDesignSafetyBoundary />
+            <div className="min-h-0 flex-1"><ProductDesignStudio /></div>
+          </div>
+        )}
 
         {activeMode === 'requirements' && (
           <div className="flex h-full min-h-0 overflow-hidden bg-slate-50">

--- a/src/lib/navigationRegistry.ts
+++ b/src/lib/navigationRegistry.ts
@@ -113,15 +113,16 @@ export const navigationDomains: readonly NavigationDomain[] = [
     purpose: 'Project health, progress, and release blockers.',
     items: [
       item('dashboard', 'Project Dashboard', 'See project health, next actions, and current blockers.', 'dashboard', 'dashboard', 'HOME'),
-      item('product-studio', 'Product Studio', 'Work with requirements, architecture, interfaces, and risks.', 'product', 'product-studio', 'WORK'),
+      item('product-studio', 'Product Workspace', 'Open the connected Product Design, Requirements, and Architecture workbenches.', 'product', 'product-studio', 'WORK'),
       item('readiness', 'Release Readiness', 'Review evidence, unresolved findings, and release blockers.', 'readiness', 'readiness', 'GATE'),
     ],
   },
   {
     id: 'product',
     label: 'Product',
-    purpose: 'Define what the product must do and how it is structured.',
+    purpose: 'Explore product form, define intent, and connect it to engineering.',
     items: [
+      item('product-design', 'Product Design', 'Create layered product concepts, references, dimensions, concept parts, and lightweight 3D previews.', 'product', 'product-studio', 'DESIGN'),
       item('requirements', 'Requirements', 'Define measurable product needs and acceptance criteria.', 'requirements', 'product-studio', 'REQ'),
       item('product-architecture', 'Product Architecture', 'Organize functions, interfaces, and system relationships.', 'architecture', 'product-studio', 'ARCH'),
       item('risks-interfaces', 'Risks & Interfaces', 'Track product risks, assumptions, and cross-domain interfaces.', 'risk', 'product-studio', 'RISK'),
@@ -217,7 +218,7 @@ export const compatibleNavigationItems: readonly NavigationItem[] = [
     layout: 'canvas',
     showVisualizer: true,
   }),
-  item('electronics', 'Product Studio', 'Legacy product-electronics section retained for safe project loading.', 'product', 'product-studio', 'WORK'),
+  item('electronics', 'Product Workspace', 'Legacy product-electronics section retained for safe project loading.', 'product', 'product-studio', 'WORK'),
   item('power-budget', 'Power Tree', 'Legacy power-budget ID retained for safe project loading.', 'power', 'power-budget', 'PWR'),
   item('board-studio', 'Board Settings', 'Legacy board-studio ID retained for safe project loading.', 'layers', 'board-studio', 'SET'),
   item('board-components', 'Board Settings', 'Legacy board-components ID retained for safe project loading.', 'layers', 'board-studio', 'SET'),

--- a/src/lib/product-design/importPolicy.ts
+++ b/src/lib/product-design/importPolicy.ts
@@ -44,36 +44,39 @@ function rebaseDocument(
 ): ProductDesignDocument {
   const timestamp = new Date().toISOString();
   const layerIdMap = new Map(source.layers.map((layer) => [layer.id, createProductDesignId('layer')]));
+  const fallbackLayerId = Array.from(layerIdMap.values())[0];
   const objectIdMap = new Map(source.objects.map((object) => [object.id, createProductDesignId('object')]));
   const groupIds = Array.from(new Set(source.objects.map((object) => object.groupId).filter((id): id is string => Boolean(id))));
   const groupIdMap = new Map(groupIds.map((groupId) => [groupId, createProductDesignId('group')]));
 
-  const objects = source.objects.map((object) => {
-    const base = {
+  const objects: ProductDesignObject[] = source.objects.map((object): ProductDesignObject => {
+    const common = {
       ...object,
       id: objectIdMap.get(object.id) as string,
       documentId: targetDocumentId,
-      layerId: layerIdMap.get(object.layerId) || Array.from(layerIdMap.values())[0],
+      layerId: layerIdMap.get(object.layerId) || fallbackLayerId,
       groupId: object.groupId ? groupIdMap.get(object.groupId) : undefined,
       createdAt: timestamp,
       updatedAt: timestamp,
-    } as ProductDesignObject;
+    };
 
-    if (base.type === 'reference-image') {
+    if (object.type === 'reference-image') {
       return {
-        ...base,
-        assetId: assetIdMap.get(object.type === 'reference-image' ? object.assetId : '') || createProductDesignId('asset'),
+        ...common,
+        type: 'reference-image',
+        assetId: assetIdMap.get(object.assetId) || createProductDesignId('asset'),
       };
     }
-    if (base.type === 'concept-part') {
+    if (object.type === 'concept-part') {
       return {
-        ...base,
-        sourceObjectIds: object.type === 'concept-part'
-          ? object.sourceObjectIds.map((id) => objectIdMap.get(id)).filter((id): id is string => Boolean(id))
-          : [],
+        ...common,
+        type: 'concept-part',
+        sourceObjectIds: object.sourceObjectIds
+          .map((id) => objectIdMap.get(id))
+          .filter((id): id is string => Boolean(id)),
       };
     }
-    return base;
+    return common;
   });
 
   return {

--- a/src/lib/product-design/importPolicy.ts
+++ b/src/lib/product-design/importPolicy.ts
@@ -44,14 +44,13 @@ function rebaseDocument(
 ): ProductDesignDocument {
   const timestamp = new Date().toISOString();
   const layerIdMap = new Map(source.layers.map((layer) => [layer.id, createProductDesignId('layer')]));
-  const fallbackLayerId = Array.from(layerIdMap.values())[0];
+  const fallbackLayerId = Array.from(layerIdMap.values())[0] || createProductDesignId('layer');
   const objectIdMap = new Map(source.objects.map((object) => [object.id, createProductDesignId('object')]));
   const groupIds = Array.from(new Set(source.objects.map((object) => object.groupId).filter((id): id is string => Boolean(id))));
   const groupIdMap = new Map(groupIds.map((groupId) => [groupId, createProductDesignId('group')]));
 
   const objects: ProductDesignObject[] = source.objects.map((object): ProductDesignObject => {
-    const common = {
-      ...object,
+    const identity = {
       id: objectIdMap.get(object.id) as string,
       documentId: targetDocumentId,
       layerId: layerIdMap.get(object.layerId) || fallbackLayerId,
@@ -62,21 +61,26 @@ function rebaseDocument(
 
     if (object.type === 'reference-image') {
       return {
-        ...common,
+        ...object,
+        ...identity,
         type: 'reference-image',
         assetId: assetIdMap.get(object.assetId) || createProductDesignId('asset'),
       };
     }
     if (object.type === 'concept-part') {
       return {
-        ...common,
+        ...object,
+        ...identity,
         type: 'concept-part',
         sourceObjectIds: object.sourceObjectIds
           .map((id) => objectIdMap.get(id))
           .filter((id): id is string => Boolean(id)),
       };
     }
-    return common;
+    return {
+      ...object,
+      ...identity,
+    };
   });
 
   return {
@@ -86,7 +90,7 @@ function rebaseDocument(
     name: appendCopyLabel ? `${source.name} (imported copy)` : source.name,
     layers: source.layers.map((layer, index) => ({
       ...layer,
-      id: layerIdMap.get(layer.id) as string,
+      id: layerIdMap.get(layer.id) || fallbackLayerId,
       documentId: targetDocumentId,
       order: index,
       createdAt: timestamp,
@@ -152,7 +156,7 @@ export function prepareProductDesignImport(
     document,
     assets: bundle.assets.map((asset) => ({
       ...asset,
-      id: assetIdMap.get(asset.id) as string,
+      id: assetIdMap.get(asset.id) || createProductDesignId('asset'),
       documentId: targetDocumentId,
     })),
     checkpoints,

--- a/src/lib/product-design/importPolicy.ts
+++ b/src/lib/product-design/importPolicy.ts
@@ -1,0 +1,163 @@
+import {
+  createProductDesignId,
+  normalizeProductDesignDocument,
+} from './model';
+import type {
+  ProductDesignCheckpoint,
+  ProductDesignDocument,
+  ProductDesignExportBundle,
+  ProductDesignObject,
+} from './types';
+
+export interface ProductDesignImportPlan {
+  mode: 'preserve-identities' | 'create-conflict-safe-copy';
+  serializedBundle: string;
+  documentId: string;
+}
+
+function parseImport(raw: string): ProductDesignExportBundle {
+  const parsed = JSON.parse(raw) as ProductDesignExportBundle | ProductDesignDocument;
+  if ('format' in parsed && parsed.format === 'hardware-studio-product-design') {
+    return {
+      ...parsed,
+      document: normalizeProductDesignDocument(parsed.document),
+      assets: Array.isArray(parsed.assets) ? parsed.assets : [],
+      checkpoints: Array.isArray(parsed.checkpoints) ? parsed.checkpoints : [],
+    };
+  }
+  return {
+    format: 'hardware-studio-product-design',
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    document: normalizeProductDesignDocument(parsed),
+    assets: [],
+    checkpoints: [],
+  };
+}
+
+function rebaseDocument(
+  source: ProductDesignDocument,
+  targetProjectId: string,
+  targetDocumentId: string,
+  assetIdMap: Map<string, string>,
+  appendCopyLabel: boolean,
+): ProductDesignDocument {
+  const timestamp = new Date().toISOString();
+  const layerIdMap = new Map(source.layers.map((layer) => [layer.id, createProductDesignId('layer')]));
+  const objectIdMap = new Map(source.objects.map((object) => [object.id, createProductDesignId('object')]));
+  const groupIds = Array.from(new Set(source.objects.map((object) => object.groupId).filter((id): id is string => Boolean(id))));
+  const groupIdMap = new Map(groupIds.map((groupId) => [groupId, createProductDesignId('group')]));
+
+  const objects = source.objects.map((object) => {
+    const base = {
+      ...object,
+      id: objectIdMap.get(object.id) as string,
+      documentId: targetDocumentId,
+      layerId: layerIdMap.get(object.layerId) || Array.from(layerIdMap.values())[0],
+      groupId: object.groupId ? groupIdMap.get(object.groupId) : undefined,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    } as ProductDesignObject;
+
+    if (base.type === 'reference-image') {
+      return {
+        ...base,
+        assetId: assetIdMap.get(object.type === 'reference-image' ? object.assetId : '') || createProductDesignId('asset'),
+      };
+    }
+    if (base.type === 'concept-part') {
+      return {
+        ...base,
+        sourceObjectIds: object.type === 'concept-part'
+          ? object.sourceObjectIds.map((id) => objectIdMap.get(id)).filter((id): id is string => Boolean(id))
+          : [],
+      };
+    }
+    return base;
+  });
+
+  return {
+    ...source,
+    id: targetDocumentId,
+    projectId: targetProjectId,
+    name: appendCopyLabel ? `${source.name} (imported copy)` : source.name,
+    layers: source.layers.map((layer, index) => ({
+      ...layer,
+      id: layerIdMap.get(layer.id) as string,
+      documentId: targetDocumentId,
+      order: index,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })),
+    objects,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    revision: appendCopyLabel ? 1 : source.revision,
+  };
+}
+
+export function prepareProductDesignImport(
+  raw: string,
+  existingDocuments: ProductDesignDocument[],
+  targetProjectId: string,
+): ProductDesignImportPlan {
+  const bundle = parseImport(raw);
+  const collision = existingDocuments.some((document) => document.id === bundle.document.id);
+
+  if (!collision && bundle.document.projectId === targetProjectId) {
+    return {
+      mode: 'preserve-identities',
+      serializedBundle: JSON.stringify(bundle),
+      documentId: bundle.document.id,
+    };
+  }
+
+  const targetDocumentId = createProductDesignId('design');
+  const assetIdMap = new Map<string, string>();
+  bundle.assets.forEach((asset) => assetIdMap.set(asset.id, createProductDesignId('asset')));
+  bundle.document.objects.forEach((object) => {
+    if (object.type === 'reference-image' && !assetIdMap.has(object.assetId)) {
+      assetIdMap.set(object.assetId, createProductDesignId('asset'));
+    }
+  });
+
+  const document = rebaseDocument(
+    bundle.document,
+    targetProjectId,
+    targetDocumentId,
+    assetIdMap,
+    true,
+  );
+
+  const checkpoints: ProductDesignCheckpoint[] = bundle.checkpoints.map((checkpoint) => ({
+    ...checkpoint,
+    id: createProductDesignId('checkpoint'),
+    documentId: targetDocumentId,
+    createdAt: new Date().toISOString(),
+    document: rebaseDocument(
+      normalizeProductDesignDocument(checkpoint.document),
+      targetProjectId,
+      targetDocumentId,
+      assetIdMap,
+      false,
+    ),
+  }));
+
+  const safeBundle: ProductDesignExportBundle = {
+    ...bundle,
+    exportedAt: new Date().toISOString(),
+    document,
+    assets: bundle.assets.map((asset) => ({
+      ...asset,
+      id: assetIdMap.get(asset.id) as string,
+      documentId: targetDocumentId,
+    })),
+    checkpoints,
+  };
+
+  return {
+    mode: 'create-conflict-safe-copy',
+    serializedBundle: JSON.stringify(safeBundle),
+    documentId: targetDocumentId,
+  };
+}

--- a/src/lib/product-design/model.ts
+++ b/src/lib/product-design/model.ts
@@ -1,0 +1,312 @@
+import type {
+  ProductDesignAuthority,
+  ProductDesignDocument,
+  ProductDesignLayer,
+  ProductDesignObject,
+  ProductDesignObjectType,
+  ProductDesignSelectionBounds,
+  ProductDesignUnits,
+} from './types';
+
+export const PRODUCT_DESIGN_SCHEMA_VERSION = 1;
+
+export function createProductDesignId(prefix: string): string {
+  const randomId = typeof globalThis.crypto?.randomUUID === 'function'
+    ? globalThis.crypto.randomUUID()
+    : `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  return `${prefix}_${randomId}`;
+}
+
+export function cloneProductDesignDocument(document: ProductDesignDocument): ProductDesignDocument {
+  if (typeof structuredClone === 'function') return structuredClone(document);
+  return JSON.parse(JSON.stringify(document)) as ProductDesignDocument;
+}
+
+export function createProductDesignLayer(
+  documentId: string,
+  name: string,
+  order: number,
+): ProductDesignLayer {
+  const timestamp = new Date().toISOString();
+  return {
+    id: createProductDesignId('layer'),
+    documentId,
+    name,
+    order,
+    visible: true,
+    locked: false,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+export function createProductDesignDocument(
+  projectId: string,
+  name = 'Untitled product concept',
+  units: ProductDesignUnits = 'mm',
+): ProductDesignDocument {
+  const timestamp = new Date().toISOString();
+  const id = createProductDesignId('design');
+  return {
+    id,
+    projectId,
+    schemaVersion: PRODUCT_DESIGN_SCHEMA_VERSION,
+    name,
+    description: '',
+    units,
+    canvas: {
+      width: 1200,
+      height: 800,
+      background: '#ffffff',
+      gridSize: 10,
+      gridVisible: true,
+      snapToGrid: true,
+    },
+    layers: [createProductDesignLayer(id, 'Concept', 0)],
+    objects: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    revision: 1,
+  };
+}
+
+function commonObjectFields(
+  document: ProductDesignDocument,
+  type: ProductDesignObjectType,
+  layerId: string,
+  x: number,
+  y: number,
+  authority: ProductDesignAuthority,
+) {
+  const timestamp = new Date().toISOString();
+  return {
+    id: createProductDesignId('object'),
+    documentId: document.id,
+    layerId,
+    type,
+    name: `${type.replace('-', ' ')} ${document.objects.length + 1}`,
+    x,
+    y,
+    width: 140,
+    height: 90,
+    rotation: 0,
+    fill: '#dbeafe',
+    stroke: '#334155',
+    strokeWidth: 2,
+    opacity: 1,
+    visible: true,
+    locked: false,
+    order: document.objects.length,
+    authority,
+    notes: '',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+export function createProductDesignObject(
+  document: ProductDesignDocument,
+  type: ProductDesignObjectType,
+  layerId: string,
+  x: number,
+  y: number,
+): ProductDesignObject {
+  if (type === 'rectangle') {
+    return { ...commonObjectFields(document, type, layerId, x, y, 'concept'), type, cornerRadius: 12 };
+  }
+  if (type === 'ellipse') {
+    return { ...commonObjectFields(document, type, layerId, x, y, 'concept'), type };
+  }
+  if (type === 'line' || type === 'arrow') {
+    return {
+      ...commonObjectFields(document, type, layerId, x, y, 'intent'),
+      type,
+      width: 160,
+      height: 0,
+      fill: 'transparent',
+    };
+  }
+  if (type === 'text') {
+    return {
+      ...commonObjectFields(document, type, layerId, x, y, 'concept'),
+      type,
+      width: 220,
+      height: 44,
+      fill: 'transparent',
+      stroke: 'transparent',
+      text: 'Product text',
+      fontSize: 24,
+      fontWeight: 600,
+      textAlign: 'left',
+    };
+  }
+  if (type === 'note') {
+    return {
+      ...commonObjectFields(document, type, layerId, x, y, 'intent'),
+      type,
+      width: 220,
+      height: 120,
+      fill: '#fef3c7',
+      stroke: '#d97706',
+      text: 'Design note',
+      fontSize: 16,
+      fontWeight: 500,
+      textAlign: 'left',
+    };
+  }
+  if (type === 'dimension') {
+    return {
+      ...commonObjectFields(document, type, layerId, x, y, 'intent'),
+      type,
+      width: 180,
+      height: 24,
+      fill: 'transparent',
+      stroke: '#0f766e',
+      value: 180,
+      units: document.units,
+      prefix: '',
+      suffix: ' intent',
+    };
+  }
+  if (type === 'concept-part') {
+    return {
+      ...commonObjectFields(document, type, layerId, x, y, 'concept'),
+      type,
+      width: 180,
+      height: 120,
+      depth: 24,
+      material: 'Unspecified polymer',
+      finish: 'Concept finish',
+      appearance: '#94a3b8',
+      sourceObjectIds: [],
+      linkedRequirementIds: [],
+    };
+  }
+  if (type === 'reference-image') {
+    return {
+      ...commonObjectFields(document, type, layerId, x, y, 'reference'),
+      type,
+      width: 320,
+      height: 220,
+      fill: '#f8fafc',
+      stroke: '#94a3b8',
+      assetId: '',
+      fit: 'contain',
+      sourceUrl: '',
+      attribution: '',
+      license: '',
+      altText: '',
+    };
+  }
+
+  const exhaustive: never = type;
+  throw new Error(`Unsupported product design object: ${exhaustive}`);
+}
+
+export function touchProductDesignDocument(
+  document: ProductDesignDocument,
+  incrementRevision = true,
+): ProductDesignDocument {
+  return {
+    ...document,
+    schemaVersion: PRODUCT_DESIGN_SCHEMA_VERSION,
+    updatedAt: new Date().toISOString(),
+    revision: incrementRevision ? document.revision + 1 : document.revision,
+  };
+}
+
+export function getProductDesignSelectionBounds(
+  objects: ProductDesignObject[],
+  selectedIds: string[],
+): ProductDesignSelectionBounds | null {
+  const selected = objects.filter((object) => selectedIds.includes(object.id) && object.visible);
+  if (selected.length === 0) return null;
+
+  const left = Math.min(...selected.map((object) => Math.min(object.x, object.x + object.width)));
+  const top = Math.min(...selected.map((object) => Math.min(object.y, object.y + object.height)));
+  const right = Math.max(...selected.map((object) => Math.max(object.x, object.x + object.width)));
+  const bottom = Math.max(...selected.map((object) => Math.max(object.y, object.y + object.height)));
+
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+export function snapProductDesignValue(value: number, gridSize: number, enabled: boolean): number {
+  if (!enabled || gridSize <= 0) return value;
+  return Math.round(value / gridSize) * gridSize;
+}
+
+export function normalizeProductDesignDocument(input: unknown): ProductDesignDocument {
+  if (!input || typeof input !== 'object') throw new Error('Product Design document must be an object.');
+  const raw = input as Partial<ProductDesignDocument>;
+  if (!raw.id || !raw.projectId || !raw.name) throw new Error('Product Design document identity is incomplete.');
+
+  const timestamp = new Date().toISOString();
+  const layers = Array.isArray(raw.layers) && raw.layers.length > 0
+    ? raw.layers.map((layer, index) => ({
+        ...layer,
+        id: layer.id || createProductDesignId('layer'),
+        documentId: raw.id as string,
+        name: layer.name || `Layer ${index + 1}`,
+        order: Number.isFinite(layer.order) ? layer.order : index,
+        visible: layer.visible !== false,
+        locked: Boolean(layer.locked),
+        createdAt: layer.createdAt || timestamp,
+        updatedAt: layer.updatedAt || timestamp,
+      }))
+    : [createProductDesignLayer(raw.id, 'Concept', 0)];
+  const layerIds = new Set(layers.map((layer) => layer.id));
+  const fallbackLayerId = layers[0].id;
+
+  const objects = Array.isArray(raw.objects)
+    ? raw.objects.map((object, index) => ({
+        ...object,
+        id: object.id || createProductDesignId('object'),
+        documentId: raw.id as string,
+        layerId: layerIds.has(object.layerId) ? object.layerId : fallbackLayerId,
+        name: object.name || `${object.type || 'object'} ${index + 1}`,
+        x: Number(object.x) || 0,
+        y: Number(object.y) || 0,
+        width: Number.isFinite(object.width) ? Number(object.width) : 100,
+        height: Number.isFinite(object.height) ? Number(object.height) : 100,
+        rotation: Number(object.rotation) || 0,
+        fill: object.fill || '#dbeafe',
+        stroke: object.stroke || '#334155',
+        strokeWidth: Number.isFinite(object.strokeWidth) ? Number(object.strokeWidth) : 2,
+        opacity: Number.isFinite(object.opacity) ? Number(object.opacity) : 1,
+        visible: object.visible !== false,
+        locked: Boolean(object.locked),
+        order: Number.isFinite(object.order) ? Number(object.order) : index,
+        authority: object.authority || 'concept',
+        notes: object.notes || '',
+        createdAt: object.createdAt || timestamp,
+        updatedAt: object.updatedAt || timestamp,
+      })) as ProductDesignObject[]
+    : [];
+
+  return {
+    id: raw.id,
+    projectId: raw.projectId,
+    schemaVersion: PRODUCT_DESIGN_SCHEMA_VERSION,
+    name: raw.name,
+    description: raw.description || '',
+    units: raw.units || 'mm',
+    canvas: {
+      width: raw.canvas?.width || 1200,
+      height: raw.canvas?.height || 800,
+      background: raw.canvas?.background || '#ffffff',
+      gridSize: raw.canvas?.gridSize || 10,
+      gridVisible: raw.canvas?.gridVisible !== false,
+      snapToGrid: raw.canvas?.snapToGrid !== false,
+    },
+    layers,
+    objects,
+    createdAt: raw.createdAt || timestamp,
+    updatedAt: raw.updatedAt || timestamp,
+    revision: Math.max(1, Number(raw.revision) || 1),
+  };
+}
+
+export function objectTypeFromTool(tool: string): ProductDesignObjectType | null {
+  if (tool === 'rectangle' || tool === 'ellipse' || tool === 'line' || tool === 'arrow' || tool === 'text' || tool === 'note' || tool === 'dimension' || tool === 'reference-image') return tool;
+  return null;
+}

--- a/src/lib/product-design/repository.ts
+++ b/src/lib/product-design/repository.ts
@@ -1,0 +1,252 @@
+import type {
+  ProductDesignAsset,
+  ProductDesignCheckpoint,
+  ProductDesignDocument,
+  ProductDesignRepository,
+} from './types';
+import { cloneProductDesignDocument, normalizeProductDesignDocument } from './model';
+
+const DATABASE_NAME = 'hardware-studio-product-design';
+const DATABASE_VERSION = 1;
+const DOCUMENTS_STORE = 'documents';
+const ASSETS_STORE = 'assets';
+const CHECKPOINTS_STORE = 'checkpoints';
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('IndexedDB request failed.'));
+  });
+}
+
+function transactionToPromise(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error || new Error('IndexedDB transaction was aborted.'));
+    transaction.onerror = () => reject(transaction.error || new Error('IndexedDB transaction failed.'));
+  });
+}
+
+async function openProductDesignDatabase(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') throw new Error('IndexedDB is unavailable in this environment.');
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(DOCUMENTS_STORE)) {
+        const store = database.createObjectStore(DOCUMENTS_STORE, { keyPath: 'id' });
+        store.createIndex('projectId', 'projectId', { unique: false });
+        store.createIndex('updatedAt', 'updatedAt', { unique: false });
+      }
+      if (!database.objectStoreNames.contains(ASSETS_STORE)) {
+        const store = database.createObjectStore(ASSETS_STORE, { keyPath: 'id' });
+        store.createIndex('documentId', 'documentId', { unique: false });
+      }
+      if (!database.objectStoreNames.contains(CHECKPOINTS_STORE)) {
+        const store = database.createObjectStore(CHECKPOINTS_STORE, { keyPath: 'id' });
+        store.createIndex('documentId', 'documentId', { unique: false });
+        store.createIndex('createdAt', 'createdAt', { unique: false });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('Unable to open Product Design database.'));
+    request.onblocked = () => reject(new Error('Product Design database upgrade is blocked by another tab.'));
+  });
+}
+
+export class IndexedDbProductDesignRepository implements ProductDesignRepository {
+  private databasePromise: Promise<IDBDatabase> | null = null;
+
+  private database(): Promise<IDBDatabase> {
+    this.databasePromise ||= openProductDesignDatabase();
+    return this.databasePromise;
+  }
+
+  async listDocuments(projectId: string): Promise<ProductDesignDocument[]> {
+    const database = await this.database();
+    const transaction = database.transaction(DOCUMENTS_STORE, 'readonly');
+    const records = await requestToPromise(
+      transaction.objectStore(DOCUMENTS_STORE).index('projectId').getAll(projectId),
+    );
+    await transactionToPromise(transaction);
+    return (records as ProductDesignDocument[])
+      .map(normalizeProductDesignDocument)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  async getDocument(documentId: string): Promise<ProductDesignDocument | null> {
+    const database = await this.database();
+    const transaction = database.transaction(DOCUMENTS_STORE, 'readonly');
+    const record = await requestToPromise(transaction.objectStore(DOCUMENTS_STORE).get(documentId));
+    await transactionToPromise(transaction);
+    return record ? normalizeProductDesignDocument(record) : null;
+  }
+
+  async saveDocument(document: ProductDesignDocument): Promise<void> {
+    const database = await this.database();
+    const transaction = database.transaction(DOCUMENTS_STORE, 'readwrite');
+    transaction.objectStore(DOCUMENTS_STORE).put(cloneProductDesignDocument(document));
+    await transactionToPromise(transaction);
+  }
+
+  async deleteDocument(documentId: string): Promise<void> {
+    const database = await this.database();
+    const transaction = database.transaction(
+      [DOCUMENTS_STORE, ASSETS_STORE, CHECKPOINTS_STORE],
+      'readwrite',
+    );
+    transaction.objectStore(DOCUMENTS_STORE).delete(documentId);
+
+    const assetIndex = transaction.objectStore(ASSETS_STORE).index('documentId');
+    const checkpointIndex = transaction.objectStore(CHECKPOINTS_STORE).index('documentId');
+    const assetKeys = await requestToPromise(assetIndex.getAllKeys(documentId));
+    const checkpointKeys = await requestToPromise(checkpointIndex.getAllKeys(documentId));
+    assetKeys.forEach((key) => transaction.objectStore(ASSETS_STORE).delete(key));
+    checkpointKeys.forEach((key) => transaction.objectStore(CHECKPOINTS_STORE).delete(key));
+    await transactionToPromise(transaction);
+  }
+
+  async saveAsset(asset: ProductDesignAsset): Promise<void> {
+    const database = await this.database();
+    const transaction = database.transaction(ASSETS_STORE, 'readwrite');
+    transaction.objectStore(ASSETS_STORE).put(asset);
+    await transactionToPromise(transaction);
+  }
+
+  async getAsset(assetId: string): Promise<ProductDesignAsset | null> {
+    const database = await this.database();
+    const transaction = database.transaction(ASSETS_STORE, 'readonly');
+    const asset = await requestToPromise(transaction.objectStore(ASSETS_STORE).get(assetId));
+    await transactionToPromise(transaction);
+    return (asset as ProductDesignAsset | undefined) || null;
+  }
+
+  async listAssets(documentId: string): Promise<ProductDesignAsset[]> {
+    const database = await this.database();
+    const transaction = database.transaction(ASSETS_STORE, 'readonly');
+    const assets = await requestToPromise(
+      transaction.objectStore(ASSETS_STORE).index('documentId').getAll(documentId),
+    );
+    await transactionToPromise(transaction);
+    return assets as ProductDesignAsset[];
+  }
+
+  async deleteAsset(assetId: string): Promise<void> {
+    const database = await this.database();
+    const transaction = database.transaction(ASSETS_STORE, 'readwrite');
+    transaction.objectStore(ASSETS_STORE).delete(assetId);
+    await transactionToPromise(transaction);
+  }
+
+  async saveCheckpoint(checkpoint: ProductDesignCheckpoint): Promise<void> {
+    const database = await this.database();
+    const transaction = database.transaction(CHECKPOINTS_STORE, 'readwrite');
+    transaction.objectStore(CHECKPOINTS_STORE).put({
+      ...checkpoint,
+      document: cloneProductDesignDocument(checkpoint.document),
+    });
+    await transactionToPromise(transaction);
+  }
+
+  async listCheckpoints(documentId: string): Promise<ProductDesignCheckpoint[]> {
+    const database = await this.database();
+    const transaction = database.transaction(CHECKPOINTS_STORE, 'readonly');
+    const checkpoints = await requestToPromise(
+      transaction.objectStore(CHECKPOINTS_STORE).index('documentId').getAll(documentId),
+    );
+    await transactionToPromise(transaction);
+    return (checkpoints as ProductDesignCheckpoint[])
+      .map((checkpoint) => ({
+        ...checkpoint,
+        document: normalizeProductDesignDocument(checkpoint.document),
+      }))
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async deleteCheckpoint(checkpointId: string): Promise<void> {
+    const database = await this.database();
+    const transaction = database.transaction(CHECKPOINTS_STORE, 'readwrite');
+    transaction.objectStore(CHECKPOINTS_STORE).delete(checkpointId);
+    await transactionToPromise(transaction);
+  }
+}
+
+export class MemoryProductDesignRepository implements ProductDesignRepository {
+  private readonly documents = new Map<string, ProductDesignDocument>();
+  private readonly assets = new Map<string, ProductDesignAsset>();
+  private readonly checkpoints = new Map<string, ProductDesignCheckpoint>();
+
+  async listDocuments(projectId: string): Promise<ProductDesignDocument[]> {
+    return Array.from(this.documents.values())
+      .filter((document) => document.projectId === projectId)
+      .map(cloneProductDesignDocument)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  async getDocument(documentId: string): Promise<ProductDesignDocument | null> {
+    const document = this.documents.get(documentId);
+    return document ? cloneProductDesignDocument(document) : null;
+  }
+
+  async saveDocument(document: ProductDesignDocument): Promise<void> {
+    this.documents.set(document.id, cloneProductDesignDocument(document));
+  }
+
+  async deleteDocument(documentId: string): Promise<void> {
+    this.documents.delete(documentId);
+    for (const [assetId, asset] of this.assets) {
+      if (asset.documentId === documentId) this.assets.delete(assetId);
+    }
+    for (const [checkpointId, checkpoint] of this.checkpoints) {
+      if (checkpoint.documentId === documentId) this.checkpoints.delete(checkpointId);
+    }
+  }
+
+  async saveAsset(asset: ProductDesignAsset): Promise<void> {
+    this.assets.set(asset.id, asset);
+  }
+
+  async getAsset(assetId: string): Promise<ProductDesignAsset | null> {
+    return this.assets.get(assetId) || null;
+  }
+
+  async listAssets(documentId: string): Promise<ProductDesignAsset[]> {
+    return Array.from(this.assets.values()).filter((asset) => asset.documentId === documentId);
+  }
+
+  async deleteAsset(assetId: string): Promise<void> {
+    this.assets.delete(assetId);
+  }
+
+  async saveCheckpoint(checkpoint: ProductDesignCheckpoint): Promise<void> {
+    this.checkpoints.set(checkpoint.id, {
+      ...checkpoint,
+      document: cloneProductDesignDocument(checkpoint.document),
+    });
+  }
+
+  async listCheckpoints(documentId: string): Promise<ProductDesignCheckpoint[]> {
+    return Array.from(this.checkpoints.values())
+      .filter((checkpoint) => checkpoint.documentId === documentId)
+      .map((checkpoint) => ({
+        ...checkpoint,
+        document: cloneProductDesignDocument(checkpoint.document),
+      }))
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async deleteCheckpoint(checkpointId: string): Promise<void> {
+    this.checkpoints.delete(checkpointId);
+  }
+}
+
+let browserRepository: ProductDesignRepository | null = null;
+
+export function createProductDesignRepository(): ProductDesignRepository {
+  if (typeof window === 'undefined' || typeof indexedDB === 'undefined') {
+    return new MemoryProductDesignRepository();
+  }
+  browserRepository ||= new IndexedDbProductDesignRepository();
+  return browserRepository;
+}

--- a/src/lib/product-design/repository.ts
+++ b/src/lib/product-design/repository.ts
@@ -27,6 +27,26 @@ function transactionToPromise(transaction: IDBTransaction): Promise<void> {
   });
 }
 
+function deleteRecordsByIndex(
+  store: IDBObjectStore,
+  indexName: string,
+  value: IDBValidKey,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = store.index(indexName).openCursor(IDBKeyRange.only(value));
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor) {
+        resolve();
+        return;
+      }
+      cursor.delete();
+      cursor.continue();
+    };
+    request.onerror = () => reject(request.error || new Error(`Unable to delete records from ${indexName}.`));
+  });
+}
+
 async function openProductDesignDatabase(): Promise<IDBDatabase> {
   if (typeof indexedDB === 'undefined') throw new Error('IndexedDB is unavailable in this environment.');
 
@@ -97,13 +117,10 @@ export class IndexedDbProductDesignRepository implements ProductDesignRepository
       'readwrite',
     );
     transaction.objectStore(DOCUMENTS_STORE).delete(documentId);
-
-    const assetIndex = transaction.objectStore(ASSETS_STORE).index('documentId');
-    const checkpointIndex = transaction.objectStore(CHECKPOINTS_STORE).index('documentId');
-    const assetKeys = await requestToPromise(assetIndex.getAllKeys(documentId));
-    const checkpointKeys = await requestToPromise(checkpointIndex.getAllKeys(documentId));
-    assetKeys.forEach((key) => transaction.objectStore(ASSETS_STORE).delete(key));
-    checkpointKeys.forEach((key) => transaction.objectStore(CHECKPOINTS_STORE).delete(key));
+    await Promise.all([
+      deleteRecordsByIndex(transaction.objectStore(ASSETS_STORE), 'documentId', documentId),
+      deleteRecordsByIndex(transaction.objectStore(CHECKPOINTS_STORE), 'documentId', documentId),
+    ]);
     await transactionToPromise(transaction);
   }
 

--- a/src/lib/product-design/types.ts
+++ b/src/lib/product-design/types.ts
@@ -120,6 +120,33 @@ export type ProductDesignObject =
   | ProductDesignReferenceImage
   | ProductDesignConceptPart;
 
+export type ProductDesignObjectPatch = Partial<
+  Omit<ProductDesignBaseObject, 'id' | 'documentId' | 'type' | 'createdAt'>
+> & {
+  cornerRadius?: number;
+  text?: string;
+  fontSize?: number;
+  fontWeight?: number;
+  textAlign?: 'left' | 'center' | 'right';
+  value?: number;
+  units?: ProductDesignUnits;
+  prefix?: string;
+  suffix?: string;
+  assetId?: string;
+  fit?: 'contain' | 'cover';
+  sourceUrl?: string;
+  attribution?: string;
+  license?: string;
+  altText?: string;
+  depth?: number;
+  material?: string;
+  finish?: string;
+  appearance?: string;
+  sourceObjectIds?: string[];
+  linkedMechanicalObjectId?: string;
+  linkedRequirementIds?: string[];
+};
+
 export interface ProductDesignCanvasSettings {
   width: number;
   height: number;

--- a/src/lib/product-design/types.ts
+++ b/src/lib/product-design/types.ts
@@ -3,20 +3,24 @@ export type ProductDesignUnits = 'mm' | 'cm' | 'in';
 export type ProductDesignTool =
   | 'select'
   | 'pan'
+  | 'frame'
   | 'rectangle'
   | 'ellipse'
   | 'line'
   | 'arrow'
+  | 'freehand'
   | 'text'
   | 'note'
   | 'dimension'
   | 'reference-image';
 
 export type ProductDesignObjectType =
+  | 'frame'
   | 'rectangle'
   | 'ellipse'
   | 'line'
   | 'arrow'
+  | 'freehand-path'
   | 'text'
   | 'note'
   | 'dimension'
@@ -24,6 +28,11 @@ export type ProductDesignObjectType =
   | 'concept-part';
 
 export type ProductDesignAuthority = 'concept' | 'intent' | 'reference' | 'qualified';
+
+export interface ProductDesignPoint {
+  x: number;
+  y: number;
+}
 
 export interface ProductDesignLayer {
   id: string;
@@ -61,6 +70,12 @@ export interface ProductDesignBaseObject {
   updatedAt: string;
 }
 
+export interface ProductDesignFrame extends ProductDesignBaseObject {
+  type: 'frame';
+  title: string;
+  clipContent: boolean;
+}
+
 export interface ProductDesignRectangle extends ProductDesignBaseObject {
   type: 'rectangle';
   cornerRadius: number;
@@ -72,6 +87,12 @@ export interface ProductDesignEllipse extends ProductDesignBaseObject {
 
 export interface ProductDesignLine extends ProductDesignBaseObject {
   type: 'line' | 'arrow';
+}
+
+export interface ProductDesignFreehandPath extends ProductDesignBaseObject {
+  type: 'freehand-path';
+  points: ProductDesignPoint[];
+  smoothing: number;
 }
 
 export interface ProductDesignText extends ProductDesignBaseObject {
@@ -112,9 +133,11 @@ export interface ProductDesignConceptPart extends ProductDesignBaseObject {
 }
 
 export type ProductDesignObject =
+  | ProductDesignFrame
   | ProductDesignRectangle
   | ProductDesignEllipse
   | ProductDesignLine
+  | ProductDesignFreehandPath
   | ProductDesignText
   | ProductDesignDimension
   | ProductDesignReferenceImage
@@ -123,7 +146,11 @@ export type ProductDesignObject =
 export type ProductDesignObjectPatch = Partial<
   Omit<ProductDesignBaseObject, 'id' | 'documentId' | 'type' | 'createdAt'>
 > & {
+  title?: string;
+  clipContent?: boolean;
   cornerRadius?: number;
+  points?: ProductDesignPoint[];
+  smoothing?: number;
   text?: string;
   fontSize?: number;
   fontWeight?: number;

--- a/src/lib/product-design/types.ts
+++ b/src/lib/product-design/types.ts
@@ -1,0 +1,226 @@
+export type ProductDesignUnits = 'mm' | 'cm' | 'in';
+
+export type ProductDesignTool =
+  | 'select'
+  | 'pan'
+  | 'rectangle'
+  | 'ellipse'
+  | 'line'
+  | 'arrow'
+  | 'text'
+  | 'note'
+  | 'dimension'
+  | 'reference-image';
+
+export type ProductDesignObjectType =
+  | 'rectangle'
+  | 'ellipse'
+  | 'line'
+  | 'arrow'
+  | 'text'
+  | 'note'
+  | 'dimension'
+  | 'reference-image'
+  | 'concept-part';
+
+export type ProductDesignAuthority = 'concept' | 'intent' | 'reference' | 'qualified';
+
+export interface ProductDesignLayer {
+  id: string;
+  documentId: string;
+  name: string;
+  order: number;
+  visible: boolean;
+  locked: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductDesignBaseObject {
+  id: string;
+  documentId: string;
+  layerId: string;
+  groupId?: string;
+  type: ProductDesignObjectType;
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  opacity: number;
+  visible: boolean;
+  locked: boolean;
+  order: number;
+  authority: ProductDesignAuthority;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProductDesignRectangle extends ProductDesignBaseObject {
+  type: 'rectangle';
+  cornerRadius: number;
+}
+
+export interface ProductDesignEllipse extends ProductDesignBaseObject {
+  type: 'ellipse';
+}
+
+export interface ProductDesignLine extends ProductDesignBaseObject {
+  type: 'line' | 'arrow';
+}
+
+export interface ProductDesignText extends ProductDesignBaseObject {
+  type: 'text' | 'note';
+  text: string;
+  fontSize: number;
+  fontWeight: number;
+  textAlign: 'left' | 'center' | 'right';
+}
+
+export interface ProductDesignDimension extends ProductDesignBaseObject {
+  type: 'dimension';
+  value: number;
+  units: ProductDesignUnits;
+  prefix: string;
+  suffix: string;
+}
+
+export interface ProductDesignReferenceImage extends ProductDesignBaseObject {
+  type: 'reference-image';
+  assetId: string;
+  fit: 'contain' | 'cover';
+  sourceUrl: string;
+  attribution: string;
+  license: string;
+  altText: string;
+}
+
+export interface ProductDesignConceptPart extends ProductDesignBaseObject {
+  type: 'concept-part';
+  depth: number;
+  material: string;
+  finish: string;
+  appearance: string;
+  sourceObjectIds: string[];
+  linkedMechanicalObjectId?: string;
+  linkedRequirementIds: string[];
+}
+
+export type ProductDesignObject =
+  | ProductDesignRectangle
+  | ProductDesignEllipse
+  | ProductDesignLine
+  | ProductDesignText
+  | ProductDesignDimension
+  | ProductDesignReferenceImage
+  | ProductDesignConceptPart;
+
+export interface ProductDesignCanvasSettings {
+  width: number;
+  height: number;
+  background: string;
+  gridSize: number;
+  gridVisible: boolean;
+  snapToGrid: boolean;
+}
+
+export interface ProductDesignDocument {
+  id: string;
+  projectId: string;
+  schemaVersion: number;
+  name: string;
+  description: string;
+  units: ProductDesignUnits;
+  canvas: ProductDesignCanvasSettings;
+  layers: ProductDesignLayer[];
+  objects: ProductDesignObject[];
+  createdAt: string;
+  updatedAt: string;
+  revision: number;
+}
+
+export interface ProductDesignAsset {
+  id: string;
+  documentId: string;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  checksum?: string;
+  sourceUrl: string;
+  attribution: string;
+  license: string;
+  altText: string;
+  blob: Blob;
+  createdAt: string;
+}
+
+export interface ProductDesignCheckpoint {
+  id: string;
+  documentId: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  document: ProductDesignDocument;
+}
+
+export type ProductDesignCommandType =
+  | 'CREATE_DOCUMENT'
+  | 'UPDATE_DOCUMENT'
+  | 'CREATE_LAYER'
+  | 'UPDATE_LAYER'
+  | 'DELETE_LAYER'
+  | 'CREATE_OBJECT'
+  | 'UPDATE_OBJECT'
+  | 'DELETE_OBJECTS'
+  | 'DUPLICATE_OBJECTS'
+  | 'GROUP_OBJECTS'
+  | 'UNGROUP_OBJECTS'
+  | 'REORDER_OBJECT'
+  | 'CREATE_CONCEPT_PART'
+  | 'IMPORT_DOCUMENT'
+  | 'RESTORE_CHECKPOINT';
+
+export interface ProductDesignCommandRecord {
+  id: string;
+  documentId: string;
+  type: ProductDesignCommandType;
+  label: string;
+  timestamp: string;
+  before: ProductDesignDocument;
+  after: ProductDesignDocument;
+}
+
+export interface ProductDesignExportBundle {
+  format: 'hardware-studio-product-design';
+  version: 1;
+  exportedAt: string;
+  document: ProductDesignDocument;
+  assets: Array<Omit<ProductDesignAsset, 'blob'> & { dataUrl?: string }>;
+  checkpoints: ProductDesignCheckpoint[];
+}
+
+export interface ProductDesignRepository {
+  listDocuments(projectId: string): Promise<ProductDesignDocument[]>;
+  getDocument(documentId: string): Promise<ProductDesignDocument | null>;
+  saveDocument(document: ProductDesignDocument): Promise<void>;
+  deleteDocument(documentId: string): Promise<void>;
+  saveAsset(asset: ProductDesignAsset): Promise<void>;
+  getAsset(assetId: string): Promise<ProductDesignAsset | null>;
+  listAssets(documentId: string): Promise<ProductDesignAsset[]>;
+  deleteAsset(assetId: string): Promise<void>;
+  saveCheckpoint(checkpoint: ProductDesignCheckpoint): Promise<void>;
+  listCheckpoints(documentId: string): Promise<ProductDesignCheckpoint[]>;
+  deleteCheckpoint(checkpointId: string): Promise<void>;
+}
+
+export interface ProductDesignSelectionBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}

--- a/src/store/productDesignStore.ts
+++ b/src/store/productDesignStore.ts
@@ -1,0 +1,714 @@
+'use client';
+
+import { create } from 'zustand';
+import {
+  cloneProductDesignDocument,
+  createProductDesignDocument,
+  createProductDesignId,
+  createProductDesignLayer,
+  createProductDesignObject,
+  getProductDesignSelectionBounds,
+  normalizeProductDesignDocument,
+  snapProductDesignValue,
+  touchProductDesignDocument,
+} from '../lib/product-design/model';
+import {
+  createProductDesignRepository,
+  MemoryProductDesignRepository,
+} from '../lib/product-design/repository';
+import type {
+  ProductDesignAsset,
+  ProductDesignCheckpoint,
+  ProductDesignCommandRecord,
+  ProductDesignCommandType,
+  ProductDesignDocument,
+  ProductDesignExportBundle,
+  ProductDesignLayer,
+  ProductDesignObject,
+  ProductDesignObjectType,
+  ProductDesignRepository,
+  ProductDesignTool,
+  ProductDesignUnits,
+} from '../lib/product-design/types';
+
+type PersistenceStatus = 'idle' | 'loading' | 'saving' | 'saved' | 'error';
+
+type ObjectPatch = Partial<ProductDesignObject>;
+
+interface ProductDesignStoreState {
+  repository: ProductDesignRepository;
+  projectId: string;
+  documents: ProductDesignDocument[];
+  document: ProductDesignDocument | null;
+  checkpoints: ProductDesignCheckpoint[];
+  activeLayerId: string | null;
+  selectedObjectIds: string[];
+  activeTool: ProductDesignTool;
+  zoom: number;
+  panX: number;
+  panY: number;
+  previewPatches: Record<string, ObjectPatch>;
+  assetUrls: Record<string, string>;
+  missingAssetIds: string[];
+  persistenceStatus: PersistenceStatus;
+  persistenceMessage: string;
+  undoStack: ProductDesignCommandRecord[];
+  redoStack: ProductDesignCommandRecord[];
+  is3DOpen: boolean;
+
+  setRepository: (repository: ProductDesignRepository) => void;
+  initialize: (projectId: string) => Promise<void>;
+  createDocument: (name?: string, units?: ProductDesignUnits) => Promise<ProductDesignDocument>;
+  openDocument: (documentId: string) => Promise<void>;
+  updateDocument: (patch: Partial<Pick<ProductDesignDocument, 'name' | 'description' | 'units' | 'canvas'>>) => void;
+  addLayer: (name?: string) => void;
+  updateLayer: (layerId: string, patch: Partial<ProductDesignLayer>) => void;
+  deleteLayer: (layerId: string) => void;
+  setActiveLayer: (layerId: string) => void;
+  addObject: (type: ProductDesignObjectType, x: number, y: number, patch?: ObjectPatch) => string | null;
+  updateObjects: (objectIds: string[], patch: ObjectPatch, label?: string) => void;
+  updateObjectById: (objectId: string, patch: ObjectPatch, label?: string) => void;
+  setPreviewPatch: (objectId: string, patch: ObjectPatch) => void;
+  clearPreviewPatches: () => void;
+  commitPreviewPatches: (label: string) => void;
+  selectObject: (objectId: string | null, additive?: boolean) => void;
+  selectObjects: (objectIds: string[]) => void;
+  deleteSelected: () => void;
+  duplicateSelected: () => void;
+  groupSelected: () => void;
+  ungroupSelected: () => void;
+  bringSelectedForward: () => void;
+  sendSelectedBackward: () => void;
+  moveSelected: (dx: number, dy: number) => void;
+  alignSelected: (alignment: 'left' | 'center-x' | 'right' | 'top' | 'center-y' | 'bottom') => void;
+  createConceptPartFromSelection: () => string | null;
+  addReferenceImage: (file: File, metadata?: Partial<Pick<ProductDesignAsset, 'sourceUrl' | 'attribution' | 'license' | 'altText'>>) => Promise<string | null>;
+  removeAsset: (assetId: string) => Promise<void>;
+  createCheckpoint: (name: string, description?: string) => Promise<ProductDesignCheckpoint | null>;
+  restoreCheckpoint: (checkpointId: string) => void;
+  deleteCheckpoint: (checkpointId: string) => Promise<void>;
+  undo: () => void;
+  redo: () => void;
+  setActiveTool: (tool: ProductDesignTool) => void;
+  setViewport: (patch: Partial<Pick<ProductDesignStoreState, 'zoom' | 'panX' | 'panY'>>) => void;
+  fitDocument: () => void;
+  set3DOpen: (open: boolean) => void;
+  exportDocument: () => Promise<string | null>;
+  importDocument: (raw: string) => Promise<ProductDesignDocument>;
+  resetForTests: () => void;
+}
+
+const MAX_HISTORY = 80;
+
+function revokeAssetUrls(urls: Record<string, string>): void {
+  if (typeof URL === 'undefined') return;
+  Object.values(urls).forEach((url) => URL.revokeObjectURL(url));
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error || new Error('Unable to read asset.'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function dataUrlToBlob(dataUrl: string): Blob {
+  const [header, encoded] = dataUrl.split(',');
+  const mimeType = /data:([^;]+)/.exec(header)?.[1] || 'application/octet-stream';
+  const binary = atob(encoded || '');
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return new Blob([bytes], { type: mimeType });
+}
+
+export const useProductDesignStore = create<ProductDesignStoreState>((set, get) => {
+  const persist = async (document: ProductDesignDocument) => {
+    set({ persistenceStatus: 'saving', persistenceMessage: 'Saving locally…' });
+    try {
+      await get().repository.saveDocument(document);
+      const documents = await get().repository.listDocuments(document.projectId);
+      set({ documents, persistenceStatus: 'saved', persistenceMessage: 'Saved locally' });
+    } catch (error) {
+      set({
+        persistenceStatus: 'error',
+        persistenceMessage: error instanceof Error ? error.message : 'Local save failed.',
+      });
+    }
+  };
+
+  const loadAssets = async (document: ProductDesignDocument) => {
+    revokeAssetUrls(get().assetUrls);
+    const assetUrls: Record<string, string> = {};
+    const missingAssetIds: string[] = [];
+    const references = document.objects.filter((object) => object.type === 'reference-image');
+    await Promise.all(references.map(async (reference) => {
+      const asset = await get().repository.getAsset(reference.assetId);
+      if (!asset) {
+        missingAssetIds.push(reference.assetId);
+        return;
+      }
+      if (typeof URL !== 'undefined') assetUrls[asset.id] = URL.createObjectURL(asset.blob);
+    }));
+    set({ assetUrls, missingAssetIds });
+  };
+
+  const commit = (
+    type: ProductDesignCommandType,
+    label: string,
+    mutate: (draft: ProductDesignDocument) => ProductDesignDocument | void,
+  ) => {
+    const current = get().document;
+    if (!current) return;
+    const before = cloneProductDesignDocument(current);
+    const draft = cloneProductDesignDocument(current);
+    const result = mutate(draft);
+    const after = touchProductDesignDocument(result || draft);
+    const command: ProductDesignCommandRecord = {
+      id: createProductDesignId('command'),
+      documentId: current.id,
+      type,
+      label,
+      timestamp: new Date().toISOString(),
+      before,
+      after: cloneProductDesignDocument(after),
+    };
+    set((state) => ({
+      document: after,
+      undoStack: [...state.undoStack, command].slice(-MAX_HISTORY),
+      redoStack: [],
+      previewPatches: {},
+    }));
+    void persist(after);
+  };
+
+  return {
+    repository: createProductDesignRepository(),
+    projectId: '',
+    documents: [],
+    document: null,
+    checkpoints: [],
+    activeLayerId: null,
+    selectedObjectIds: [],
+    activeTool: 'select',
+    zoom: 1,
+    panX: 40,
+    panY: 40,
+    previewPatches: {},
+    assetUrls: {},
+    missingAssetIds: [],
+    persistenceStatus: 'idle',
+    persistenceMessage: 'Not loaded',
+    undoStack: [],
+    redoStack: [],
+    is3DOpen: false,
+
+    setRepository: (repository) => set({ repository }),
+
+    initialize: async (projectId) => {
+      set({ projectId, persistenceStatus: 'loading', persistenceMessage: 'Opening Product Design…' });
+      try {
+        const documents = await get().repository.listDocuments(projectId);
+        if (documents[0]) {
+          const checkpoints = await get().repository.listCheckpoints(documents[0].id);
+          set({
+            documents,
+            document: documents[0],
+            checkpoints,
+            activeLayerId: documents[0].layers[0]?.id || null,
+            selectedObjectIds: [],
+            undoStack: [],
+            redoStack: [],
+            persistenceStatus: 'saved',
+            persistenceMessage: 'Opened from local database',
+          });
+          await loadAssets(documents[0]);
+          return;
+        }
+        const document = createProductDesignDocument(projectId, 'Product concept');
+        await get().repository.saveDocument(document);
+        set({
+          documents: [document],
+          document,
+          checkpoints: [],
+          activeLayerId: document.layers[0].id,
+          persistenceStatus: 'saved',
+          persistenceMessage: 'Created and saved locally',
+        });
+      } catch (error) {
+        set({
+          persistenceStatus: 'error',
+          persistenceMessage: error instanceof Error ? error.message : 'Unable to open Product Design.',
+        });
+      }
+    },
+
+    createDocument: async (name = 'Product concept', units = 'mm') => {
+      const projectId = get().projectId || 'local-project';
+      const document = createProductDesignDocument(projectId, name, units);
+      await get().repository.saveDocument(document);
+      const documents = await get().repository.listDocuments(projectId);
+      revokeAssetUrls(get().assetUrls);
+      set({
+        document,
+        documents,
+        checkpoints: [],
+        activeLayerId: document.layers[0].id,
+        selectedObjectIds: [],
+        undoStack: [],
+        redoStack: [],
+        assetUrls: {},
+        missingAssetIds: [],
+        persistenceStatus: 'saved',
+        persistenceMessage: 'Created and saved locally',
+      });
+      return document;
+    },
+
+    openDocument: async (documentId) => {
+      set({ persistenceStatus: 'loading', persistenceMessage: 'Opening document…' });
+      const document = await get().repository.getDocument(documentId);
+      if (!document) {
+        set({ persistenceStatus: 'error', persistenceMessage: 'Document was not found.' });
+        return;
+      }
+      const checkpoints = await get().repository.listCheckpoints(document.id);
+      set({
+        document,
+        checkpoints,
+        activeLayerId: document.layers[0]?.id || null,
+        selectedObjectIds: [],
+        undoStack: [],
+        redoStack: [],
+        persistenceStatus: 'saved',
+        persistenceMessage: 'Opened from local database',
+      });
+      await loadAssets(document);
+    },
+
+    updateDocument: (patch) => commit('UPDATE_DOCUMENT', 'Update product design document', (draft) => {
+      Object.assign(draft, patch);
+    }),
+
+    addLayer: (name) => commit('CREATE_LAYER', 'Create design layer', (draft) => {
+      const layer = createProductDesignLayer(draft.id, name || `Layer ${draft.layers.length + 1}`, draft.layers.length);
+      draft.layers.push(layer);
+      set({ activeLayerId: layer.id });
+    }),
+
+    updateLayer: (layerId, patch) => commit('UPDATE_LAYER', 'Update design layer', (draft) => {
+      draft.layers = draft.layers.map((layer) => layer.id === layerId
+        ? { ...layer, ...patch, id: layer.id, documentId: layer.documentId, updatedAt: new Date().toISOString() }
+        : layer);
+    }),
+
+    deleteLayer: (layerId) => {
+      const document = get().document;
+      if (!document || document.layers.length <= 1) return;
+      commit('DELETE_LAYER', 'Delete design layer', (draft) => {
+        const fallback = draft.layers.find((layer) => layer.id !== layerId);
+        if (!fallback) return;
+        draft.objects = draft.objects.map((object) => object.layerId === layerId
+          ? { ...object, layerId: fallback.id, updatedAt: new Date().toISOString() }
+          : object);
+        draft.layers = draft.layers.filter((layer) => layer.id !== layerId)
+          .map((layer, order) => ({ ...layer, order }));
+        set({ activeLayerId: fallback.id });
+      });
+    },
+
+    setActiveLayer: (layerId) => set({ activeLayerId: layerId }),
+
+    addObject: (type, x, y, patch = {}) => {
+      const document = get().document;
+      const activeLayerId = get().activeLayerId || document?.layers[0]?.id;
+      if (!document || !activeLayerId) return null;
+      const object = { ...createProductDesignObject(document, type, activeLayerId, x, y), ...patch } as ProductDesignObject;
+      commit('CREATE_OBJECT', `Create ${type.replace('-', ' ')}`, (draft) => {
+        draft.objects.push(object);
+      });
+      set({ selectedObjectIds: [object.id], activeTool: 'select' });
+      return object.id;
+    },
+
+    updateObjects: (objectIds, patch, label = 'Update design objects') => commit('UPDATE_OBJECT', label, (draft) => {
+      const selected = new Set(objectIds);
+      draft.objects = draft.objects.map((object) => selected.has(object.id) && !object.locked
+        ? { ...object, ...patch, id: object.id, type: object.type, updatedAt: new Date().toISOString() } as ProductDesignObject
+        : object);
+    }),
+
+    updateObjectById: (objectId, patch, label) => get().updateObjects([objectId], patch, label),
+
+    setPreviewPatch: (objectId, patch) => set((state) => ({
+      previewPatches: {
+        ...state.previewPatches,
+        [objectId]: { ...state.previewPatches[objectId], ...patch },
+      },
+    })),
+
+    clearPreviewPatches: () => set({ previewPatches: {} }),
+
+    commitPreviewPatches: (label) => {
+      const patches = get().previewPatches;
+      if (Object.keys(patches).length === 0) return;
+      commit('UPDATE_OBJECT', label, (draft) => {
+        draft.objects = draft.objects.map((object) => patches[object.id] && !object.locked
+          ? { ...object, ...patches[object.id], id: object.id, type: object.type, updatedAt: new Date().toISOString() } as ProductDesignObject
+          : object);
+      });
+    },
+
+    selectObject: (objectId, additive = false) => set((state) => {
+      if (!objectId) return { selectedObjectIds: [] };
+      if (!additive) return { selectedObjectIds: [objectId] };
+      return {
+        selectedObjectIds: state.selectedObjectIds.includes(objectId)
+          ? state.selectedObjectIds.filter((id) => id !== objectId)
+          : [...state.selectedObjectIds, objectId],
+      };
+    }),
+
+    selectObjects: (objectIds) => set({ selectedObjectIds: Array.from(new Set(objectIds)) }),
+
+    deleteSelected: () => {
+      const selected = get().selectedObjectIds;
+      if (selected.length === 0) return;
+      commit('DELETE_OBJECTS', 'Delete selected design objects', (draft) => {
+        const selectedSet = new Set(selected);
+        draft.objects = draft.objects.filter((object) => !selectedSet.has(object.id));
+      });
+      set({ selectedObjectIds: [] });
+    },
+
+    duplicateSelected: () => {
+      const selected = get().selectedObjectIds;
+      const current = get().document;
+      if (!current || selected.length === 0) return;
+      const timestamp = new Date().toISOString();
+      const copies = current.objects.filter((object) => selected.includes(object.id)).map((object, index) => ({
+        ...object,
+        id: createProductDesignId('object'),
+        name: `${object.name} copy`,
+        x: object.x + 20,
+        y: object.y + 20,
+        groupId: undefined,
+        order: current.objects.length + index,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })) as ProductDesignObject[];
+      commit('DUPLICATE_OBJECTS', 'Duplicate selected design objects', (draft) => {
+        draft.objects.push(...copies);
+      });
+      set({ selectedObjectIds: copies.map((copy) => copy.id) });
+    },
+
+    groupSelected: () => {
+      const selected = get().selectedObjectIds;
+      if (selected.length < 2) return;
+      const groupId = createProductDesignId('group');
+      commit('GROUP_OBJECTS', 'Group selected design objects', (draft) => {
+        draft.objects = draft.objects.map((object) => selected.includes(object.id)
+          ? { ...object, groupId, updatedAt: new Date().toISOString() }
+          : object);
+      });
+    },
+
+    ungroupSelected: () => {
+      const selected = get().selectedObjectIds;
+      if (selected.length === 0) return;
+      const selectedObjects = get().document?.objects.filter((object) => selected.includes(object.id)) || [];
+      const groups = new Set(selectedObjects.map((object) => object.groupId).filter(Boolean));
+      commit('UNGROUP_OBJECTS', 'Ungroup selected design objects', (draft) => {
+        draft.objects = draft.objects.map((object) => object.groupId && groups.has(object.groupId)
+          ? { ...object, groupId: undefined, updatedAt: new Date().toISOString() }
+          : object);
+      });
+    },
+
+    bringSelectedForward: () => {
+      const selected = get().selectedObjectIds;
+      commit('REORDER_OBJECT', 'Bring selected objects forward', (draft) => {
+        const maxOrder = Math.max(0, ...draft.objects.map((object) => object.order));
+        draft.objects = draft.objects.map((object, index) => selected.includes(object.id)
+          ? { ...object, order: maxOrder + index + 1, updatedAt: new Date().toISOString() }
+          : object);
+      });
+    },
+
+    sendSelectedBackward: () => {
+      const selected = get().selectedObjectIds;
+      commit('REORDER_OBJECT', 'Send selected objects backward', (draft) => {
+        const minOrder = Math.min(0, ...draft.objects.map((object) => object.order));
+        draft.objects = draft.objects.map((object, index) => selected.includes(object.id)
+          ? { ...object, order: minOrder - index - 1, updatedAt: new Date().toISOString() }
+          : object);
+      });
+    },
+
+    moveSelected: (dx, dy) => {
+      const document = get().document;
+      const selected = get().selectedObjectIds;
+      if (!document || selected.length === 0) return;
+      commit('UPDATE_OBJECT', 'Move selected design objects', (draft) => {
+        draft.objects = draft.objects.map((object) => selected.includes(object.id) && !object.locked
+          ? {
+              ...object,
+              x: snapProductDesignValue(object.x + dx, document.canvas.gridSize, document.canvas.snapToGrid),
+              y: snapProductDesignValue(object.y + dy, document.canvas.gridSize, document.canvas.snapToGrid),
+              updatedAt: new Date().toISOString(),
+            }
+          : object);
+      });
+    },
+
+    alignSelected: (alignment) => {
+      const document = get().document;
+      const selected = get().selectedObjectIds;
+      if (!document || selected.length < 2) return;
+      const bounds = getProductDesignSelectionBounds(document.objects, selected);
+      if (!bounds) return;
+      commit('UPDATE_OBJECT', `Align selected objects ${alignment}`, (draft) => {
+        draft.objects = draft.objects.map((object) => {
+          if (!selected.includes(object.id) || object.locked) return object;
+          let x = object.x;
+          let y = object.y;
+          if (alignment === 'left') x = bounds.x;
+          if (alignment === 'center-x') x = bounds.x + bounds.width / 2 - object.width / 2;
+          if (alignment === 'right') x = bounds.x + bounds.width - object.width;
+          if (alignment === 'top') y = bounds.y;
+          if (alignment === 'center-y') y = bounds.y + bounds.height / 2 - object.height / 2;
+          if (alignment === 'bottom') y = bounds.y + bounds.height - object.height;
+          return { ...object, x, y, updatedAt: new Date().toISOString() };
+        });
+      });
+    },
+
+    createConceptPartFromSelection: () => {
+      const document = get().document;
+      const selected = get().selectedObjectIds;
+      if (!document || selected.length === 0) return null;
+      const bounds = getProductDesignSelectionBounds(document.objects, selected);
+      const activeLayerId = get().activeLayerId || document.layers[0]?.id;
+      if (!bounds || !activeLayerId) return null;
+      const conceptPart = {
+        ...createProductDesignObject(document, 'concept-part', activeLayerId, bounds.x, bounds.y),
+        width: Math.max(20, bounds.width),
+        height: Math.max(20, bounds.height),
+        depth: Math.max(8, Math.round(Math.min(bounds.width, bounds.height) * 0.2)),
+        sourceObjectIds: [...selected],
+        name: `Concept part ${document.objects.filter((object) => object.type === 'concept-part').length + 1}`,
+      } as ProductDesignObject;
+      commit('CREATE_CONCEPT_PART', 'Create concept part from selection', (draft) => {
+        draft.objects.push(conceptPart);
+      });
+      set({ selectedObjectIds: [conceptPart.id], is3DOpen: true });
+      return conceptPart.id;
+    },
+
+    addReferenceImage: async (file, metadata = {}) => {
+      const document = get().document;
+      const activeLayerId = get().activeLayerId || document?.layers[0]?.id;
+      if (!document || !activeLayerId) return null;
+      const assetId = createProductDesignId('asset');
+      const asset: ProductDesignAsset = {
+        id: assetId,
+        documentId: document.id,
+        fileName: file.name,
+        mimeType: file.type || 'application/octet-stream',
+        size: file.size,
+        sourceUrl: metadata.sourceUrl || '',
+        attribution: metadata.attribution || '',
+        license: metadata.license || '',
+        altText: metadata.altText || file.name,
+        blob: file,
+        createdAt: new Date().toISOString(),
+      };
+      set({ persistenceStatus: 'saving', persistenceMessage: 'Saving reference image…' });
+      try {
+        await get().repository.saveAsset(asset);
+        const object = {
+          ...createProductDesignObject(document, 'reference-image', activeLayerId, 120, 120),
+          assetId,
+          name: file.name,
+          altText: asset.altText,
+          sourceUrl: asset.sourceUrl,
+          attribution: asset.attribution,
+          license: asset.license,
+        } as ProductDesignObject;
+        commit('CREATE_OBJECT', 'Add reference image', (draft) => {
+          draft.objects.push(object);
+        });
+        if (typeof URL !== 'undefined') {
+          set((state) => ({ assetUrls: { ...state.assetUrls, [assetId]: URL.createObjectURL(file) } }));
+        }
+        set({ selectedObjectIds: [object.id] });
+        return object.id;
+      } catch (error) {
+        set({
+          persistenceStatus: 'error',
+          persistenceMessage: error instanceof Error ? error.message : 'Reference image could not be saved.',
+        });
+        return null;
+      }
+    },
+
+    removeAsset: async (assetId) => {
+      await get().repository.deleteAsset(assetId);
+      const url = get().assetUrls[assetId];
+      if (url && typeof URL !== 'undefined') URL.revokeObjectURL(url);
+      set((state) => {
+        const assetUrls = { ...state.assetUrls };
+        delete assetUrls[assetId];
+        return { assetUrls, missingAssetIds: state.missingAssetIds.filter((id) => id !== assetId) };
+      });
+    },
+
+    createCheckpoint: async (name, description = '') => {
+      const document = get().document;
+      if (!document || !name.trim()) return null;
+      const checkpoint: ProductDesignCheckpoint = {
+        id: createProductDesignId('checkpoint'),
+        documentId: document.id,
+        name: name.trim(),
+        description: description.trim(),
+        createdAt: new Date().toISOString(),
+        document: cloneProductDesignDocument(document),
+      };
+      await get().repository.saveCheckpoint(checkpoint);
+      const checkpoints = await get().repository.listCheckpoints(document.id);
+      set({ checkpoints, persistenceStatus: 'saved', persistenceMessage: `Checkpoint “${checkpoint.name}” created` });
+      return checkpoint;
+    },
+
+    restoreCheckpoint: (checkpointId) => {
+      const checkpoint = get().checkpoints.find((candidate) => candidate.id === checkpointId);
+      if (!checkpoint) return;
+      commit('RESTORE_CHECKPOINT', `Restore checkpoint ${checkpoint.name}`, () => cloneProductDesignDocument(checkpoint.document));
+      set({ selectedObjectIds: [] });
+      void loadAssets(checkpoint.document);
+    },
+
+    deleteCheckpoint: async (checkpointId) => {
+      await get().repository.deleteCheckpoint(checkpointId);
+      const documentId = get().document?.id;
+      if (documentId) set({ checkpoints: await get().repository.listCheckpoints(documentId) });
+    },
+
+    undo: () => {
+      const command = get().undoStack.at(-1);
+      if (!command) return;
+      const document = cloneProductDesignDocument(command.before);
+      set((state) => ({
+        document,
+        undoStack: state.undoStack.slice(0, -1),
+        redoStack: [...state.redoStack, command].slice(-MAX_HISTORY),
+        selectedObjectIds: state.selectedObjectIds.filter((id) => document.objects.some((object) => object.id === id)),
+        previewPatches: {},
+      }));
+      void persist(document);
+      void loadAssets(document);
+    },
+
+    redo: () => {
+      const command = get().redoStack.at(-1);
+      if (!command) return;
+      const document = cloneProductDesignDocument(command.after);
+      set((state) => ({
+        document,
+        undoStack: [...state.undoStack, command].slice(-MAX_HISTORY),
+        redoStack: state.redoStack.slice(0, -1),
+        previewPatches: {},
+      }));
+      void persist(document);
+      void loadAssets(document);
+    },
+
+    setActiveTool: (tool) => set({ activeTool: tool }),
+
+    setViewport: (patch) => set((state) => ({
+      zoom: patch.zoom ?? state.zoom,
+      panX: patch.panX ?? state.panX,
+      panY: patch.panY ?? state.panY,
+    })),
+
+    fitDocument: () => set({ zoom: 0.78, panX: 40, panY: 40 }),
+
+    set3DOpen: (open) => set({ is3DOpen: open }),
+
+    exportDocument: async () => {
+      const document = get().document;
+      if (!document) return null;
+      const assets = await get().repository.listAssets(document.id);
+      const checkpoints = await get().repository.listCheckpoints(document.id);
+      const bundle: ProductDesignExportBundle = {
+        format: 'hardware-studio-product-design',
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        document: cloneProductDesignDocument(document),
+        assets: await Promise.all(assets.map(async ({ blob, ...asset }) => ({
+          ...asset,
+          dataUrl: await blobToDataUrl(blob),
+        }))),
+        checkpoints,
+      };
+      return JSON.stringify(bundle, null, 2);
+    },
+
+    importDocument: async (raw) => {
+      const parsed = JSON.parse(raw) as ProductDesignExportBundle | ProductDesignDocument;
+      const isBundle = 'format' in parsed && parsed.format === 'hardware-studio-product-design';
+      const document = normalizeProductDesignDocument(isBundle ? parsed.document : parsed);
+      await get().repository.saveDocument(document);
+      if (isBundle) {
+        for (const asset of parsed.assets) {
+          if (!asset.dataUrl) continue;
+          await get().repository.saveAsset({ ...asset, blob: dataUrlToBlob(asset.dataUrl) });
+        }
+        for (const checkpoint of parsed.checkpoints) await get().repository.saveCheckpoint(checkpoint);
+      }
+      const documents = await get().repository.listDocuments(document.projectId);
+      const checkpoints = await get().repository.listCheckpoints(document.id);
+      set({
+        projectId: document.projectId,
+        documents,
+        document,
+        checkpoints,
+        activeLayerId: document.layers[0]?.id || null,
+        selectedObjectIds: [],
+        undoStack: [],
+        redoStack: [],
+        persistenceStatus: 'saved',
+        persistenceMessage: 'Imported and saved locally',
+      });
+      await loadAssets(document);
+      return document;
+    },
+
+    resetForTests: () => {
+      revokeAssetUrls(get().assetUrls);
+      set({
+        repository: new MemoryProductDesignRepository(),
+        projectId: '',
+        documents: [],
+        document: null,
+        checkpoints: [],
+        activeLayerId: null,
+        selectedObjectIds: [],
+        activeTool: 'select',
+        zoom: 1,
+        panX: 40,
+        panY: 40,
+        previewPatches: {},
+        assetUrls: {},
+        missingAssetIds: [],
+        persistenceStatus: 'idle',
+        persistenceMessage: 'Not loaded',
+        undoStack: [],
+        redoStack: [],
+        is3DOpen: false,
+      });
+    },
+  };
+});


### PR DESCRIPTION
## Status

Draft implementation for #67. Keep this PR draft until the complete Product Design acceptance journey, CI, preview, persistence recovery, and production verification pass.

## Product outcome

This PR replaces the previous assumption that Product Architecture was Product Design. It introduces a dedicated Product Design workbench inside the unified Studio while preserving Requirements and Architecture as separate connected views.

The intended complete path is:

`Document → layers → objects/references → dimensions/notes → concept part → lightweight 3D → checkpoint → reload → export/import`

## Implemented so far

- official open-source research and simplification decisions;
- renderer-independent Product Design document/object contracts;
- native IndexedDB repository with documents, Blob assets, and checkpoints;
- memory repository for deterministic tests;
- command-based Zustand editor session with autosave, bounded undo/redo, grouping, alignment, z-order, checkpoints, and export/import;
- interactive SVG canvas with grid, zoom/pan, drawing, selection, marquee, drag, resize, keyboard movement, and missing-asset states;
- clean editor workbench with compact toolbar, layer/object tree, contextual inspector, history/checkpoints, local save status, and responsive panel collapse;
- same-ID concept-part handoff into an event-driven low-power Three.js preview;
- Product navigation now distinguishes Product Design, Requirements, Architecture, and System Blueprint.

## Trust boundary

Product Design owns visual/product intent and concept dimensions. It does not claim exact B-Rep/STEP CAD, tolerances, interference, mass, tooling, or manufacturing authority.

## Remaining before review

- model/repository/store and interaction contract tests;
- resolve lint and TypeScript findings;
- verify IndexedDB reload and export/import identity;
- asset failure/relink acceptance;
- responsive manual review;
- exact-head Vercel preview and `/studio` verification;
- issue completion evidence and merged production deployment.

Closes #67 only after the full production acceptance gate passes.