### PR TITLE
Retire stale adaptive-workflow documentation after Studio convergence

### DIFF
--- a/docs/architecture/UNIFIED_STUDIO_GOLDEN_PATH.md
+++ b/docs/architecture/UNIFIED_STUDIO_GOLDEN_PATH.md
@@ -1,10 +1,11 @@
 # Unified Hardware Studio golden path
 
-Status: active P0 integration architecture for issue #64.
+**Status:** active connected-object architecture. The bounded issue #64 implementation is complete; the broader V1 convergence program remains active.  
+**Current shell decision:** PR #69, merged August 25, 2026.
 
 ## Why this exists
 
-Hardware Studio accumulated useful workbenches, but a collection of routes is not a product. A user must be able to carry one engineering object through the complete build process without recreating it, losing context, or returning to a generic dashboard to unlock the next editor.
+Hardware Studio accumulated useful workbenches, but a collection of routes is not a product. A user must be able to carry one engineering object through the complete build process without recreating it, losing context, or returning to unrelated surfaces to unlock the next editor.
 
 The first production golden path is:
 
@@ -30,7 +31,7 @@ A definition is not automatically a project component and is not automatically p
 
 ### Project component instance
 
-Owned by canonical `boardComponents` project state.
+Owned by canonical `boardComponents` project state today, pending migration into the canonical repository/domain packages.
 
 This is the shared identity used by every downstream workbench. It contains:
 
@@ -52,28 +53,30 @@ Component Library creates this instance. Schematic, PCB, BOM, 3D and Validation 
 
 Owned by canonical `boards` plus `boardOutlines`.
 
-Board Designer can recover from an empty project by creating a starter board or opening Board Settings. It must never depend on a removed dashboard generator.
+The PCB workbench can recover from an empty project by creating or configuring the real board context. It must never depend on a removed dashboard generator.
 
 A starter outline is explicitly provisional until the user verifies dimensions. It is not silently treated as manufacturing authority.
 
 ### Schematic
 
-Owned by component `schematic` placement, `schematicWires`, `nets`, component pin net fields and `padNetAssignments`.
+Owned by component `schematic` placement, `schematicWires`, `nets`, component pin net fields and `padNetAssignments` while the canonical electrical graph is being completed.
 
-The live unified Schematic editor:
+The live Schematic editor:
 
 - places existing project instances;
 - connects their real pins;
 - creates or reuses canonical nets;
 - exposes ERC findings linked to responsible objects;
 - does not create a second project component from a library definition;
-- uses an in-app dependency review before whole-product deletion.
+- uses in-app dependency review for destructive whole-product changes.
 
 ### PCB
 
 Owned by component `pcb` placement, board geometry, traces, vias, constraints and pad-net assignments.
 
-The live Board Designer receives the selected board, component and net from shared UI context, while editing canonical project records.
+PCB is part of the **Electronics** product area in the V1 shell. Board setup, routing rules and DRC are contextual PCB tools, not separate product domains.
+
+The live PCB editor receives the selected board, component and net from shared UI context while editing canonical project records.
 
 ### Lightweight 3D
 
@@ -102,7 +105,7 @@ A selected project component can create one linked BOM record. Electrical values
 
 Owned by canonical `validationTests` and `validationRuns`.
 
-A component-linked test stores the same component ID and current canonical net IDs. The validation editor remains capable of generic requirement/factory testing, but selected-object context is preserved above it.
+A component-linked test stores the same component ID and current canonical net IDs. The validation editor remains capable of generic requirement/factory testing, but selected-object context is preserved across handoffs.
 
 ## UI-only Studio context
 
@@ -120,30 +123,45 @@ It may store:
 
 It must not become a second engineering database. Clearing this store must not modify project records.
 
-## Persistent Studio frame
+## V1 Studio frame
 
-Every workbench is mounted under:
+The V1 shell deliberately has one stable product lifecycle:
 
-1. the complete product build map;
-2. the context bar when the workbench participates in shared object flow;
-3. the workbench itself;
-4. the shared findings/status area.
+`Home → Define → Electronics → Mechanical → Firmware → Validate → Release`
 
