### PR TITLE
Make Mechanical validation reviewable and stop fake Thermal automation

### DIFF
--- a/src/__tests__/validationExecution.test.ts
+++ b/src/__tests__/validationExecution.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useProjectStore } from '../store/projectStore';
-import { runValidationTest } from '../lib/validationRunner';
+import { getValidationExecutionMode, runValidationTest } from '../lib/validationRunner';
 
 describe('Slice 6 Validation Execution Engine', () => {
   beforeEach(() => {
     useProjectStore.getState().resetProject();
+  });
+
+  it('classifies only implemented checks as fully automated', () => {
+    expect(getValidationExecutionMode('DRC', 'Board DRC')).toBe('drc-auto');
+    expect(getValidationExecutionMode('Firmware', 'Firmware state machine reachability')).toBe('firmware-state-auto');
+    expect(getValidationExecutionMode('Mechanical', 'Enclosure clearance review')).toBe('mechanical-screen');
+    expect(getValidationExecutionMode('Thermal', 'Thermal rise validation')).toBe('manual');
+    expect(getValidationExecutionMode('Firmware', 'Firmware build on target')).toBe('manual');
   });
 
   it('should return Needs Review for unknown or manual test categories instead of auto-passing', () => {
@@ -61,6 +69,151 @@ describe('Slice 6 Validation Execution Engine', () => {
     expect(result.run.logs.some((line) => line.includes('insufficient explicit comparable geometry'))).toBe(true);
     expect(result.run.logs.some((line) => line.includes('Missing geometry was not replaced with defaults'))).toBe(true);
     expect(result.run.logs.some((line) => line.includes('approximate geometry cannot verify physical clearance'))).toBe(true);
+  });
+
+  it('accepts an engineer-reviewed mechanical verdict only with evidence and reviewer identity', () => {
+    useProjectStore.setState({
+      validationTests: [{
+        id: 'test_mechanical_reviewed',
+        name: 'Mechanical clearance evidence review',
+        category: 'Mechanical',
+        linkedRequirementIds: [],
+        steps: [],
+        measurements: [],
+        passCriteria: ['Exact CAD or physical evidence confirms required clearance'],
+        evidence: [],
+      }],
+      mechanicalBodies: [],
+      mechanicalObjects: [],
+      boardComponents: [],
+      boards: [],
+      activeBoardId: '',
+    });
+
+    const rejected = runValidationTest(useProjectStore.getState(), 'test_mechanical_reviewed', {
+      manualVerdict: 'Pass',
+    });
+    expect(rejected.run.status).toBe('Needs Review');
+    expect(rejected.run.logs.some((line) => line.includes('requested engineer verdict was not accepted'))).toBe(true);
+
+    const reviewed = runValidationTest(useProjectStore.getState(), 'test_mechanical_reviewed', {
+      manualVerdict: 'Pass',
+      evidenceLink: 'cad://enclosure/rev-c/interference-review',
+      runBy: 'Mechanical Lead',
+    });
+    expect(reviewed.run.status).toBe('Pass');
+    expect(reviewed.run.runBy).toBe('Mechanical Lead');
+    expect(reviewed.run.logs.some((line) => line.includes('ENGINEER VERDICT RECORDED: Pass'))).toBe(true);
+    expect(reviewed.run.logs.some((line) => line.includes('AABB screen itself did not produce a verified pass'))).toBe(true);
+  });
+
+  it('does not allow an engineer verdict to override an approximate mechanical collision blocker', () => {
+    useProjectStore.setState({
+      validationTests: [{
+        id: 'test_mechanical_collision',
+        name: '3D enclosure clearance',
+        category: 'Mechanical',
+        linkedRequirementIds: [],
+        steps: [],
+        measurements: [],
+        passCriteria: ['No enclosure protrusion'],
+        evidence: [],
+      }],
+      mechanicalObjects: [
+        {
+          id: 'enc',
+          name: 'Enclosure',
+          type: 'Outer Profile',
+          shape: 'rect',
+          layer: 'Enclosure',
+          xMm: 0,
+          yMm: 0,
+          widthMm: 20,
+          heightMm: 20,
+          depthMm: 10,
+          rotationDeg: 0,
+          locked: false,
+          visible: true,
+        },
+        {
+          id: 'connector',
+          name: 'Connector',
+          type: 'Connector Opening',
+          shape: 'rect',
+          layer: 'Internal',
+          xMm: 18,
+          yMm: 5,
+          widthMm: 6,
+          heightMm: 5,
+          depthMm: 5,
+          rotationDeg: 0,
+          locked: false,
+          visible: true,
+        },
+      ],
+      boardComponents: [],
+      boards: [],
+      activeBoardId: '',
+    });
+
+    const result = runValidationTest(useProjectStore.getState(), 'test_mechanical_collision', {
+      manualVerdict: 'Pass',
+      evidenceLink: 'cad://review/attempted-override',
+      runBy: 'Mechanical Reviewer',
+    });
+
+    expect(result.run.status).toBe('Fail');
+    expect(result.run.logs.some((line) => line.includes('ENGINEER VERDICT NOT APPLIED'))).toBe(true);
+  });
+
+  it('keeps thermal validation manual and evidence-backed instead of using the collision engine', () => {
+    useProjectStore.setState({
+      validationTests: [{
+        id: 'test_thermal',
+        name: 'Thermal rise validation',
+        category: 'Thermal',
+        linkedRequirementIds: [],
+        steps: [],
+        measurements: [],
+        passCriteria: ['Temperature rise remains within requirement'],
+        evidence: [],
+      }],
+    });
+
+    const unresolved = runValidationTest(useProjectStore.getState(), 'test_thermal');
+    expect(unresolved.run.status).toBe('Needs Review');
+    expect(unresolved.run.logs.some((line) => line.includes('does not currently run a thermal solver'))).toBe(true);
+    expect(unresolved.run.logs.some((line) => line.includes('AABB collision'))).toBe(false);
+
+    const reviewed = runValidationTest(useProjectStore.getState(), 'test_thermal', {
+      measuredValue: 'Peak case temperature 51.2 C',
+      manualVerdict: 'Pass',
+      evidenceLink: 'lab://thermal/chamber-run-42',
+      runBy: 'Thermal Test Engineer',
+    });
+    expect(reviewed.run.status).toBe('Pass');
+    expect(reviewed.run.logs.some((line) => line.includes('No internal thermal solver was executed'))).toBe(true);
+  });
+
+  it('does not treat every Firmware-category test as a state-machine auto-pass', () => {
+    useProjectStore.setState({
+      validationTests: [{
+        id: 'test_firmware_build',
+        name: 'Firmware build on target',
+        category: 'Firmware',
+        linkedRequirementIds: [],
+        steps: [],
+        measurements: [],
+        passCriteria: ['Firmware builds and runs on target hardware'],
+        evidence: [],
+      }],
+      firmwareStates: [],
+      firmwareTransitions: [],
+    });
+
+    const result = runValidationTest(useProjectStore.getState(), 'test_firmware_build');
+    expect(result.run.status).toBe('Needs Review');
+    expect(result.run.logs.some((line) => line.includes('not a supported automated state-machine structural check'))).toBe(true);
   });
 
   it('should maintain immutable run history prepending new runs', () => {

--- a/src/__tests__/validationExecutionModeUx.test.ts
+++ b/src/__tests__/validationExecutionModeUx.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('validation execution mode UX contract', () => {
+  it('uses one shared execution classifier across the engine and validation workbench', () => {
+    const runner = source('../lib/validationRunner.ts');
+    const workbench = source('../components/studio/UnifiedValidationWorkbench.tsx');
+
+    expect(runner).toContain("export type ValidationExecutionMode = 'drc-auto' | 'firmware-state-auto' | 'mechanical-screen' | 'manual'");
+    expect(runner).toContain('getValidationExecutionMode(category, testName)');
+    expect(workbench).toContain('getValidationExecutionMode');
+    expect(workbench).not.toContain('function isAutomatedValidation');
+  });
+
+  it('makes screened Mechanical review and unsupported Thermal automation explicit to the user', () => {
+    const workbench = source('../components/studio/UnifiedValidationWorkbench.tsx');
+
+    expect(workbench).toContain('Run approximate screen');
+    expect(workbench).toContain('exact CAD/physical evidence');
+    expect(workbench).toContain('reviewer identity');
+    expect(workbench).toContain('No thermal solver is implemented in Hardware Studio yet');
+    expect(workbench).toContain('external simulation/lab evidence');
+  });
+});

--- a/src/components/studio/UnifiedValidationWorkbench.tsx
+++ b/src/components/studio/UnifiedValidationWorkbench.tsx
@@ -14,7 +14,11 @@ import {
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore } from '../../store/studioContextStore';
-import { getValidationRunHistory, runValidationTest } from '../../lib/validationRunner';
+import {
+  getValidationExecutionMode,
+  getValidationRunHistory,
+  runValidationTest,
+} from '../../lib/validationRunner';
 import { useFeedback } from '../feedback/FeedbackProvider';
 import { ValidationStudio } from '../validation/ValidationStudio';
 import { EditorDockButton } from '../editor/EditorDockButton';
@@ -27,15 +31,6 @@ function runStatusToTestStatus(status: string): string {
   if (status === 'Pass' || status === 'Passed') return 'Passed';
   if (status === 'Fail' || status === 'Failed') return 'Failed';
   return 'In Progress';
-}
-
-function isAutomatedValidation(category?: string, name?: string): boolean {
-  const normalized = (category || '').toLowerCase();
-  const testName = (name || '').toLowerCase();
-  return ['drc', 'mechanical', 'thermal', 'firmware'].includes(normalized)
-    || testName.includes('drc')
-    || testName.includes('clearance')
-    || testName.includes('state');
 }
 
 export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProps> = ({ initialMode }) => {
@@ -75,7 +70,11 @@ export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProp
     || validationTests[0];
   const runHistory = runTest ? getValidationRunHistory({ ...store, validationRuns }, runTest.id) : [];
   const latestRun = runHistory[0];
-  const automatedRun = isAutomatedValidation(runTest?.category, runTest?.name || runTest?.testName);
+  const executionMode = getValidationExecutionMode(runTest?.category, runTest?.name || runTest?.testName);
+  const automatedRun = executionMode === 'drc-auto' || executionMode === 'firmware-state-auto';
+  const mechanicalScreenRun = executionMode === 'mechanical-screen';
+  const thermalReview = (runTest?.category || '').trim().toLowerCase() === 'thermal';
+  const evidenceBackedReview = mechanicalScreenRun || thermalReview;
 
   const contextualComponentCount = useMemo(
     () => boardComponents.filter((component) => !activeBoardId || component.boardId === activeBoardId).length,
@@ -125,11 +124,23 @@ export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProp
       feedback.notify({ tone: 'warning', title: 'No validation test selected', detail: 'Create or select a validation test before recording evidence.' });
       return;
     }
-    if (!automatedRun && !manualVerdict) {
+
+    if (!automatedRun && !mechanicalScreenRun && !manualVerdict) {
       feedback.notify({
         tone: 'warning',
-        title: 'Manual verdict required',
-        detail: 'Physical/manual validation cannot auto-pass from a measurement alone. Choose Pass, Fail, or Inconclusive after reviewing the procedure and evidence.',
+        title: 'Engineer verdict required',
+        detail: 'This validation type is not fully automated. Choose Pass, Fail, or Inconclusive after reviewing the procedure and evidence.',
+      });
+      return;
+    }
+
+    if (evidenceBackedReview && manualVerdict && (!evidenceLink.trim() || !operator.trim())) {
+      feedback.notify({
+        tone: 'warning',
+        title: 'Evidence and reviewer required',
+        detail: mechanicalScreenRun
+          ? 'A reviewed Mechanical verdict requires an exact CAD/physical evidence reference and reviewer identity. You can run the approximate screen without a verdict first.'
+          : 'A Thermal verdict requires external simulation/lab evidence and reviewer identity because Hardware Studio does not run a thermal solver yet.',
       });
       return;
     }
@@ -154,6 +165,20 @@ export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProp
     setEvidenceLink('');
     setManualVerdict('');
   };
+
+  const measurementPlaceholder = automatedRun
+    ? 'Optional reading or observation'
+    : mechanicalScreenRun
+      ? 'Optional observation; the local screen uses recorded explicit geometry'
+      : thermalReview
+        ? 'Record measured temperature, simulation result, or lab observation'
+        : 'Record the observed result';
+
+  const runActionLabel = mechanicalScreenRun && !manualVerdict
+    ? 'Run approximate screen'
+    : runHistory.length > 0
+      ? 'Record retest'
+      : 'Record run';
 
   return (
     <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-50" aria-label="Context-aware validation workbench">
@@ -189,23 +214,34 @@ export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProp
         {runPanelOpen && (
           <aside className="absolute bottom-3 right-3 top-3 z-40 flex w-[min(360px,calc(100%-1.5rem))] flex-col overflow-hidden rounded-lg border border-slate-300 bg-white shadow-xl" aria-label="Validation run evidence">
             <div className="flex items-start justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-2.5">
-              <div><p className="text-[11px] font-semibold text-slate-900">Record run evidence</p><p className="mt-0.5 text-[9px] leading-4 text-slate-500">Runs are append-only. Manual measurements never imply Pass without an explicit verdict.</p></div>
+              <div><p className="text-[11px] font-semibold text-slate-900">Record run evidence</p><p className="mt-0.5 text-[9px] leading-4 text-slate-500">Runs are append-only. A screen, measurement, or visual review never implies Pass unless that validation mode can actually support the verdict.</p></div>
               <button type="button" onClick={() => setRunPanelOpen(false)} className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-slate-500 hover:bg-slate-200" aria-label="Close run evidence"><X className="h-3.5 w-3.5" /></button>
             </div>
 
             <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
               <label className="block"><span className="text-[9px] font-semibold text-slate-500">Test</span><select value={runTest?.id || ''} onChange={(event) => setSelectedRunTestId(event.target.value)} className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-800 outline-none focus:border-slate-500">{validationTests.length === 0 && <option value="">No validation tests</option>}{validationTests.map((test) => <option key={test.id} value={test.id}>{test.name} · {test.category || 'Manual'}</option>)}</select></label>
 
-              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Measurement / observation</span><textarea value={measurement} onChange={(event) => setMeasurement(event.target.value)} placeholder={automatedRun ? 'Optional reading or observation' : 'Record the observed result'} className="mt-1 min-h-20 w-full resize-y rounded-md border border-slate-300 bg-white p-2.5 text-[10px] leading-5 outline-none focus:border-slate-500" /></label>
+              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Measurement / observation</span><textarea value={measurement} onChange={(event) => setMeasurement(event.target.value)} placeholder={measurementPlaceholder} className="mt-1 min-h-20 w-full resize-y rounded-md border border-slate-300 bg-white p-2.5 text-[10px] leading-5 outline-none focus:border-slate-500" /></label>
 
-              {automatedRun ? (
-                <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2.5 text-[10px] font-semibold text-emerald-800">The validation engine derives this verdict from recorded project state.</div>
-              ) : (
-                <label className="block"><span className="text-[9px] font-semibold text-slate-500">Manual verdict</span><select value={manualVerdict} onChange={(event) => setManualVerdict(event.target.value as typeof manualVerdict)} className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold outline-none focus:border-slate-500"><option value="">Choose verdict…</option><option value="Pass">Pass</option><option value="Fail">Fail</option><option value="Inconclusive">Inconclusive</option></select></label>
+              {executionMode === 'drc-auto' && (
+                <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2.5 text-[10px] font-semibold leading-4 text-emerald-800">The implemented local DRC rules derive this verdict from recorded PCB state.</div>
+              )}
+              {executionMode === 'firmware-state-auto' && (
+                <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2.5 text-[10px] font-semibold leading-4 text-emerald-800">The local state-machine validator checks structural reachability only. It does not verify compilation, timing, hardware behavior, or runtime correctness.</div>
+              )}
+              {mechanicalScreenRun && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-2.5 text-[10px] font-semibold leading-4 text-amber-900">Mechanical first runs an approximate AABB collision screen. A detected collision can fail the run; a clean screen stays Needs Review unless an engineer records a verdict with exact CAD/physical evidence and reviewer identity.</div>
+              )}
+              {thermalReview && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-2.5 text-[10px] font-semibold leading-4 text-amber-900">No thermal solver is implemented in Hardware Studio yet. Thermal verdicts require external simulation/lab evidence plus reviewer identity.</div>
               )}
 
-              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Evidence reference</span><input value={evidenceLink} onChange={(event) => setEvidenceLink(event.target.value)} placeholder="File, URL, log, image, or lab reference" className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] outline-none focus:border-slate-500" /></label>
-              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Operator / reviewer</span><input value={operator} onChange={(event) => setOperator(event.target.value)} placeholder="Name or role" className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] outline-none focus:border-slate-500" /></label>
+              {!automatedRun && (
+                <label className="block"><span className="text-[9px] font-semibold text-slate-500">Engineer verdict{mechanicalScreenRun ? ' (optional for screen-only run)' : ''}</span><select value={manualVerdict} onChange={(event) => setManualVerdict(event.target.value as typeof manualVerdict)} className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold outline-none focus:border-slate-500"><option value="">Choose verdict…</option><option value="Pass">Pass</option><option value="Fail">Fail</option><option value="Inconclusive">Inconclusive</option></select></label>
+              )}
+
+              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Evidence reference{evidenceBackedReview && manualVerdict ? ' · required' : ''}</span><input value={evidenceLink} onChange={(event) => setEvidenceLink(event.target.value)} placeholder="File, URL, log, image, CAD review, simulation, or lab reference" className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] outline-none focus:border-slate-500" /></label>
+              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Operator / reviewer{evidenceBackedReview && manualVerdict ? ' · required' : ''}</span><input value={operator} onChange={(event) => setOperator(event.target.value)} placeholder="Name or role" className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] outline-none focus:border-slate-500" /></label>
 
               <div className="rounded-md border border-slate-200 bg-slate-50 p-2.5">
                 <div className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-700"><History className="h-3.5 w-3.5" /> Run history</div>
@@ -219,7 +255,7 @@ export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProp
             <div className="border-t border-slate-200 bg-slate-50 p-3">
               <button type="button" onClick={recordRun} disabled={!runTest} className="inline-flex min-h-9 w-full items-center justify-center gap-1.5 rounded-md bg-slate-950 px-3 text-[10px] font-semibold text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-40">
                 {runHistory.length > 0 ? <RotateCcw className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
-                {runHistory.length > 0 ? 'Record retest' : 'Record run'}
+                {runActionLabel}
               </button>
             </div>
           </aside>

--- a/src/lib/validationRunner.ts
+++ b/src/lib/validationRunner.ts
@@ -11,6 +11,22 @@ export interface ExecuteRunOptions {
   manualVerdict?: 'Pass' | 'Fail' | 'Inconclusive';
 }
 
+export type ValidationExecutionMode = 'drc-auto' | 'firmware-state-auto' | 'mechanical-screen' | 'manual';
+
+export function getValidationExecutionMode(category?: string, name?: string): ValidationExecutionMode {
+  const normalizedCategory = (category || '').trim().toLowerCase();
+  const normalizedName = (name || '').trim().toLowerCase();
+
+  if (normalizedCategory === 'drc' || normalizedName.includes('drc')) return 'drc-auto';
+  if (normalizedName.includes('state') && (normalizedCategory === 'firmware' || normalizedName.includes('firmware') || normalizedName.includes('state machine') || normalizedName.includes('state-machine'))) {
+    return 'firmware-state-auto';
+  }
+  if (normalizedCategory === 'mechanical' || normalizedName.includes('3d') || normalizedName.includes('clearance')) {
+    return 'mechanical-screen';
+  }
+  return 'manual';
+}
+
 function runTimestamp(run: ValidationRun): number {
   const parsed = run.timestamp ? Date.parse(run.timestamp) : 0;
   return Number.isFinite(parsed) ? parsed : 0;
@@ -35,11 +51,15 @@ export function runValidationTest(
   const rawTest = tests.find((test) => test.id === testId || test.name === testId || test.testName === testId);
   const testName = rawTest?.testName || rawTest?.name || testId || 'Manual Validation Test';
   const category = rawTest?.category || (testId.toLowerCase().includes('drc') ? 'DRC' : 'Manual');
+  const normalizedCategory = category.trim().toLowerCase();
+  const executionMode = getValidationExecutionMode(category, testName);
   const rawCriteria = rawTest?.passCriteria || 'Verification criteria';
   const passCriteriaStr = Array.isArray(rawCriteria) ? rawCriteria.join(', ') : String(rawCriteria);
   const priorRuns = getValidationRunHistory(project, rawTest?.id || testId);
   const previousRun = priorRuns[0];
   const nextRunNumber = Math.max(0, ...priorRuns.map((run) => run.runNumber || 0)) + 1;
+  const evidenceLink = options?.evidenceLink?.trim() || undefined;
+  const reviewer = options?.runBy?.trim() || undefined;
 
   const logs: string[] = [];
   const now = new Date().toISOString();
@@ -50,16 +70,9 @@ export function runValidationTest(
 
   let status: ValidationRun['status'] = 'Needs Review';
   let measuredValue: number | string = options?.measuredValue ?? 'Pending Verification';
-  const isAutomatedCategory = category === 'DRC'
-    || category === 'Thermal'
-    || category === 'Mechanical'
-    || category === 'Firmware'
-    || testName.toLowerCase().includes('drc')
-    || testName.toLowerCase().includes('3d')
-    || testName.toLowerCase().includes('clearance')
-    || testName.toLowerCase().includes('state');
+  const isFullyAutomated = executionMode === 'drc-auto' || executionMode === 'firmware-state-auto';
 
-  if (category === 'DRC' || testName.toLowerCase().includes('drc')) {
+  if (executionMode === 'drc-auto') {
     const drcIssues = runBoardDRC(project);
     const blockers = drcIssues.filter((issue) => issue.severity === 'Blocker' || issue.severity === 'Error');
     measuredValue = options?.measuredValue ?? `${blockers.length} errors`;
@@ -69,9 +82,9 @@ export function runValidationTest(
       logs.push(`FAILED: ${blockers.length} design rule violations detected.`);
     } else {
       status = 'Pass';
-      logs.push('PASSED: Zero blocking design rule violations found.');
+      logs.push('PASSED: Zero blocking design rule violations found for the implemented local DRC rules.');
     }
-  } else if (category === 'Thermal' || category === 'Mechanical' || testName.toLowerCase().includes('3d') || testName.toLowerCase().includes('clearance')) {
+  } else if (executionMode === 'mechanical-screen') {
     const interference = checkMechanicalInterference(project);
     const clearanceLabel = interference.minClearanceMm === null
       ? 'unresolved'
@@ -81,35 +94,58 @@ export function runValidationTest(
       : `Approximate AABB clearance ${clearanceLabel}`);
 
     if (interference.minClearanceMm === null) {
-      logs.push('Approximate AABB collision scan completed with insufficient explicit comparable geometry to report a clearance value. Missing geometry was not replaced with defaults.');
+      logs.push('Approximate AABB collision screen completed with insufficient explicit comparable geometry to report a clearance value. Missing geometry was not replaced with defaults.');
     } else {
-      logs.push(`Approximate AABB collision scan completed: reported minimum separation ${interference.minClearanceMm}mm. This local geometry check is not CAD-kernel or physical clearance verification.`);
+      logs.push(`Approximate AABB collision screen completed: reported minimum separation ${interference.minClearanceMm}mm. This local geometry check is not CAD-kernel or physical clearance verification.`);
     }
 
     if (interference.hasCollision) {
       status = 'Fail';
       logs.push(`FAILED: ${interference.collisions.length} approximate 3D bounding-box collisions detected. Resolve these before detailed mechanical review.`);
+      if (options?.manualVerdict) {
+        logs.push('ENGINEER VERDICT NOT APPLIED: an approximate collision blocker is present, so the screening result remains Fail until the conflicting geometry is corrected.');
+      }
+    } else if (options?.manualVerdict && evidenceLink && reviewer) {
+      status = options.manualVerdict;
+      logs.push(`ENGINEER VERDICT RECORDED: ${options.manualVerdict}. Reviewer ${reviewer} attached external CAD/physical evidence after the approximate screen.`);
+      logs.push('The engineer verdict is evidence-backed; the approximate AABB screen itself did not produce a verified pass.');
     } else {
       status = 'Needs Review';
-      logs.push('NEEDS REVIEW: No bounding-box collision was detected, but approximate geometry cannot verify physical clearance. Review exact CAD/package geometry or physical evidence before recording a pass.');
+      if (options?.manualVerdict) {
+        const missing = [!evidenceLink ? 'evidence reference' : null, !reviewer ? 'reviewer identity' : null].filter(Boolean).join(' and ');
+        logs.push(`NEEDS REVIEW: ${missing || 'required review evidence'} is missing, so the requested engineer verdict was not accepted.`);
+      } else {
+        logs.push('NEEDS REVIEW: No bounding-box collision was detected, but approximate geometry cannot verify physical clearance. Review exact CAD/package geometry or physical evidence before recording a verdict.');
+      }
     }
-  } else if (category === 'Firmware' || testName.toLowerCase().includes('state')) {
+  } else if (executionMode === 'firmware-state-auto') {
     const warnings = validateStateMachine(project.firmwareStates || [], project.firmwareTransitions || []);
     measuredValue = options?.measuredValue ?? `${warnings.length} warnings`;
-    logs.push(`Firmware state-machine scan completed: ${warnings.length} warnings.`);
+    logs.push(`Firmware state-machine structural scan completed: ${warnings.length} warnings.`);
     if (warnings.some((warning) => warning.severity === 'Error')) {
       status = 'Fail';
       logs.push('FAILED: Unreachable states or invalid state-machine transitions were detected.');
     } else {
       status = 'Pass';
-      logs.push('PASSED: State-machine graph is valid and reachable according to the local validator.');
+      logs.push('PASSED: State-machine structure is valid and reachable according to the local validator. This does not verify compilation, timing, hardware behavior, or runtime correctness.');
     }
   } else if (options?.manualVerdict) {
-    status = options.manualVerdict;
-    measuredValue = options.measuredValue ?? 'No numeric measurement recorded';
-    logs.push(`MANUAL VERDICT RECORDED: ${options.manualVerdict}.`);
-    if (options.measuredValue != null) {
-      logs.push(`Manual measurement recorded: ${options.measuredValue}`);
+    if (normalizedCategory === 'thermal' && (!evidenceLink || !reviewer)) {
+      status = 'Needs Review';
+      const missing = [!evidenceLink ? 'thermal evidence reference' : null, !reviewer ? 'reviewer identity' : null].filter(Boolean).join(' and ');
+      logs.push(`NEEDS REVIEW: ${missing || 'required thermal evidence'} is missing. Hardware Studio does not currently run a thermal solver, so a thermal verdict must be supported by external simulation or lab evidence.`);
+    } else {
+      status = options.manualVerdict;
+      measuredValue = options.measuredValue ?? 'No numeric measurement recorded';
+      logs.push(`MANUAL VERDICT RECORDED: ${options.manualVerdict}.`);
+      if (normalizedCategory === 'thermal') {
+        logs.push('THERMAL EVIDENCE: No internal thermal solver was executed. This verdict depends on the attached external simulation/lab evidence and reviewer judgment.');
+      } else if (normalizedCategory === 'firmware') {
+        logs.push('FIRMWARE EVIDENCE: Only state-machine structural checks are automated. This verdict depends on the recorded build/runtime/hardware evidence.');
+      }
+      if (options.measuredValue != null) {
+        logs.push(`Manual measurement recorded: ${options.measuredValue}`);
+      }
     }
   } else {
     if (options?.measuredValue != null) {
@@ -117,10 +153,15 @@ export function runValidationTest(
       logs.push(`Manual measurement recorded without a verdict: ${options.measuredValue}`);
     }
     status = 'Needs Review';
-    logs.push('NEEDS REVIEW: Manual/physical validation cannot auto-pass from a measurement value alone. Record an explicit engineer verdict after reviewing the procedure and evidence.');
+    if (normalizedCategory === 'thermal') {
+      logs.push('NEEDS REVIEW: Hardware Studio does not currently run a thermal solver. Attach external simulation or lab evidence, identify the reviewer, and record an explicit engineer verdict.');
+    } else if (normalizedCategory === 'firmware') {
+      logs.push('NEEDS REVIEW: This firmware test is not a supported automated state-machine structural check. Record build/runtime/hardware evidence and an explicit engineer verdict.');
+    } else {
+      logs.push('NEEDS REVIEW: Manual/physical validation cannot auto-pass from a measurement value alone. Record an explicit engineer verdict after reviewing the procedure and evidence.');
+    }
   }
 
-  const evidenceLink = options?.evidenceLink?.trim() || undefined;
   if (evidenceLink) {
     logs.push(`Evidence link attached: ${evidenceLink}`);
   }
@@ -138,6 +179,12 @@ export function runValidationTest(
     });
   }
 
+  const defaultRunBy = executionMode === 'mechanical-screen'
+    ? 'Local Engineering Screening Engine'
+    : isFullyAutomated
+      ? 'Local Engineering Validation Engine'
+      : 'Local engineer — attribution not recorded';
+
   const newRun: ValidationRun = {
     id: `val_run_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`,
     testId: rawTest?.id || testId,
@@ -151,7 +198,7 @@ export function runValidationTest(
     evidence: frozenEvidence,
     stepResults: JSON.parse(JSON.stringify(rawTest?.steps || [])),
     logs,
-    runBy: options?.runBy?.trim() || (isAutomatedCategory ? 'Local Engineering Validation Engine' : 'Local engineer — attribution not recorded'),
+    runBy: reviewer || defaultRunBy,
     environment: 'Desktop Hardware Studio V1'
   };
 


### PR DESCRIPTION
## Why

After the mechanical truthfulness hardening, the engine correctly leaves clean approximate 3D screens at `Needs Review`. The Validation UI still classified Mechanical as fully automated, so users could not record the evidence-backed engineer verdict needed to complete the review. Thermal tests were also incorrectly routed through the mechanical AABB collision engine, and every `Firmware` category test was treated as if a state-machine structural check could prove it.

## Changes

- introduce one shared `ValidationExecutionMode` classifier used by both engine and UI;
- keep only implemented DRC and firmware state-machine structural checks as fully automated modes;
- make Mechanical an explicit `mechanical-screen` mode;
- allow a screen-only Mechanical run to remain `Needs Review`;
- allow an engineer verdict only when no collision blocker exists and exact CAD/physical evidence plus reviewer identity are recorded;
- refuse to let a manual verdict override detected approximate collisions;
- remove Thermal from the mechanical collision path entirely;
- require external simulation/lab evidence and reviewer identity for Thermal verdicts;
- stop generic Firmware tests from auto-passing through the state-machine validator;
- make the Validation panel explain what each mode can and cannot prove;
- add regression coverage for classification, screened review, collision override prevention, Thermal evidence, generic Firmware tests, and UI/engine classifier convergence.

## Product effect

Validation is now both more truthful and more usable: early local screens can block obvious problems, but unsupported engineering claims remain reviewable rather than silently automated or permanently stuck.

## Scope

This does not add a thermal solver, exact CAD kernel, firmware compiler/runtime validator, or durable backend evidence store. Those remain separate capabilities.

## Completion rule

Merge only if lint, typecheck, full tests, production build, and exact-head Vercel preview pass.