### PR TITLE
Make project migrations deterministic and geometry-truthful

### DIFF
--- a/src/__tests__/projectMigrationDeterminism.test.ts
+++ b/src/__tests__/projectMigrationDeterminism.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { CURRENT_SCHEMA_VERSION, migrateProjectSchema } from '../lib/projectMigrations';
+
+function legacyProject(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'legacy-project',
+    projectName: 'Legacy Project',
+    description: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    version: '1',
+    schemaVersion: 5,
+    activeView: 'dashboard',
+    nodes: [],
+    edges: [],
+    bom: [],
+    testing: [],
+    powerBudget: [],
+    pinMap: [],
+    firmwareTasks: [],
+    ...overrides,
+  };
+}
+
+describe('project migration determinism and truthful unresolved geometry', () => {
+  it('assigns stable component IDs and remains idempotent', () => {
+    const input = legacyProject({
+      boards: [{ id: 'board-real', name: 'Main', boardType: 'Main PCB' }],
+      boardComponents: [{
+        boardId: 'board_main',
+        referenceDesignator: 'U1',
+        componentName: 'Controller',
+        partNumber: 'MCU-1',
+        footprint: 'QFN-32',
+        pins: [{ pinNumber: '1', pinName: 'VCC' }],
+      }],
+    });
+
+    const first = migrateProjectSchema(input);
+    const second = migrateProjectSchema(input);
+    const repeated = migrateProjectSchema(first);
+
+    const firstComponent = first.boardComponents?.[0];
+    const secondComponent = second.boardComponents?.[0];
+    const repeatedComponent = repeated.boardComponents?.[0];
+
+    expect(CURRENT_SCHEMA_VERSION).toBe(6);
+    expect(first.schemaVersion).toBe(6);
+    expect(firstComponent?.id).toMatch(/^cmp_legacy_/);
+    expect(secondComponent?.id).toBe(firstComponent?.id);
+    expect(repeatedComponent?.id).toBe(firstComponent?.id);
+    expect(firstComponent?.pins?.[0].componentId).toBe(firstComponent?.id);
+    expect(repeatedComponent?.pins?.[0].componentId).toBe(firstComponent?.id);
+    expect(firstComponent?.boardId).toBe('board-real');
+  });
+
+  it('does not invent schematic coordinates for an unplaced component', () => {
+    const migrated = migrateProjectSchema(legacyProject({
+      boardComponents: [{
+        referenceDesignator: 'U2',
+        componentName: 'Sensor',
+        schematic: { placed: true },
+      }],
+    }));
+
+    const schematic = migrated.boardComponents?.[0].schematic;
+    expect(schematic?.placed).toBe(false);
+    expect(schematic?.x).toBeUndefined();
+    expect(schematic?.y).toBeUndefined();
+  });
+
+  it('preserves valid zero schematic coordinates', () => {
+    const migrated = migrateProjectSchema(legacyProject({
+      boardComponents: [{
+        referenceDesignator: 'U3',
+        componentName: 'Zero Origin Part',
+        schematic: { placed: true, x: 0, y: 0, rotation: 90 },
+      }],
+    }));
+
+    const schematic = migrated.boardComponents?.[0].schematic;
+    expect(schematic).toMatchObject({ placed: true, x: 0, y: 0, rotation: 90 });
+  });
+
+  it('does not guess a board when a legacy sentinel is ambiguous', () => {
+    const migrated = migrateProjectSchema(legacyProject({
+      boards: [
+        { id: 'board-a', name: 'A', boardType: 'Main PCB' },
+        { id: 'board-b', name: 'B', boardType: 'Daughterboard' },
+      ],
+      boardComponents: [{
+        boardId: 'board_main',
+        referenceDesignator: 'U4',
+        componentName: 'Ambiguous Part',
+      }],
+    }));
+
+    expect(migrated.boardComponents?.[0].boardId).toBe('');
+  });
+
+  it('gives duplicate legacy components distinct but repeatable IDs by input position', () => {
+    const component = {
+      referenceDesignator: 'R1',
+      componentName: 'Resistor',
+      partNumber: 'R-10K',
+    };
+    const input = legacyProject({ boardComponents: [component, component] });
+
+    const first = migrateProjectSchema(input).boardComponents || [];
+    const second = migrateProjectSchema(input).boardComponents || [];
+
+    expect(first[0].id).not.toBe(first[1].id);
+    expect(second.map((item) => item.id)).toEqual(first.map((item) => item.id));
+  });
+});