-Workflow profiles control focus and emphasis. They do not remove discoverability of Product, Mechanical, Electronics, PCB, Firmware, Validation or Outputs from the build map.
+The global shell owns only:
+
+1. product-area navigation;
+2. the active area's compact primary-workbench navigation;
+3. project/storage state and recovery;
+4. the active workbench.
+
+The owning workbench supplies its own toolbar, inspector, findings/status and contextual next action. Supporting tools remain inside that workbench instead of becoming additional global routes the user has to learn.
+
+The following are **not** part of the current V1 shell architecture:
+
+- workflow profiles;
+- custom domain visibility configuration;
+- Scope/show-hidden-domain controls;
+- permanent workspace coaching;
+- permanent “Start here” tutorials beside every workbench.
+
+Those systems were removed in PR #69 because they duplicated navigation and guidance rather than completing the engineering lifecycle.
 
 ## Connected handoff rules
 
 ### Components → Schematic
 
 - preserve board, definition and instance IDs;
-- place the selected instance if unplaced;
-- focus the existing symbol if already placed.
+- place the selected instance if explicitly requested and unplaced;
+- focus the existing symbol if already placed;
+- navigation alone must never create engineering data.
 
 ### Schematic → PCB
 
 - preserve board, instance and net context;
-- open Board Settings when no board exists;
-- otherwise open Board Designer with the same selected object.
+- if no board exists, the PCB workspace must expose the real setup action;
+- otherwise open PCB with the same selected object.
 
 ### PCB → 3D
 
@@ -160,26 +178,29 @@ Workflow profiles control focus and emphasis. They do not remove discoverability
 ### Any engineering workbench → Validation
 
 - preserve selected component and active net;
-- create tests with `linkedComponentIds` and `linkedNetIds`.
+- create tests with `linkedComponentIds` and `linkedNetIds` only through an explicit mutation action.
 
 ## Empty-state rule
 
 Every empty state must do one of the following:
 
-- create the real missing canonical object;
-- route to the workbench that owns it;
+- create the real missing canonical object after an explicit user action;
+- route to the workbench/tool that owns it;
 - explain why progress is blocked.
 
-It must not reference deleted actions, hidden generators or unrelated dashboards.
+It must not reference deleted actions, hidden generators, unrelated dashboards, or create placeholder engineering truth merely by opening a view.
 
-## Completion requirements for issue #64
+## Current completion boundary
 
-The issue remains open until:
+Issue #64 proved a bounded connected Electronics → PCB → 3D path with one component/board/net identity and production verification. It did **not** complete the broader product architecture.
 
-- one canonical component identity completes the full golden path;
-- integration tests verify board, definition, component, pins, wires, nets, PCB placement, BOM and validation links;
-- touched native browser dialogs are removed;
-- CI and production builds pass;
-- a Vercel preview and merged production deployment are verified;
-- the production `/studio` route is healthy;
-- the broader open boundaries are documented without closing unrelated parent issues.
+The remaining convergence work is governed by the product constitution and recovery plan, especially:
+
+- canonical schema and ownership;
+- durable shared repository;
+- typed command/transaction lifecycle;
+- monolith decomposition;
+- browser-level reference-product verification;
+- authoritative electrical/mechanical/firmware/validation/release depth.
+
+A new shell wrapper or another navigation abstraction is not progress unless it replaces an existing path and makes the reference-product lifecycle measurably more complete.

--- a/docs/research/ADAPTIVE_WORKFLOWS.md
+++ b/docs/research/ADAPTIVE_WORKFLOWS.md
@@ -1,135 +1,87 @@
-# Adaptive workflows and capability-based navigation
+# Adaptive workflow research — superseded implementation
 
-Status: implementation decision for issue #59.
+**Status:** historical research only  
+**Superseded by:** PR #69, merged August 25, 2026  
+**Current navigation authority:** `src/lib/navigationRegistry.ts`  
+**Product scope authority:** `docs/product/V1_PRODUCT_CONSTITUTION.md`
 
-## Product problem
+## Why this document remains
 
-Hardware Studio spans product intent, mechanical design, electronics, PCB, firmware, validation, and release outputs. Showing every workbench to every user makes the product appear comprehensive but makes ordinary tasks harder to understand.
+This research explored how mature engineering tools reduce visible complexity while keeping connected project data. The research observations remain useful, but the workflow-profile implementation that originally came from this document has been removed from Hardware Studio V1.
 
