### PR TITLE
Keep Electronics supporting tools inside one workspace

### DIFF
--- a/src/__tests__/electronicsContextualTools.test.ts
+++ b/src/__tests__/electronicsContextualTools.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('Electronics contextual tool convergence', () => {
+  it('keeps power, pin mapping, board rules and legacy aliases inside the Electronics workspace', () => {
+    const workspace = source('../components/studio/ElectronicsWorkspace.tsx');
+
+    for (const viewId of ['electronics', 'power-tree', 'power-budget', 'pin-map', 'pcb-constraints']) {
+      expect(workspace).toContain(`'${viewId}'`);
+    }
+
+    expect(workspace).toContain("case 'power-budget': return <PowerBudgetTable />;");
+    expect(workspace).toContain("case 'pin-map': return <PinMapTable />;");
+    expect(workspace).toContain("case 'pcb-constraints': return <PCBConstraints />;");
+    expect(workspace).toContain("if (viewId === 'power-tree') return 'power-budget';");
+  });
+
+  it('does not mount those contextual tools as separate shell pages', () => {
+    const shell = source('../components/AppShell.tsx');
+
+    expect(shell).not.toContain("import { PowerBudgetTable } from './PowerBudgetTable';");
+    expect(shell).not.toContain("import { PinMapTable } from './PinMapTable';");
+    expect(shell).not.toContain("import { PCBConstraints } from './PCBConstraints';");
+    expect(shell).toContain("case 'power-budget':");
+    expect(shell).toContain("case 'pin-map':");
+    expect(shell).toContain("case 'pcb-constraints':");
+    expect(shell).toContain('return <ElectronicsWorkspace />;');
+  });
+});

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,10 +11,7 @@ import { BlueprintCanvas } from './BlueprintCanvas';
 import { ExportCenter } from './ExportCenter';
 import { PropertiesPanel } from './PropertiesPanel';
 import { ProductVisualizer } from './ProductVisualizer';
-import { PowerBudgetTable } from './PowerBudgetTable';
-import { PinMapTable } from './PinMapTable';
 import { ReadinessDashboard } from './ReadinessDashboard';
-import { PCBConstraints } from './PCBConstraints';
 import { ProjectDashboard } from './ProjectDashboard';
 import { BlueprintSheets } from './BlueprintSheets';
 import { FactoryPackageBuilder } from './FactoryPackageBuilder';
@@ -35,9 +32,6 @@ function renderSurface(surface: NavigationSurface, viewId: string): React.ReactN
     case 'readiness': return <ReadinessDashboard />;
     case 'mechanical-canvas': return <UnifiedMechanicalWorkbench defaultMode="canvas" />;
     case 'mechanical-assembly': return <UnifiedMechanicalWorkbench defaultMode="assembly" />;
-    case 'power-budget': return <PowerBudgetTable />;
-    case 'pin-map': return <PinMapTable />;
-    case 'pcb-constraints': return <PCBConstraints />;
     case 'firmware-modules': return <FirmwareStudio key={viewId} initialMode={viewId === 'firmware-evidence' ? 'evidence' : 'modules'} />;
     case 'firmware-state-machine': return <FirmwareStudio key={viewId} initialMode="state-machine" />;
     case 'firmware-hardware-map': return <FirmwareStudio key={viewId} initialMode="hardware-map" />;
@@ -51,9 +45,12 @@ function renderSurface(surface: NavigationSurface, viewId: string): React.ReactN
     case 'factory-builder': return <FactoryPackageBuilder />;
     case 'component-library':
     case 'schematic-editor':
+    case 'power-budget':
+    case 'pin-map':
     case 'bom':
     case 'board-designer':
     case 'board-studio':
+    case 'pcb-constraints':
       return <ElectronicsWorkspace />;
   }
 }

