### PR TITLE
Make validation execution modes respect explicit engineering categories

### DIFF
--- a/src/__tests__/validationExecutionModeAuthority.test.ts
+++ b/src/__tests__/validationExecutionModeAuthority.test.ts
@@ -5,6 +5,7 @@ describe('validation execution mode category authority', () => {
   it('never lets a test name override an explicit engineering category', () => {
     expect(getValidationExecutionMode('Thermal', 'Thermal clearance DRC review')).toBe('manual');
     expect(getValidationExecutionMode('Electrical', '3D clearance state DRC')).toBe('manual');
+    expect(getValidationExecutionMode('EMC', '3D clearance DRC screening')).toBe('manual');
     expect(getValidationExecutionMode('Mechanical', 'Board DRC review')).toBe('mechanical-screen');
     expect(getValidationExecutionMode('Firmware', 'Mechanical clearance review')).toBe('manual');
     expect(getValidationExecutionMode('Firmware', 'Firmware state machine reachability')).toBe('firmware-state-auto');

--- a/src/__tests__/validationExecutionModeAuthority.test.ts
+++ b/src/__tests__/validationExecutionModeAuthority.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getValidationExecutionMode } from '../lib/validationRunner';
+
+describe('validation execution mode category authority', () => {
+  it('never lets a test name override an explicit engineering category', () => {
+    expect(getValidationExecutionMode('Thermal', 'Thermal clearance DRC review')).toBe('manual');
+    expect(getValidationExecutionMode('Electrical', '3D clearance state DRC')).toBe('manual');
+    expect(getValidationExecutionMode('Mechanical', 'Board DRC review')).toBe('mechanical-screen');
+    expect(getValidationExecutionMode('Firmware', 'Mechanical clearance review')).toBe('manual');
+    expect(getValidationExecutionMode('Firmware', 'Firmware state machine reachability')).toBe('firmware-state-auto');
+  });
+
+  it('uses conservative name heuristics only when category is absent or explicitly Manual', () => {
+    expect(getValidationExecutionMode(undefined, 'Board DRC')).toBe('drc-auto');
+    expect(getValidationExecutionMode('Manual', 'Firmware state machine review')).toBe('firmware-state-auto');
+    expect(getValidationExecutionMode('Manual', '3D enclosure clearance')).toBe('mechanical-screen');
+    expect(getValidationExecutionMode('Manual', 'Thermal chamber run')).toBe('manual');
+  });
+});

--- a/src/lib/validationRunner.ts
+++ b/src/lib/validationRunner.ts
@@ -17,13 +17,18 @@ export function getValidationExecutionMode(category?: string, name?: string): Va
   const normalizedCategory = (category || '').trim().toLowerCase();
   const normalizedName = (name || '').trim().toLowerCase();
 
-  if (normalizedCategory === 'drc' || normalizedName.includes('drc')) return 'drc-auto';
-  if (normalizedName.includes('state') && (normalizedCategory === 'firmware' || normalizedName.includes('firmware') || normalizedName.includes('state machine') || normalizedName.includes('state-machine'))) {
-    return 'firmware-state-auto';
+  if (normalizedCategory === 'drc') return 'drc-auto';
+  if (normalizedCategory === 'firmware') {
+    return normalizedName.includes('state') ? 'firmware-state-auto' : 'manual';
   }
-  if (normalizedCategory === 'mechanical' || normalizedName.includes('3d') || normalizedName.includes('clearance')) {
-    return 'mechanical-screen';
-  }
+  if (normalizedCategory === 'mechanical') return 'mechanical-screen';
+  if (normalizedCategory && normalizedCategory !== 'manual') return 'manual';
+
+  // Name heuristics are allowed only when no explicit engineering category was supplied.
+  // They must never override a user/domain classification such as Thermal or Electrical.
+  if (normalizedName.includes('drc')) return 'drc-auto';
+  if (normalizedName.includes('firmware') && normalizedName.includes('state')) return 'firmware-state-auto';
+  if (normalizedName.includes('3d') || normalizedName.includes('clearance')) return 'mechanical-screen';
   return 'manual';
 }
 


### PR DESCRIPTION
## Why

The validation classifier still allowed test-name heuristics such as `clearance`, `3d`, or `drc` to override an explicitly assigned engineering category. That means a Thermal test named “thermal clearance” could accidentally enter the Mechanical AABB screening path, recreating the exact kind of false automation we just removed.

## Changes

- make explicit validation category authoritative;
- keep `DRC` category on the implemented local DRC engine;
- keep `Mechanical` category on the approximate Mechanical screening workflow;
- allow only Firmware-category state checks to use state-machine automation;
- keep Thermal, Electrical, and other explicit categories manual/evidence-reviewed unless a dedicated engine exists;
- permit conservative name heuristics only when the category is absent or explicitly `Manual`;
- add regression tests covering conflicting names across Thermal, Electrical, Mechanical, and Firmware categories.

## Product effect

A label in the test name can no longer silently switch engineering engines. The recorded domain classification controls what Hardware Studio is allowed to automate.

## Scope

Classifier truthfulness only; no new validation engines or UI changes.

## Completion rule

Merge only if lint, typecheck, full tests, production build, and exact-head Vercel preview pass.