-The product must therefore support both:
+The implementation had introduced another product-structure layer on top of domain navigation, contextual navigation, workbench guidance, and shared engineering context. In practice that created more choices about **how to navigate** without making the underlying engineering workflow more complete.
 
-- **connected work**, where multiple domains share one project graph; and
-- **standalone work**, where a user can focus on one domain without being forced through unrelated upstream or downstream modules.
+The V1 convergence decision is therefore simpler:
 
-Progressive disclosure changes what the shell shows. It does not delete engineering records or create a second project model.
+> **One product lifecycle is always understandable. Supporting tools live inside the workbench that owns the decision.**
 
-## Research patterns
+## Retained research lessons
 
 ### KiCad
 
-KiCad intentionally connects schematic and PCB editors while still allowing standalone editor workflows. The PCB editor can maintain board-local nets in standalone use, while richer synchronization comes from the associated schematic.
+Schematic and PCB can remain distinct specialist editors while sharing authoritative electrical identity. Hardware Studio should preserve this principle without turning every supporting tool into a global destination.
 
 Sources:
 
 - https://docs.kicad.org/9.0/en/eeschema/eeschema.html
 - https://docs.kicad.org/10.0/en/pcbnew/pcbnew.pdf
 
-Hardware Studio decision: Electronics and PCB can be enabled independently. When PCB is shown without Electronics, the product must state that schematic synchronization and component-definition context are unavailable rather than blocking the user.
+### Autodesk Fusion and Blender
 
-### Autodesk Fusion
+Task-oriented workspaces reduce visible commands and panels. The transferable lesson is **contextual tools**, not user-configurable product structure before the core lifecycle is mature.
 
-Fusion groups capabilities into purpose-driven workspaces. The active workspace controls the commands and data most relevant to the current task.
-
-Source:
+Sources:
 
 - https://help.autodesk.com/view/NINVFUS/ENU/?guid=GS-WORKSPACES
-
-Hardware Studio decision: workflow profiles are task-oriented starting points, not permanent product editions. Every non-overview domain remains independently configurable.
-
-### Blender
-
-Blender workspaces are task-oriented arrangements of editors. They reduce visible complexity without creating separate copies of the underlying scene.
-
-Source:
-
 - https://docs.blender.org/manual/en/4.2/interface/window_system/workspaces.html
-
-Hardware Studio decision: workflow preferences affect navigation and guidance only. Canonical project engineering data remains shared and unchanged.
 
 ### Onshape
 
-Onshape documents can hold multiple linked artifact types as tabs, and larger or reusable areas can be split into linked documents for performance and ownership.
+Different artifact types can remain linked without duplicating canonical identity. Hardware Studio should keep that principle while repository and product-graph boundaries converge.
 
 Sources:
 
 - https://cad.onshape.com/help/Content/Document/documents.htm
 - https://cad.onshape.com/help/Content/Document/linking_documents.htm
 
-Hardware Studio decision: keep one connected local project graph now, while preserving the architectural option to split large domain data behind stable references later. The adaptive shell must not require that split.
+## Current V1 shell decision
 
-## Implemented workflow model
+The normal Studio lifecycle is:
 
-The shell supports these profiles:
+`Home → Define → Electronics → Mechanical → Firmware → Validate → Release`
 
-- Complete Product
-- Electronics + PCB
-- Mechanical + Assembly
-- Firmware + Device
-- Validation + Handoff
-- Custom
+Visible primary workbenches are deliberately bounded:
 
-Profiles select initial capabilities. They do not lock the user. Product, Mechanical, Electronics, PCB, Firmware, Validation, and Outputs can each be shown or hidden independently. Overview is always available.
+- **Define:** Requirements, Architecture
+- **Electronics:** Components, Schematic, PCB, BOM
+- **Mechanical:** Design, Assembly
+- **Firmware:** Behavior, Hardware Map, Source
+- **Validate:** Tests & Evidence, Coverage
+- **Release:** Readiness, Outputs, Revisions
 
-## Persistence boundary
+Power, pin mapping, board setup, PCB rules/DRC, factory QA, drawings, factory-package preparation, legacy Blueprint routes, and experimental Product Design remain contextual, compatibility-only, or experimental rather than competing top-level workflows.
 