--- a/src/components/studio/ElectronicsWorkspace.tsx
+++ b/src/components/studio/ElectronicsWorkspace.tsx
@@ -5,6 +5,9 @@ import { ArrowRight, CheckCircle2 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
 import { evaluateElectronicsWorkflow, type ElectronicsWorkflowStageId } from '../../lib/electronics/electronicsWorkflow';
 import { BoardStudio } from '../BoardStudio';
+import { PCBConstraints } from '../PCBConstraints';
+import { PinMapTable } from '../PinMapTable';
+import { PowerBudgetTable } from '../PowerBudgetTable';
 import { UnifiedBoardDRCWorkbench } from './UnifiedBoardDRCWorkbench';
 import { UnifiedBOMWorkbench } from './UnifiedBOMWorkbench';
 import {
@@ -13,27 +16,37 @@ import {
   UnifiedSchematicWorkbench,
 } from './UnifiedWorkbenchAdapters';
 
+type ElectronicsWorkspaceViewId = ElectronicsWorkflowStageId | 'power-budget' | 'pin-map' | 'pcb-constraints';
+
 export const ELECTRONICS_WORKSPACE_VIEW_IDS = new Set([
+  'electronics',
   'component-library',
   'schematic-editor',
+  'power-tree',
+  'power-budget',
+  'pin-map',
   'board-settings',
   'board-studio',
   'board-components',
   'board-designer',
+  'pcb-constraints',
   'pcb-drc',
   'bom',
 ]);
 
-const stageLabels: Record<ElectronicsWorkflowStageId, string> = {
+const viewLabels: Record<ElectronicsWorkspaceViewId, string> = {
   'component-library': 'Components',
   'schematic-editor': 'Schematic',
+  'power-budget': 'Power',
+  'pin-map': 'Pin map',
   'board-settings': 'Board setup',
   'board-designer': 'PCB layout',
+  'pcb-constraints': 'PCB rules',
   'pcb-drc': 'DRC',
   'bom': 'BOM',
 };
 
-const decisionCopy: Record<ElectronicsWorkflowStageId, { title: string; consequence: string }> = {
+const decisionCopy: Record<ElectronicsWorkspaceViewId, { title: string; consequence: string }> = {
   'component-library': {
     title: 'Choose authoritative parts before describing connectivity',
     consequence: 'Schematic, PCB, BOM, and validation reuse the same canonical component identity instead of copied records.',
@@ -42,6 +55,14 @@ const decisionCopy: Record<ElectronicsWorkflowStageId, { title: string; conseque
     title: 'Decide how the selected parts are electrically connected',
     consequence: 'Only explicit pin/net relationships move forward; visual proximity never becomes connectivity by accident.',
   },
+  'power-budget': {
+    title: 'Review power assumptions in the context of the electronics design',
+    consequence: 'Power estimates remain supporting evidence; they do not silently create nets, components, or verified electrical behavior.',
+  },
+  'pin-map': {
+    title: 'Review hardware pin intent without creating a second connectivity model',
+    consequence: 'Pin mapping supports Electronics and Firmware while authoritative electrical connectivity remains in canonical components, pins, and nets.',
+  },
   'board-settings': {
     title: 'Establish the real PCB boundary before physical placement',
     consequence: 'PCB layout remains blocked until an explicit board and outline exist; metadata dimensions are not promoted into manufacturing geometry.',
@@ -49,6 +70,10 @@ const decisionCopy: Record<ElectronicsWorkflowStageId, { title: string; conseque
   'board-designer': {
     title: 'Place the canonical components on the selected physical board',
     consequence: 'Placement becomes board-scoped evidence used by DRC, mechanical sync, CPL, and manufacturing checks.',
+  },
+  'pcb-constraints': {
+    title: 'Review board rules as supporting constraints for the active PCB',
+    consequence: 'Rules stay contextual to PCB design and do not become a competing top-level engineering workflow.',
   },
   'pcb-drc': {
     title: 'Review rule and connectivity evidence before electronics handoff',
@@ -60,25 +85,32 @@ const decisionCopy: Record<ElectronicsWorkflowStageId, { title: string; conseque
   },
 };
 
-function resolveStage(viewId: string): ElectronicsWorkflowStageId {
+function resolveView(viewId: string): ElectronicsWorkspaceViewId {
   if (viewId === 'board-studio' || viewId === 'board-components') return 'board-settings';
+  if (viewId === 'power-tree') return 'power-budget';
   if (
     viewId === 'component-library'
     || viewId === 'schematic-editor'
+    || viewId === 'power-budget'
+    || viewId === 'pin-map'
     || viewId === 'board-settings'
     || viewId === 'board-designer'
+    || viewId === 'pcb-constraints'
     || viewId === 'pcb-drc'
     || viewId === 'bom'
   ) return viewId;
   return 'component-library';
 }
 
-function renderStage(stage: ElectronicsWorkflowStageId) {
-  switch (stage) {
+function renderView(view: ElectronicsWorkspaceViewId) {
+  switch (view) {
     case 'component-library': return <UnifiedComponentLibraryWorkbench />;
     case 'schematic-editor': return <UnifiedSchematicWorkbench />;
+    case 'power-budget': return <PowerBudgetTable />;
+    case 'pin-map': return <PinMapTable />;
     case 'board-settings': return <BoardStudio />;
     case 'board-designer': return <UnifiedBoardDesignerWorkbench />;
+    case 'pcb-constraints': return <PCBConstraints />;
     case 'pcb-drc': return <UnifiedBoardDRCWorkbench />;
     case 'bom': return <UnifiedBOMWorkbench />;
   }
@@ -88,10 +120,10 @@ export const ElectronicsWorkspace: React.FC = () => {
   const project = useProjectStore();
   const { activeView, setActiveView } = project;
   const snapshot = useMemo(() => evaluateElectronicsWorkflow(project), [project]);
-  const activeStage = resolveStage(activeView);
+  const activeWorkspaceView = resolveView(activeView);
   const nextDecision = decisionCopy[snapshot.nextStage];
-  const currentDecision = decisionCopy[activeStage];
-  const recommendedElsewhere = !snapshot.readyForValidation && activeStage !== snapshot.nextStage;
+  const currentDecision = decisionCopy[activeWorkspaceView];
+  const recommendedElsewhere = !snapshot.readyForValidation && activeWorkspaceView !== snapshot.nextStage;
 
   return (
     <section className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-slate-50 text-slate-900" aria-label="Electronics engineering workspace">
@@ -99,7 +131,7 @@ export const ElectronicsWorkspace: React.FC = () => {
         <div className="flex min-w-0 flex-col gap-2 lg:flex-row lg:items-center">
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-slate-500">
-              <span className="font-semibold text-slate-800">{stageLabels[activeStage]}</span>
+              <span className="font-semibold text-slate-800">{viewLabels[activeWorkspaceView]}</span>
               <span aria-hidden="true">·</span>
               <span>{snapshot.activeBoardName || 'No board selected'}</span>
               <span aria-hidden="true">·</span>
@@ -114,7 +146,7 @@ export const ElectronicsWorkspace: React.FC = () => {
 
           <div className="flex shrink-0 items-center gap-2">
             {recommendedElsewhere && (
-              <span className="hidden text-[10px] text-slate-500 xl:inline">Recommended next: {stageLabels[snapshot.nextStage]}</span>
+              <span className="hidden text-[10px] text-slate-500 xl:inline">Recommended next: {viewLabels[snapshot.nextStage]}</span>
             )}
             <button
               type="button"
@@ -124,7 +156,7 @@ export const ElectronicsWorkspace: React.FC = () => {
               {snapshot.readyForValidation
                 ? 'Plan validation'
                 : recommendedElsewhere
-                  ? `Go to ${stageLabels[snapshot.nextStage]}`
+                  ? `Go to ${viewLabels[snapshot.nextStage]}`
                   : 'Continue this decision'}
               {snapshot.readyForValidation ? <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" /> : <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />}
             </button>
@@ -154,7 +186,7 @@ export const ElectronicsWorkspace: React.FC = () => {
       </header>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        {renderStage(activeStage)}
+        {renderView(activeWorkspaceView)}
       </div>
     </section>
   );


### PR DESCRIPTION
## Why

Studio convergence made Electronics one primary product area, but several compatibility/tool IDs still escaped that frame and mounted as standalone shell pages: Power, Pin Mapping, and PCB Rules. That preserved the old disconnected-page feeling even though these are supporting tools, not separate product domains.

## Changes

- add `power-tree`, `power-budget`, `pin-map`, and `pcb-constraints` to the unified Electronics route set;
- render the existing Power Budget, Pin Map, and PCB Constraints tools inside `ElectronicsWorkspace`;
- preserve old/deep-link IDs without teaching them as new lifecycle stages;
- keep the primary Electronics decision path unchanged: Components → Schematic → Board/PCB → DRC → BOM;
- remove standalone shell imports for those supporting tools;
- add regression coverage proving contextual tools stay inside the Electronics frame.

## Product effect

Old projects and deep links remain routable, but users no longer fall out of the Electronics context when opening supporting engineering tools.

## Non-goals

No project-store/schema changes, no new engineering generators, no landing-page changes, and no claim that #66 is complete.

## Completion rule

Merge only if lint, typecheck, full tests, production build, and exact-head Vercel preview pass.