### PR TITLE
Stop mechanical interference checks from inventing engineering geometry

### DIFF
--- a/src/__tests__/mechanicalCadEngine.test.ts
+++ b/src/__tests__/mechanicalCadEngine.test.ts
@@ -51,6 +51,9 @@ describe('Mechanical 3D CAD & Enclosure Engine', () => {
       version: '1.0',
       activeView: 'mechanical',
       bom: [],
+      boards: [
+        { id: 'b1', name: 'Explicit Test Board' }
+      ],
       mechanicalObjects: [
         { id: 'enc1', name: 'Enclosure Shell', type: 'Outer Profile', shape: 'rect', layer: 'Enclosure', xMm: 0, yMm: 0, widthMm: 50, heightMm: 50, depthMm: 10, rotationDeg: 0, locked: false, visible: true }
       ],
@@ -65,7 +68,7 @@ describe('Mechanical 3D CAD & Enclosure Engine', () => {
           packageName: 'CAN_8MM',
           footprint: 'C_0805',
           partNumber: 'CAP-100U',
-          placementX: 60, // Outside enclosure!
+          placementX: 60,
           placementY: 25,
           placementStatus: 'Placed',
           placementCriticality: 'High',

--- a/src/__tests__/mechanicalInterferenceTruthfulness.test.ts
+++ b/src/__tests__/mechanicalInterferenceTruthfulness.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { Project } from '../types';
+import { checkMechanicalInterference } from '../lib/mechanical/mechanicalGeometry';
+
+function project(input: Partial<Project>): Project {
+  return {
+    boards: [],
+    boardComponents: [],
+    mechanicalBodies: [],
+    mechanicalObjects: [],
+    ...input,
+  } as Project;
+}
+
+const explicitBatteryBody = {
+  id: 'battery-body',
+  name: 'Battery body',
+  objectType: 'Battery',
+  xMm: 0,
+  yMm: 0,
+  zMm: 0,
+  widthMm: 20,
+  heightMm: 20,
+  depthMm: 8,
+};
+
+const explicitPlacedComponent = {
+  id: 'component-1',
+  boardId: 'board-real',
+  referenceDesignator: 'U1',
+  componentName: 'Controller',
+  componentType: 'IC',
+  value: 'MCU',
+  packageName: 'QFN',
+  footprint: 'QFN',
+  partNumber: 'MCU-1',
+  placementCriticality: 'Low' as const,
+  notes: '',
+  pcb: {
+    placed: true,
+    xMm: 5,
+    yMm: 5,
+    rotationDeg: 0,
+    side: 'Top' as const,
+    locked: false,
+    placementStatus: 'Placed' as const,
+  },
+  packageDimensions: { widthMm: 8, heightMm: 8, heightZMm: 2 },
+};
+
+describe('mechanical interference input truthfulness', () => {
+  it('does not invent a clearance value when there is nothing explicit to compare', () => {
+    const result = checkMechanicalInterference(project({}));
+
+    expect(result.hasCollision).toBe(false);
+    expect(result.collisions).toEqual([]);
+    expect(result.minClearanceMm).toBeNull();
+  });
+
+  it('does not treat legacy board_main as an active physical board', () => {
+    const result = checkMechanicalInterference(project({
+      activeBoardId: 'board_main',
+      mechanicalBodies: [explicitBatteryBody],
+      boardComponents: [{ ...explicitPlacedComponent, boardId: 'board_main' }],
+    }));
+
+    expect(result.hasCollision).toBe(false);
+    expect(result.minClearanceMm).toBeNull();
+  });
+
+  it('uses an explicitly selected real board and explicit package geometry for screening', () => {
+    const result = checkMechanicalInterference(project({
+      activeBoardId: 'board-real',
+      boards: [{ id: 'board-real', name: 'Real board', boardType: 'Main PCB' }],
+      mechanicalBodies: [explicitBatteryBody],
+      boardComponents: [explicitPlacedComponent],
+    }));
+
+    expect(result.hasCollision).toBe(true);
+    expect(result.collisions.length).toBeGreaterThan(0);
+    expect(result.minClearanceMm).toBe(0);
+  });
+
+  it('does not fabricate package dimensions for a placed component', () => {
+    const { packageDimensions: _omitted, ...withoutPackageDimensions } = explicitPlacedComponent;
+    const result = checkMechanicalInterference(project({
+      activeBoardId: 'board-real',
+      boards: [{ id: 'board-real', name: 'Real board', boardType: 'Main PCB' }],
+      mechanicalBodies: [explicitBatteryBody],
+      boardComponents: [withoutPackageDimensions],
+    }));
+
+    expect(result.hasCollision).toBe(false);
+    expect(result.minClearanceMm).toBeNull();
+  });
+});

--- a/src/__tests__/mechanicalInterferenceTruthfulness.test.ts
+++ b/src/__tests__/mechanicalInterferenceTruthfulness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Project } from '../types';
+import type { BoardComponent, MechanicalBody, Project } from '../types';
 import { checkMechanicalInterference } from '../lib/mechanical/mechanicalGeometry';
 
 function project(input: Partial<Project>): Project {
@@ -12,7 +12,7 @@ function project(input: Partial<Project>): Project {
   } as Project;
 }
 
-const explicitBatteryBody = {
+const explicitBatteryBody: MechanicalBody = {
   id: 'battery-body',
   name: 'Battery body',
   objectType: 'Battery',
@@ -24,7 +24,7 @@ const explicitBatteryBody = {
   depthMm: 8,
 };
 
-const explicitPlacedComponent = {
+const explicitPlacedComponent: BoardComponent = {
   id: 'component-1',
   boardId: 'board-real',
   referenceDesignator: 'U1',
@@ -34,16 +34,16 @@ const explicitPlacedComponent = {
   packageName: 'QFN',
   footprint: 'QFN',
   partNumber: 'MCU-1',
-  placementCriticality: 'Low' as const,
+  placementCriticality: 'Low',
   notes: '',
   pcb: {
     placed: true,
     xMm: 5,
     yMm: 5,
     rotationDeg: 0,
-    side: 'Top' as const,
+    side: 'Top',
     locked: false,
-    placementStatus: 'Placed' as const,
+    placementStatus: 'Placed',
   },
   packageDimensions: { widthMm: 8, heightMm: 8, heightZMm: 2 },
 };
@@ -82,7 +82,10 @@ describe('mechanical interference input truthfulness', () => {
   });
 
   it('does not fabricate package dimensions for a placed component', () => {
-    const { packageDimensions: _omitted, ...withoutPackageDimensions } = explicitPlacedComponent;
+    const withoutPackageDimensions: BoardComponent = {
+      ...explicitPlacedComponent,
+      packageDimensions: undefined,
+    };
     const result = checkMechanicalInterference(project({
       activeBoardId: 'board-real',
       boards: [{ id: 'board-real', name: 'Real board', boardType: 'Main PCB' }],

--- a/src/__tests__/validationExecution.test.ts
+++ b/src/__tests__/validationExecution.test.ts
@@ -35,7 +35,7 @@ describe('Slice 6 Validation Execution Engine', () => {
     expect(result.run.logs.some(l => l.includes('MANUAL VERDICT RECORDED: Pass'))).toBe(true);
   });
 
-  it('should require review when the lightweight mechanical engine finds no approximate collision', () => {
+  it('should require review and report unresolved clearance when explicit geometry is insufficient', () => {
     useProjectStore.setState({
       validationTests: [{
         id: 'test_mechanical_clearance',
@@ -57,8 +57,9 @@ describe('Slice 6 Validation Execution Engine', () => {
     const result = runValidationTest(useProjectStore.getState(), 'test_mechanical_clearance');
 
     expect(result.run.status).toBe('Needs Review');
-    expect(String(result.run.measuredValue)).toContain('Approximate AABB clearance');
-    expect(result.run.logs.some((line) => line.includes('not CAD-kernel or physical clearance verification'))).toBe(true);
+    expect(result.run.measuredValue).toBe('Approximate AABB clearance unresolved');
+    expect(result.run.logs.some((line) => line.includes('insufficient explicit comparable geometry'))).toBe(true);
+    expect(result.run.logs.some((line) => line.includes('Missing geometry was not replaced with defaults'))).toBe(true);
     expect(result.run.logs.some((line) => line.includes('approximate geometry cannot verify physical clearance'))).toBe(true);
   });
 

--- a/src/lib/mechanical/mechanicalGeometry.ts
+++ b/src/lib/mechanical/mechanicalGeometry.ts
@@ -214,43 +214,69 @@ export interface CollisionPair {
 export interface CollisionResult {
   hasCollision: boolean;
   collisions: CollisionPair[];
-  minClearanceMm: number;
+  minClearanceMm: number | null;
 }
 
-/** Check 3D Spatial Interference between all internal bodies, components, battery, and enclosure boundaries */
+function finiteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function positiveNumber(value: unknown): value is number {
+  return finiteNumber(value) && value > 0;
+}
+
+/**
+ * Lightweight AABB interference screening.
+ *
+ * This is deliberately not a CAD-kernel clearance check. Only explicit recorded
+ * coordinates and dimensions participate; missing engineering geometry stays
+ * unresolved instead of being replaced with plausible-looking defaults.
+ */
 export function checkMechanicalInterference(project: Project): CollisionResult {
   const enclosures: { id: string; name: string; bbox: BoundingBox3D }[] = [];
   const internalBodies: { id: string; name: string; bbox: BoundingBox3D }[] = [];
 
-  // 1. Separate Enclosure Shells vs Internal Bodies
-  (project.mechanicalBodies || []).forEach((b) => {
-    const w = b.widthMm || 100;
-    const h = b.heightMm || 60;
-    const d = b.depthMm || 20;
+  // 1. Explicit 3D mechanical bodies only. Flat fields and the newer
+  // position/dimensions representation are both accepted when fully specified.
+  (project.mechanicalBodies || []).forEach((body) => {
+    const xMm = finiteNumber(body.xMm) ? body.xMm : body.position?.x;
+    const yMm = finiteNumber(body.yMm) ? body.yMm : body.position?.y;
+    const zMm = finiteNumber(body.zMm) ? body.zMm : body.position?.z;
+    const widthMm = positiveNumber(body.widthMm) ? body.widthMm : body.dimensions?.x;
+    const heightMm = positiveNumber(body.heightMm) ? body.heightMm : body.dimensions?.y;
+    const depthMm = positiveNumber(body.depthMm) ? body.depthMm : body.dimensions?.z;
+
+    if (!finiteNumber(xMm) || !finiteNumber(yMm) || !finiteNumber(zMm)
+      || !positiveNumber(widthMm) || !positiveNumber(heightMm) || !positiveNumber(depthMm)) {
+      return;
+    }
+
     const item = {
-      id: b.id || 'body_enc',
-      name: b.name || 'Enclosure Shell',
+      id: body.id,
+      name: body.name || 'Mechanical Body',
       bbox: {
-        xMin: b.xMm || 0,
-        xMax: (b.xMm || 0) + w,
-        yMin: b.yMm || 0,
-        yMax: (b.yMm || 0) + h,
-        zMin: b.zMm || 0,
-        zMax: (b.zMm || 0) + d
+        xMin: xMm,
+        xMax: xMm + widthMm,
+        yMin: yMm,
+        yMax: yMm + heightMm,
+        zMin: zMm,
+        zMax: zMm + depthMm
       }
     };
-    if (b.objectType === 'Enclosure' || b.name?.toLowerCase().includes('enclosure')) {
+    if (body.objectType === 'Enclosure' || body.name?.toLowerCase().includes('enclosure')) {
       enclosures.push(item);
     } else {
       internalBodies.push(item);
     }
   });
 
-  // 2. Mechanical Objects
+  // 2. A 2D mechanical object participates only when explicit depth exists.
+  // MechanicalObject currently has no Z transform, so the local screening plane is Z=0.
   (project.mechanicalObjects || []).forEach((obj) => {
+    if (!positiveNumber(obj.depthMm)) return;
     const bbox2d = getMechanicalBoundingBox(obj);
-    const zDepth = obj.depthMm || (obj.layer === 'Enclosure' ? 25 : obj.layer === 'Battery' ? 10 : 5);
-    const zBase = obj.layer === 'Battery' ? 2 : 0;
+    if (!positiveNumber(bbox2d.width) || !positiveNumber(bbox2d.height)) return;
+
     const item = {
       id: obj.id,
       name: obj.name || 'Mechanical Component',
@@ -259,8 +285,8 @@ export function checkMechanicalInterference(project: Project): CollisionResult {
         xMax: bbox2d.xMax,
         yMin: bbox2d.yMin,
         yMax: bbox2d.yMax,
-        zMin: zBase,
-        zMax: zBase + zDepth
+        zMin: 0,
+        zMax: obj.depthMm
       }
     };
     if (obj.layer === 'Enclosure' || obj.type === 'Outer Profile') {
@@ -270,35 +296,47 @@ export function checkMechanicalInterference(project: Project): CollisionResult {
     }
   });
 
-  // 3. Placed Board Components with Package Dimensions
-  const activeBoardId = project.activeBoardId || 'board_main';
-  (project.boardComponents || [])
-    .filter((c) => c.boardId === activeBoardId && c.pcb?.placed !== false)
-    .forEach((c) => {
-      const cx = c.pcb?.xMm ?? c.placementX ?? 0;
-      const cy = c.pcb?.yMm ?? c.placementY ?? 0;
-      const packageDim = c.packageDimensions || { widthMm: 8, heightMm: 8, heightZMm: 3 };
-      const compW = packageDim.widthMm || 8;
-      const compH = packageDim.heightMm || 8;
-      const compZ = packageDim.heightZMm || 3;
-      const pcbZBase = 5;
+  // 3. Board components participate only when the selected board is a real project
+  // board and the placement + package dimensions are explicit. There is no
+  // synthetic board fallback and no invented component position/package geometry.
+  const realBoardIds = new Set((project.boards || []).map((board) => board.id));
+  const activeBoardId = project.activeBoardId && realBoardIds.has(project.activeBoardId)
+    ? project.activeBoardId
+    : null;
 
-      internalBodies.push({
-        id: c.id,
-        name: `${c.referenceDesignator || 'U'} (${c.componentName || 'Component'})`,
-        bbox: {
-          xMin: cx - compW / 2,
-          xMax: cx + compW / 2,
-          yMin: cy - compH / 2,
-          yMax: cy + compH / 2,
-          zMin: pcbZBase,
-          zMax: pcbZBase + compZ
+  if (activeBoardId) {
+    (project.boardComponents || [])
+      .filter((component) => component.boardId === activeBoardId && component.pcb?.placed === true)
+      .forEach((component) => {
+        const cx = component.pcb?.xMm;
+        const cy = component.pcb?.yMm;
+        const packageDim = component.packageDimensions;
+        if (!finiteNumber(cx) || !finiteNumber(cy) || !packageDim
+          || !positiveNumber(packageDim.widthMm)
+          || !positiveNumber(packageDim.heightMm)
+          || !positiveNumber(packageDim.heightZMm)) {
+          return;
         }
+
+        // The current lightweight representation uses the board plane as Z=0.
+        // This is an approximate screening convention, not an assembly transform.
+        internalBodies.push({
+          id: component.id,
+          name: `${component.referenceDesignator || 'Component'} (${component.componentName || 'Component'})`,
+          bbox: {
+            xMin: cx - packageDim.widthMm / 2,
+            xMax: cx + packageDim.widthMm / 2,
+            yMin: cy - packageDim.heightMm / 2,
+            yMax: cy + packageDim.heightMm / 2,
+            zMin: 0,
+            zMax: packageDim.heightZMm
+          }
+        });
       });
-    });
+  }
 
   const collisions: CollisionPair[] = [];
-  let minClearanceMm = Infinity;
+  let minClearanceMm: number | null = null;
 
   // A. Internal Object vs Internal Object Collisions (e.g. Component ↔ Battery, Component A ↔ Component B)
   for (let i = 0; i < internalBodies.length; i++) {
@@ -325,7 +363,7 @@ export function checkMechanicalInterference(project: Project): CollisionResult {
         const dy = Math.max(0, Math.max(a.yMin - b.yMax, b.yMin - a.yMax));
         const dz = Math.max(0, Math.max(a.zMin - b.zMax, b.zMin - a.zMax));
         const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-        if (dist < minClearanceMm) minClearanceMm = dist;
+        if (minClearanceMm === null || dist < minClearanceMm) minClearanceMm = dist;
       }
     }
   }
@@ -353,12 +391,10 @@ export function checkMechanicalInterference(project: Project): CollisionResult {
     }
   }
 
-  if (minClearanceMm === Infinity) minClearanceMm = 5.0;
-
   return {
     hasCollision: collisions.length > 0,
     collisions,
-    minClearanceMm: Math.round(minClearanceMm * 100) / 100
+    minClearanceMm: minClearanceMm === null ? null : Math.round(minClearanceMm * 100) / 100
   };
 }
 
@@ -455,4 +491,3 @@ export function computeEnclosureShell(
     innerDepthMm
   };
 }
-

--- a/src/lib/validationRunner.ts
+++ b/src/lib/validationRunner.ts
@@ -73,10 +73,19 @@ export function runValidationTest(
     }
   } else if (category === 'Thermal' || category === 'Mechanical' || testName.toLowerCase().includes('3d') || testName.toLowerCase().includes('clearance')) {
     const interference = checkMechanicalInterference(project);
+    const clearanceLabel = interference.minClearanceMm === null
+      ? 'unresolved'
+      : `${interference.minClearanceMm}mm`;
     measuredValue = options?.measuredValue ?? (interference.hasCollision
       ? `${interference.collisions.length} approximate AABB collisions`
-      : `Approximate AABB clearance ${interference.minClearanceMm}mm`);
-    logs.push(`Approximate AABB collision scan completed: reported minimum separation ${interference.minClearanceMm}mm. This local geometry check is not CAD-kernel or physical clearance verification.`);
+      : `Approximate AABB clearance ${clearanceLabel}`);
+
+    if (interference.minClearanceMm === null) {
+      logs.push('Approximate AABB collision scan completed with insufficient explicit comparable geometry to report a clearance value. Missing geometry was not replaced with defaults.');
+    } else {
+      logs.push(`Approximate AABB collision scan completed: reported minimum separation ${interference.minClearanceMm}mm. This local geometry check is not CAD-kernel or physical clearance verification.`);
+    }
+
     if (interference.hasCollision) {
       status = 'Fail';
       logs.push(`FAILED: ${interference.collisions.length} approximate 3D bounding-box collisions detected. Resolve these before detailed mechanical review.`);


### PR DESCRIPTION
## Why

The lightweight mechanical interference engine still contained the last production `board_main` fallback and several geometry defaults that could turn missing data into plausible-looking collision/clearance results. It also reported a synthetic `5.0 mm` minimum clearance when no comparable geometry existed.

That is incompatible with Hardware Studio's current V1 rule: missing engineering geometry must remain unresolved, and the lightweight AABB engine is only an early screening representation.

## Changes

- remove the production `activeBoardId || 'board_main'` fallback;
- require the active board to exist in the project's real board collection before board components participate;
- require `pcb.placed === true` plus explicit PCB coordinates;
- require explicit package width/height/Z dimensions instead of defaulting to `8 × 8 × 3 mm`;
- require explicit mechanical-body position and 3D extents, while supporting both flat and `position`/`dimensions` representations;
- require explicit depth before a 2D mechanical object participates in 3D screening;
- remove guessed layer-based Z offsets;
- replace the invented `5 mm` no-data clearance with `null` / unresolved;
- update validation reporting so insufficient explicit geometry is shown as unresolved rather than `null mm`;
- add regression tests for empty geometry, legacy `board_main`, real-board explicit package collision, and missing package dimensions.

## Product effect

The screening engine may report only what is supported by recorded geometry. Missing data no longer silently becomes board identity, placement, package size, body size, or clearance evidence.

## Scope

This does **not** make the AABB engine exact CAD. It remains an approximate early-warning mechanism and cannot produce a verified mechanical pass.

## Completion rule

Merge only if lint, typecheck, full tests, production build, and exact-head Vercel preview pass.