-Workflow preferences are stored under a dedicated local-storage key:
+## Removed implementation
 
-`hardware-studio:workflow-preferences:v1`
+PR #69 removed:
 
-They are not included in canonical project serialization and do not call project-store mutation actions. Hiding a domain therefore cannot remove its requirements, geometry, components, nets, firmware, tests, revisions, or output records.
+- workflow profiles;
+- custom workflow configuration;
+- workflow preference persistence;
+- Scope/show-hidden-domain controls;
+- the workflow setup dialog;
+- hidden-domain warning behavior;
+- the permanent Workspace Coach;
+- permanent “Start here” instructions in contextual navigation.
 
-Malformed or unknown preference data normalizes to safe values. Unknown domain IDs are discarded. If storage is blocked, preferences remain usable in memory.
+These concepts must not be recreated from this historical research document unless a future product decision explicitly supersedes the current V1 constitution and demonstrates a user need after the reference lifecycle is complete.
 
-## Active-view safety
+## Still-valid boundaries
 
-If a user hides the domain containing the currently open workbench:
+This convergence decision does **not** change engineering truth boundaries:
 
-- the workbench stays open;
-- the domain remains temporarily visible in navigation;
-- a banner explains that it is hidden from the configured workflow;
-- the user can show the domain again or leave the workbench;
-- no silent redirect occurs.
-
-## Guided home
-
-The previous dashboard assumed one universal linear pipeline and exposed generation or repair actions that could mutate the project before the user understood the design.
-
-The guided home instead shows:
-
-- selected workflow;
-- visible and hidden domains;
-- current canonical project-data counts;
-- connected versus standalone limitations;
-- one next action per visible domain;
-- evidence explaining why each action is suggested;
-- a direct route to workflow configuration.
-
-Actions are derived from existing project data. No fake completion percentage is used as primary guidance, and showing a domain does not imply its work is complete.
-
-## Lightweight 3D versus CAD kernel
-
-Workflow configuration and lightweight visualization are separate concerns.
-
-The lightweight Three.js representation introduced by issue #61 is:
-
-- visualization-only;
-- lazy-loaded;
-- event-driven;
-- capped by a quality profile;
-- non-authoritative for dimensions, interference, mass, manufacturing, or release.
-
-The future CAD kernel in issue #17 remains responsible for exact solids, STEP/B-Rep processing, dimensional authority, interference, manufacturing geometry, and qualified exports.
-
-Adaptive workflows can hide or show Mechanical and 3D entry points, but they do not change this trust boundary.
-
-## Non-goals
-
-This implementation does not:
-
-- create separate product editions;
-- delete data for hidden domains;
-- force domain dependencies;
-- claim parity with KiCad, Fusion, Blender, or Onshape;
-- turn Three.js previews into CAD;
-- replace the canonical product graph;
-- complete the broader shell redesign in issue #9.
+- hiding or reorganizing UI must never mutate canonical engineering data;
+- Three.js remains a visualization layer, not CAD authority;
+- missing dimensions, placement, evidence, or qualification remain unresolved;
+- one canonical component identity must survive Electronics, PCB, BOM, Firmware, Validation, and Release handoffs;
+- future customization must operate on the same repository and command system, not introduce a second project model.


### PR DESCRIPTION
## Why

PR #69 removed workflow profiles, custom workflow setup, hidden-domain scope controls, permanent workspace coaching, and the old guided-home model. The active docs still described those removed systems as implementation decisions, which could cause future work to rebuild architecture we deliberately retired.

## Changes

- convert `docs/research/ADAPTIVE_WORKFLOWS.md` into a concise historical/superseded research record;
- preserve the useful KiCad/Fusion/Blender/Onshape lessons without treating workflow profiles as current product architecture;
- update the unified golden-path architecture to the current V1 lifecycle:
  `Home → Define → Electronics → Mechanical → Firmware → Validate → Release`;
- clarify that PCB is contextual to Electronics at the product-navigation level;
- document that supporting tools belong inside their owning workbench;
- explicitly record that navigation alone must not create engineering state;
- point remaining convergence work back to schema, repository, commands, monolith split, and browser reference-product verification.

## Replaces

Stale documentation that described a removed adaptive-shell implementation as current product direction.

## Non-goals

No production code or landing-page changes.