--- a/src/__tests__/webgl3DView.test.ts
+++ b/src/__tests__/webgl3DView.test.ts
@@ -3,6 +3,8 @@ import { useProjectStore } from '../store/projectStore';
 import { checkMechanicalInterference } from '../lib/mechanical/mechanicalGeometry';
 import { MechanicalBody, BoardComponent } from '../types';
 
+const TEST_BOARD_ID = 'board_collision_fixture';
+
 describe('Slice 6 Real Mechanical 3D Synchronization & Collision Engine Tests', () => {
   it('should detect real 3D spatial collisions between bodies/components and clear them on movement', () => {
     const store = useProjectStore.getState();
@@ -23,11 +25,10 @@ describe('Slice 6 Real Mechanical 3D Synchronization & Collision Engine Tests', 
       opacity: 0.5
     };
 
-    // 2. Create PCB component at (10, 10) on active board with 3D package dimensions
+    // 2. Create PCB component at (10, 10) on a real active board with 3D package dimensions.
     const compColliding: BoardComponent = {
       id: 'cmp_3d_colliding',
-      boardId: 'board_main',
-      circuitBlockId: 'block_0',
+      boardId: TEST_BOARD_ID,
       referenceDesignator: 'U301',
       componentName: 'Power Management IC',
       componentType: 'IC',
@@ -37,7 +38,7 @@ describe('Slice 6 Real Mechanical 3D Synchronization & Collision Engine Tests', 
       partNumber: 'PMIC_24',
       placementCriticality: 'Low',
       notes: '',
-      packageDimensions: { widthMm: 30, heightMm: 30, heightZMm: 20 }, // Height overlaps with enclosure top
+      packageDimensions: { widthMm: 30, heightMm: 30, heightZMm: 20 },
       quantity: 1,
       side: 'Top',
       placementX: 10,
@@ -64,7 +65,8 @@ describe('Slice 6 Real Mechanical 3D Synchronization & Collision Engine Tests', 
     store.importProjectJSON({
       id: 'proj_3d_collision_test',
       projectName: '3D Collision Engine System',
-      activeBoardId: 'board_main',
+      activeBoardId: TEST_BOARD_ID,
+      boards: [{ id: TEST_BOARD_ID, name: 'Collision Fixture Board', boardType: 'Main PCB' }],
       mechanicalBodies: [encBody, batteryBody],
       boardComponents: [compColliding]
     });
@@ -79,10 +81,10 @@ describe('Slice 6 Real Mechanical 3D Synchronization & Collision Engine Tests', 
     useProjectStore.setState({
       mechanicalBodies: [
         encBody,
-        { ...batteryBody, xMm: 50, yMm: 20, zMm: 2, widthMm: 30, heightMm: 20, depthMm: 10 } // xMax: 80 < 100, yMax: 40 < 60, zMax: 12 < 25
+        { ...batteryBody, xMm: 50, yMm: 20, zMm: 2, widthMm: 30, heightMm: 20, depthMm: 10 }
       ],
       boardComponents: [
-        { ...compColliding, pcb: { ...compColliding.pcb!, xMm: 10, yMm: 10 }, packageDimensions: { widthMm: 8, heightMm: 8, heightZMm: 2 } } // xMax: 14 < 50
+        { ...compColliding, pcb: { ...compColliding.pcb!, xMm: 10, yMm: 10 }, packageDimensions: { widthMm: 8, heightMm: 8, heightZMm: 2 } }
       ]
     });
 

--- a/src/lib/projectMigrations.ts
+++ b/src/lib/projectMigrations.ts
@@ -2,18 +2,46 @@
 import { Project, BoardComponent } from '../types';
 import { defaultComponents } from './components/componentLibrary';
 
-export const CURRENT_SCHEMA_VERSION = 5;
+export const CURRENT_SCHEMA_VERSION = 6;
 
-const LEGACY_BOARD_SENTINELS = new Set(['board_0', 'board-main']);
+const LEGACY_BOARD_SENTINELS = new Set(['board_0', 'board-main', 'board_main']);
 const LEGACY_BLOCK_SENTINELS = new Set(['block_0']);
 
-export function normalizeProjectComponent(bc: Record<string, unknown>): BoardComponent {
-  const compId = (bc.id as string) || `cmp_${Date.now()}_${Math.random()}`;
+function hashStableString(value: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function deterministicLegacyComponentId(bc: Record<string, unknown>, index = 0): string {
+  const seed = [
+    bc.libraryId,
+    bc.referenceDesignator,
+    bc.componentName,
+    bc.partNumber,
+    bc.packageName,
+    bc.footprint,
+    bc.boardId,
+    bc.circuitBlockId,
+    index,
+  ].map((value) => String(value ?? '')).join('|');
+
+  return `cmp_legacy_${hashStableString(seed)}`;
+}
+
+export function normalizeProjectComponent(
+  bc: Record<string, unknown>,
+  fallbackId?: string,
+): BoardComponent {
+  const compId = (bc.id as string) || fallbackId || deterministicLegacyComponentId(bc);
   const preserved = bc as unknown as Partial<BoardComponent>;
   const libraryId = (bc.libraryId as string) || '';
   const sourceDefinition = defaultComponents.find((definition) => definition.libraryId === libraryId);
 
-  const rawPins = (bc.pins as Record<string, unknown>[]) || [];
+  const rawPins = Array.isArray(bc.pins) ? bc.pins as Record<string, unknown>[] : [];
   const pins = rawPins.map((pin, index) => {
     const pinNumber = String(pin.pinNumber ?? pin.number ?? index + 1);
     const pinName = String(pin.pinName ?? pin.name ?? `PIN${pinNumber}`);
@@ -36,11 +64,15 @@ export function normalizeProjectComponent(bc: Record<string, unknown>): BoardCom
   const bcSchematic = bc.schematic as Record<string, unknown> | undefined;
   const bcPcb = bc.pcb as Record<string, unknown> | undefined;
 
+  const schematicX = typeof bcSchematic?.x === 'number' ? bcSchematic.x : undefined;
+  const schematicY = typeof bcSchematic?.y === 'number' ? bcSchematic.y : undefined;
+  const hasSchematicCoordinates = schematicX !== undefined && schematicY !== undefined;
+  const explicitSchematicPlaced = typeof bcSchematic?.placed === 'boolean' ? bcSchematic.placed : undefined;
   const schematic = {
-    placed: (bcSchematic?.placed as boolean) ?? false,
-    x: (bcSchematic?.x as number) ?? 150,
-    y: (bcSchematic?.y as number) ?? 150,
-    rotation: (bcSchematic?.rotation as number) ?? 0,
+    placed: (explicitSchematicPlaced ?? hasSchematicCoordinates) && hasSchematicCoordinates,
+    x: schematicX,
+    y: schematicY,
+    rotation: typeof bcSchematic?.rotation === 'number' ? bcSchematic.rotation : 0,
     locked: (bcSchematic?.locked as boolean) ?? false,
   };
 
@@ -185,6 +217,7 @@ export function migrateProjectSchema(project: unknown): Project {
   if (!migrated.testing) migrated.testing = [];
   if (!migrated.requirements) migrated.requirements = [];
   if (!migrated.architectureNodes) migrated.architectureNodes = [];
+  if (!migrated.architectureConnections) migrated.architectureConnections = [];
   if (!migrated.mechanicalObjects) migrated.mechanicalObjects = [];
   if (!migrated.firmwareModules) migrated.firmwareModules = [];
   if (!migrated.validationTests) migrated.validationTests = [];
@@ -192,8 +225,12 @@ export function migrateProjectSchema(project: unknown): Project {
   const boardIds = new Set((migrated.boards || []).map((board) => board.id).filter(Boolean));
   const blockIds = new Set((migrated.circuitBlocks || []).map((block) => block.id).filter(Boolean));
 
-  migrated.boardComponents = (migrated.boardComponents as BoardComponent[]).map((component) => {
-    const normalized = normalizeProjectComponent(component as unknown as Record<string, unknown>);
+  migrated.boardComponents = (migrated.boardComponents as BoardComponent[]).map((component, index) => {
+    const rawComponent = component as unknown as Record<string, unknown>;
+    const normalized = normalizeProjectComponent(
+      rawComponent,
+      deterministicLegacyComponentId(rawComponent, index),
+    );
     return {
       ...normalized,
       boardId: resolveLegacyRelation(normalized.boardId, boardIds, LEGACY_BOARD_SENTINELS) || '',

--- a/src/lib/projectSerialization.ts
+++ b/src/lib/projectSerialization.ts
@@ -1,7 +1,10 @@
 import { Project } from '../types';
-import { migrateProjectSchema as migrateSchemaV4 } from './projectMigrations';
+import {
+  CURRENT_SCHEMA_VERSION,
+  migrateProjectSchema as migrateBaseProjectSchema,
+} from './projectMigrations';
 
-export const CURRENT_SCHEMA_VERSION = 5;
+export { CURRENT_SCHEMA_VERSION } from './projectMigrations';
 
 export interface ProjectIntegrityIssue {
   severity: 'Error' | 'Warning' | 'Info';
@@ -16,6 +19,7 @@ export function serializeProject(project: Project): string {
     ...project,
     updatedAt: new Date().toISOString(),
     version: String(CURRENT_SCHEMA_VERSION),
+    schemaVersion: CURRENT_SCHEMA_VERSION,
     // Ensure all 24 domain collections exist
     nodes: project.nodes || [],
     edges: project.edges || [],
@@ -88,16 +92,14 @@ export function deserializeProject(json: string): Project {
   return migrateProjectSchema(raw);
 }
 
-/** Full schema v5 migration ensuring legacy project structures are updated */
+/** Apply canonical project migration plus defaults required by current domain surfaces. */
 export function migrateProjectSchema(raw: unknown): Project {
   if (!raw || typeof raw !== 'object') {
     throw new Error('Cannot migrate non-object project payload');
   }
 
-  // First apply v4 migrations
-  const project = migrateSchemaV4(raw);
+  const project = migrateBaseProjectSchema(raw);
 
-  // Apply v5 defaults
   const pRecord = project as unknown as Record<string, unknown>;
   if (!pRecord.architectureConnections) pRecord.architectureConnections = [];
   if (!pRecord.mechanicalDimensions) pRecord.mechanicalDimensions = [];
@@ -117,6 +119,7 @@ export function migrateProjectSchema(raw: unknown): Project {
   if (!pRecord.customComponentLibrary) pRecord.customComponentLibrary = [];
 
   project.version = String(CURRENT_SCHEMA_VERSION);
+  project.schemaVersion = CURRENT_SCHEMA_VERSION;
   return project;
 }
 


### PR DESCRIPTION
## Why

P0 schema recovery requires migrations to be deterministic, idempotent, and truthful. The current migration path still generated missing component IDs with `Date.now() + Math.random()`, did not recognize the historical `board_main` sentinel, and assigned missing schematic positions to `(150,150)` even when a component was not actually placed.

## Changes

- bump canonical migration version to schema v6;
- generate missing legacy component IDs deterministically from stable legacy identity fields plus input position;
- preserve existing IDs unchanged;
- make generated pin IDs derive from the deterministic component identity;
- recognize `board_0`, `board-main`, and `board_main` as legacy board sentinels;
- resolve a legacy board sentinel only when exactly one real board exists; ambiguous multi-board input remains unresolved;
- stop inventing schematic X/Y coordinates;
- preserve valid zero schematic coordinates;
- require real schematic coordinates before `placed` can remain true;
- harden legacy pin parsing against non-array input;
- initialize missing `architectureConnections` during migration;
- add deterministic/idempotence, zero-coordinate, ambiguity, and duplicate-component regression tests.

## Product effect

Loading the same historical project now produces the same migrated identities every time, and missing schematic geometry remains explicitly unresolved instead of becoming fabricated placement data.

## Scope

This advances #6 only. It does not claim the canonical schema, repository migration, legacy Blueprint migration, or `projectStore` split complete.

## Completion rule

Merge only if lint, typecheck, full tests, production build, and exact-head Vercel preview pass.