### PR TITLE
Stop approximate 3D checks from auto-passing validation

### DIFF
--- a/src/__tests__/validationExecution.test.ts
+++ b/src/__tests__/validationExecution.test.ts
@@ -35,6 +35,33 @@ describe('Slice 6 Validation Execution Engine', () => {
     expect(result.run.logs.some(l => l.includes('MANUAL VERDICT RECORDED: Pass'))).toBe(true);
   });
 
+  it('should require review when the lightweight mechanical engine finds no approximate collision', () => {
+    useProjectStore.setState({
+      validationTests: [{
+        id: 'test_mechanical_clearance',
+        name: 'Enclosure clearance review',
+        category: 'Mechanical',
+        linkedRequirementIds: [],
+        steps: [],
+        measurements: [],
+        passCriteria: ['No physical interference at required clearance'],
+        evidence: [],
+      }],
+      mechanicalBodies: [],
+      mechanicalObjects: [],
+      boardComponents: [],
+      boards: [],
+      activeBoardId: '',
+    });
+
+    const result = runValidationTest(useProjectStore.getState(), 'test_mechanical_clearance');
+
+    expect(result.run.status).toBe('Needs Review');
+    expect(String(result.run.measuredValue)).toContain('Approximate AABB clearance');
+    expect(result.run.logs.some((line) => line.includes('not CAD-kernel or physical clearance verification'))).toBe(true);
+    expect(result.run.logs.some((line) => line.includes('approximate geometry cannot verify physical clearance'))).toBe(true);
+  });
+
   it('should maintain immutable run history prepending new runs', () => {
     const store = useProjectStore.getState();
     const initialRunCount = store.validationRuns?.length || 0;

--- a/src/lib/validationRunner.ts
+++ b/src/lib/validationRunner.ts
@@ -74,15 +74,15 @@ export function runValidationTest(
   } else if (category === 'Thermal' || category === 'Mechanical' || testName.toLowerCase().includes('3d') || testName.toLowerCase().includes('clearance')) {
     const interference = checkMechanicalInterference(project);
     measuredValue = options?.measuredValue ?? (interference.hasCollision
-      ? `${interference.collisions.length} collisions`
-      : `Clearance ${interference.minClearanceMm}mm`);
-    logs.push(`3D spatial collision scan completed: minimum clearance ${interference.minClearanceMm}mm.`);
+      ? `${interference.collisions.length} approximate AABB collisions`
+      : `Approximate AABB clearance ${interference.minClearanceMm}mm`);
+    logs.push(`Approximate AABB collision scan completed: reported minimum separation ${interference.minClearanceMm}mm. This local geometry check is not CAD-kernel or physical clearance verification.`);
     if (interference.hasCollision) {
       status = 'Fail';
-      logs.push(`FAILED: ${interference.collisions.length} 3D mechanical spatial collisions detected.`);
+      logs.push(`FAILED: ${interference.collisions.length} approximate 3D bounding-box collisions detected. Resolve these before detailed mechanical review.`);
     } else {
-      status = 'Pass';
-      logs.push('PASSED: 3D spatial clearance verified by the local geometry engine.');
+      status = 'Needs Review';
+      logs.push('NEEDS REVIEW: No bounding-box collision was detected, but approximate geometry cannot verify physical clearance. Review exact CAD/package geometry or physical evidence before recording a pass.');
     }
   } else if (category === 'Firmware' || testName.toLowerCase().includes('state')) {
     const warnings = validateStateMachine(project.firmwareStates || [], project.firmwareTransitions || []);


### PR DESCRIPTION
## Why

The production validation runner currently treats the lightweight mechanical interference engine as if it can verify physical 3D clearance. When no AABB overlap is found, the run is marked `Pass` and the log says clearance was verified. That is stronger than the underlying geometry model supports and contradicts the product truthfulness rules in #17/#19/#21.

## Changes

- keep detected approximate bounding-box collisions as a failing condition;
- change no-collision mechanical/3D results from `Pass` to `Needs Review`;
- label the measurement as approximate AABB clearance;
- explicitly state that the local check is not CAD-kernel or physical clearance verification;
- require exact CAD/package geometry or physical evidence before a pass can be recorded;
- add regression coverage against the production validation runner.

## Product effect

A user can still use the lightweight collision engine as an early warning tool, but Hardware Studio will no longer promote a negative approximate result into verified engineering evidence.

## Scope

This is a truthfulness/safety hardening slice. It does not implement the CAD kernel, exact interference, or full durable validation evidence model.

## Completion rule

Merge only if lint, typecheck, full tests, production build, and exact-head Vercel preview pass.