### PR TITLE
U2: Make Project Home truthful and action-first

### DIFF
--- a/src/__tests__/commercialGradeUxBaseline.test.ts
+++ b/src/__tests__/commercialGradeUxBaseline.test.ts
@@ -6,15 +6,22 @@ function source(relativePath: string): string {
 }
 
 describe('commercial-grade workbench UX contracts', () => {
-  it('keeps product guidance in the owning workspace instead of a permanent global coach', () => {
+  it('keeps product guidance contextual and makes Project Home evidence-driven', () => {
     const appShell = source('../components/AppShell.tsx');
     const electronics = source('../components/studio/ElectronicsWorkspace.tsx');
     const dashboard = source('../components/ProjectDashboard.tsx');
+    const homeModel = source('../lib/projectHome.ts');
 
     expect(appShell).not.toContain('WorkspaceCoach');
     expect(electronics).toContain('Continue this decision');
     expect(electronics).toContain('Recommended next');
-    expect(dashboard).toContain('One product. One identity. One path forward.');
+
+    expect(dashboard).toContain('buildProjectHomeModel(project)');
+    expect(dashboard).toContain('Evidence drives state; counts are inventory only.');
+    expect(dashboard).toContain('Needs attention');
+    expect(dashboard).not.toContain('completedAreas');
+    expect(homeModel).toContain('evaluateElectronicsWorkflow(project)');
+    expect(homeModel).toContain('evaluateFirmwareEvidence(project)');
   });
 
   it('uses one desktop-grade editor chrome instead of card-like per-editor shells', () => {

--- a/src/__tests__/decisionWorkspaceUxBaseline.test.ts
+++ b/src/__tests__/decisionWorkspaceUxBaseline.test.ts
@@ -8,14 +8,19 @@ function source(relativePath: string): string {
 describe('decision-first product UX baseline', () => {
   it('keeps project overview and readiness focused on evidence-driven next actions', () => {
     const dashboard = source('../components/ProjectDashboard.tsx');
+    const homeModel = source('../lib/projectHome.ts');
     const readiness = source('../components/ReadinessDashboard.tsx');
     const engine = source('../lib/readinessScore.ts');
 
-    expect(dashboard).toContain('deriveNextAction');
-    expect(dashboard).toContain('The complete product path');
-    expect(dashboard).toContain('One product. One identity. One path forward.');
-    expect(dashboard).toContain('Existing evidence—not a progress percentage—decides what can move forward.');
-    expect(dashboard).toContain("viewId: 'readiness'");
+    expect(dashboard).toContain('buildProjectHomeModel');
+    expect(dashboard).toContain('Evidence drives state; counts are inventory only.');
+    expect(dashboard).toContain('Needs attention');
+    expect(dashboard).toContain('onClick={() => setActiveView(nextAction.viewId)}');
+    expect(dashboard).not.toContain('One product. One identity. One path forward.');
+    expect(homeModel).toContain('Existing evidence—not a progress percentage—decides what can move forward.');
+    expect(homeModel).toContain("viewId: 'readiness'");
+    expect(homeModel).toContain('evaluateElectronicsWorkflow');
+    expect(homeModel).toContain('evaluateFirmwareEvidence');
 
     expect(readiness).toContain('What can this project safely do next?');
     expect(readiness).toContain('Blocking evidence');

--- a/src/__tests__/editorInteractionBaseline.test.ts
+++ b/src/__tests__/editorInteractionBaseline.test.ts
@@ -23,22 +23,25 @@ describe('editor-first interaction model', () => {
   });
 
   it('keeps navigation, selection, and mutation as visibly separate actions', () => {
-    const subnav = source('../components/ContextSubnav.tsx');
+    const navigation = source('../components/StudioWorkbenchNavigation.tsx');
     const product = source('../components/product/ProductStudio.tsx');
     const dashboard = source('../components/ProjectDashboard.tsx');
     const readiness = source('../components/ReadinessDashboard.tsx');
     const schematic = source('../components/schematic/EngineeringSchematicWorkbench.tsx');
     const pcb = source('../components/board/EngineeringBoardWorkbench.tsx');
 
-    expect(subnav).toContain('onClick={() => setActiveView(item.id)}');
-    expect(subnav).not.toContain('addBlockLibraryItemToProject');
-    expect(subnav).not.toContain('libraryItem');
+    expect(navigation).toContain('onClick={() => setActiveView(workbench.defaultView)}');
+    expect(navigation).toContain('onClick={() => setActiveView(item.id)}');
+    expect(navigation).not.toContain('addBlockLibraryItemToProject');
+    expect(navigation).not.toContain('libraryItem');
     expect(product).toContain('onClick={() => handleAddElement(preset)}');
     expect(product).toContain('aria-label={`Place ${preset.name}`}');
 
     expect(dashboard).toContain('onClick={() => setActiveView(nextAction.viewId)}');
     expect(dashboard).toContain('onClick={() => setActiveView(area.viewId)}');
-    expect(dashboard).toContain('Open an area only when that is the work you need.');
+    expect(dashboard).toContain('onClick={() => setActiveView(item.viewId)}');
+    expect(dashboard).toContain('Needs attention');
+    expect(dashboard).toContain('Evidence drives state; counts are inventory only.');
     expect(readiness).toContain('Evidence text is inert. Use the explicit Resolve button to change workspaces.');
     expect(readiness).toContain('Gate rows show state. Only Review changes the workspace.');
 

--- a/src/__tests__/projectHome.test.ts
+++ b/src/__tests__/projectHome.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 import type { Project } from '../types';
 import { buildProjectHomeModel } from '../lib/projectHome';
 
+type Requirement = NonNullable<Project['requirements']>[number];
+type ArchitectureNode = NonNullable<Project['architectureNodes']>[number];
+type BoardComponent = NonNullable<Project['boardComponents']>[number];
+type Revision = NonNullable<Project['revisions']>[number];
+
 function project(overrides: Partial<Project> = {}): Project {
   return {
     id: 'home-fixture',
@@ -64,7 +69,7 @@ describe('Project Home guidance', () => {
         linkedArchitectureNodeIds: [],
         linkedComponentIds: [],
         linkedTestIds: [],
-      }],
+      } as unknown as Requirement],
       architectureNodes: [{
         id: 'arch-1',
         name: 'Environmental sensing',
@@ -72,7 +77,7 @@ describe('Project Home guidance', () => {
         description: 'Measure ambient environment.',
         x: 0,
         y: 0,
-      }],
+      } as unknown as ArchitectureNode],
     }));
 
     expect(model.nextAction.viewId).toBe('component-library');
@@ -83,8 +88,8 @@ describe('Project Home guidance', () => {
 
   it('surfaces real Electronics blockers instead of treating component count as readiness', () => {
     const model = buildProjectHomeModel(project({
-      requirements: [{ id: 'req-1' } as Project['requirements'][number]],
-      architectureNodes: [{ id: 'arch-1' } as Project['architectureNodes'][number]],
+      requirements: [{ id: 'req-1' } as unknown as Requirement],
+      architectureNodes: [{ id: 'arch-1' } as unknown as ArchitectureNode],
       boardComponents: [{
         id: 'cmp-1',
         referenceDesignator: 'U1',
@@ -96,7 +101,7 @@ describe('Project Home guidance', () => {
         status: 'Draft',
         schematic: { placed: false, rotation: 0, locked: false },
         pcb: { placed: false, rotationDeg: 0, side: 'Top', locked: false, placementStatus: 'Unplaced' },
-      } as Project['boardComponents'][number]],
+      } as unknown as BoardComponent],
     }));
 
     expect(model.nextAction.viewId).toBe('component-library');
@@ -122,7 +127,7 @@ describe('Project Home guidance', () => {
         locked: false,
         visible: true,
       }],
-      revisions: [{ id: 'rev-1' } as Project['revisions'][number]],
+      revisions: [{ id: 'rev-1' } as unknown as Revision],
     }));
 
     expect(model.areas.find((area) => area.id === 'mechanical')?.state).toBe('In progress');

--- a/src/__tests__/projectHome.test.ts
+++ b/src/__tests__/projectHome.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import type { Project } from '../types';
+import { buildProjectHomeModel } from '../lib/projectHome';
+
+function project(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'home-fixture',
+    projectName: 'Home Fixture',
+    description: '',
+    createdAt: '2026-08-30T00:00:00.000Z',
+    updatedAt: '2026-08-30T00:00:00.000Z',
+    version: '1',
+    schemaVersion: 6,
+    activeView: 'dashboard',
+    nodes: [],
+    edges: [],
+    bom: [],
+    testing: [],
+    powerBudget: [],
+    pinMap: [],
+    firmwareTasks: [],
+    requirements: [],
+    architectureNodes: [],
+    architectureConnections: [],
+    boards: [],
+    boardComponents: [],
+    nets: [],
+    traces: [],
+    boardOutlines: [],
+    mechanicalObjects: [],
+    firmwareModules: [],
+    firmwareSourceFiles: [],
+    firmwareBuildRecords: [],
+    validationTests: [],
+    validationRuns: [],
+    revisions: [],
+    ...overrides,
+  } as Project;
+}
+
+describe('Project Home guidance', () => {
+  it('starts with measurable intent instead of exposing the rest of the product taxonomy', () => {
+    const model = buildProjectHomeModel(project());
+
+    expect(model.nextAction.viewId).toBe('requirements');
+    expect(model.nextAction.title).toContain('measurable requirement');
+    expect(model.attention[0]).toMatchObject({
+      id: 'requirements-missing',
+      viewId: 'requirements',
+    });
+    expect(model.areas.find((area) => area.id === 'define')?.state).toBe('Not started');
+  });
+
+  it('moves into Electronics only after requirements and architecture evidence exist', () => {
+    const model = buildProjectHomeModel(project({
+      requirements: [{
+        id: 'req-1',
+        title: 'Measure ambient temperature',
+        description: 'Report ambient temperature within the defined tolerance.',
+        type: 'Functional',
+        priority: 'Must Have',
+        status: 'Draft',
+        acceptanceCriteria: ['Temperature can be measured and reported.'],
+        linkedArchitectureNodeIds: [],
+        linkedComponentIds: [],
+        linkedTestIds: [],
+      }],
+      architectureNodes: [{
+        id: 'arch-1',
+        name: 'Environmental sensing',
+        category: 'Function',
+        description: 'Measure ambient environment.',
+        x: 0,
+        y: 0,
+      }],
+    }));
+
+    expect(model.nextAction.viewId).toBe('component-library');
+    expect(model.nextAction.title).toContain('component');
+    expect(model.areas.find((area) => area.id === 'define')?.state).toBe('Evidence present');
+    expect(model.areas.find((area) => area.id === 'electronics')?.state).toBe('Not started');
+  });
+
+  it('surfaces real Electronics blockers instead of treating component count as readiness', () => {
+    const model = buildProjectHomeModel(project({
+      requirements: [{ id: 'req-1' } as Project['requirements'][number]],
+      architectureNodes: [{ id: 'arch-1' } as Project['architectureNodes'][number]],
+      boardComponents: [{
+        id: 'cmp-1',
+        referenceDesignator: 'U1',
+        componentName: 'Controller',
+        libraryId: 'mcu',
+        pins: [],
+        boardId: '',
+        quantity: 1,
+        status: 'Draft',
+        schematic: { placed: false, rotation: 0, locked: false },
+        pcb: { placed: false, rotationDeg: 0, side: 'Top', locked: false, placementStatus: 'Unplaced' },
+      } as Project['boardComponents'][number]],
+    }));
+
+    expect(model.nextAction.viewId).toBe('component-library');
+    expect(model.nextAction.detail).toContain('footprint/package');
+    expect(model.areas.find((area) => area.id === 'electronics')?.state).toBe('In progress');
+    expect(model.attention.some((item) => item.detail.includes('footprint/package'))).toBe(true);
+  });
+
+  it('never calls one mechanical object or one revision ready for review', () => {
+    const model = buildProjectHomeModel(project({
+      mechanicalObjects: [{
+        id: 'body-1',
+        name: 'Envelope',
+        type: 'Outer Profile',
+        shape: 'rect',
+        layer: 'Enclosure',
+        xMm: 0,
+        yMm: 0,
+        widthMm: 20,
+        heightMm: 20,
+        depthMm: 8,
+        rotationDeg: 0,
+        locked: false,
+        visible: true,
+      }],
+      revisions: [{ id: 'rev-1' } as Project['revisions'][number]],
+    }));
+
+    expect(model.areas.find((area) => area.id === 'mechanical')?.state).toBe('In progress');
+    expect(model.areas.find((area) => area.id === 'release')?.state).toBe('In progress');
+    expect(model.areas.find((area) => area.id === 'release')?.evidence).toContain('explicit readiness review');
+  });
+
+  it('distinguishes validation definitions from actual run evidence', () => {
+    const model = buildProjectHomeModel(project({
+      validationTests: [{
+        id: 'test-1',
+        name: 'Temperature accuracy',
+        stage: 'EVT',
+        category: 'Requirement',
+        linkedRequirementIds: [],
+        linkedArchitectureNodeIds: [],
+        linkedComponentIds: [],
+        linkedNetIds: [],
+        linkedFirmwareModuleIds: [],
+        steps: [],
+        measurements: [],
+        passCriteria: [],
+        status: 'Not Started',
+        evidence: [],
+      }],
+    }));
+
+    expect(model.areas.find((area) => area.id === 'validation')?.state).toBe('In progress');
+    expect(model.areas.find((area) => area.id === 'validation')?.evidence).toContain('0 recorded runs');
+  });
+
+  it('does not mark a firmware module reviewable merely because the module exists', () => {
+    const model = buildProjectHomeModel(project({
+      firmwareModules: [{
+        id: 'fw-1',
+        name: 'Sensor driver',
+        type: 'Driver',
+        description: '',
+        linkedArchitectureNodeIds: [],
+        linkedComponentIds: [],
+        linkedPinIds: [],
+        linkedNetIds: [],
+        linkedTestIds: [],
+        dependencies: [],
+        sourceFiles: [],
+        status: 'Draft',
+      }],
+    }));
+
+    expect(model.areas.find((area) => area.id === 'firmware')?.state).toBe('In progress');
+    expect(model.areas.find((area) => area.id === 'firmware')?.evidence).toContain('0 reviewable');
+  });
+});

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -2,243 +2,168 @@
 
 import React from 'react';
 import {
+  AlertTriangle,
   ArrowRight,
   Binary,
   Box,
-  Boxes,
-  CheckCircle2,
   CircuitBoard,
   FileCheck2,
   Network,
   Package,
   TestTube2,
+  type LucideIcon,
 } from 'lucide-react';
+import { buildProjectHomeModel, type ProjectHomeArea } from '../lib/projectHome';
+import { storageHealthLabel } from '../lib/reliability';
 import { useProjectStore } from '../store/projectStore';
+import { useStorageHealthStore } from '../store/storageHealthStore';
 
-function count(value: unknown): number {
-  return Array.isArray(value) ? value.length : 0;
-}
-
-type ProjectSnapshot = {
-  requirements: number;
-  architecture: number;
-  components: number;
-  schematic: number;
-  nets: number;
-  boards: number;
-  traces: number;
-  mechanical: number;
-  firmware: number;
-  tests: number;
-  revisions: number;
+const areaIcons: Record<ProjectHomeArea['id'], LucideIcon> = {
+  define: Network,
+  electronics: CircuitBoard,
+  mechanical: Box,
+  firmware: Binary,
+  validation: TestTube2,
+  release: Package,
 };
 
-type LifecycleArea = {
-  id: string;
-  label: string;
-  description: string;
-  viewId: string;
-  evidence: string;
-  ready: boolean;
-  icon: React.ComponentType<{ className?: string; 'aria-hidden'?: React.AriaAttributes['aria-hidden'] }>;
-};
-
-function deriveSnapshot(project: Record<string, unknown>): ProjectSnapshot {
-  const editorLayouts = project.editorLayouts as Record<string, unknown> | undefined;
-  return {
-    requirements: count(project.requirements),
-    architecture: Math.max(count(project.architectureNodes), count(project.nodes)),
-    components: count(project.boardComponents),
-    schematic: count(project.schematicSymbols),
-    nets: count(project.nets),
-    boards: count(project.boards),
-    traces: count(project.traces),
-    mechanical: Math.max(count(project.mechanicalObjects), count(editorLayouts?.mechanical)),
-    firmware: Math.max(count(project.firmwareModules), count(project.firmwareTasks)),
-    tests: Math.max(count(project.validationTests), count(project.testing)),
-    revisions: count(project.revisions),
-  };
-}
-
-function deriveNextAction(snapshot: ProjectSnapshot) {
-  if (snapshot.requirements === 0) {
-    return { eyebrow: 'Start with intent', title: 'Write the first measurable requirement', detail: 'Define what the product must achieve before choosing parts or drawing geometry.', viewId: 'requirements', label: 'Define requirements' };
-  }
-  if (snapshot.architecture === 0) {
-    return { eyebrow: 'Define the system', title: 'Turn requirements into a simple product architecture', detail: 'Describe the major functions, devices, and interfaces that will satisfy the requirements.', viewId: 'product-architecture', label: 'Build architecture' };
-  }
-  if (snapshot.components === 0) {
-    return { eyebrow: 'Begin electronics', title: 'Choose the first canonical project component', detail: 'Select a real component definition once, then reuse the same identity in schematic, PCB, BOM, firmware, and validation.', viewId: 'component-library', label: 'Choose components' };
-  }
-  if (snapshot.schematic === 0 || snapshot.nets === 0) {
-    return { eyebrow: 'Connect electronics', title: 'Describe the electrical design in the schematic', detail: 'Place the existing project components and connect explicit pins and nets before physical board layout.', viewId: 'schematic-editor', label: 'Open schematic' };
-  }
-  if (snapshot.boards === 0 || snapshot.traces === 0) {
-    return { eyebrow: 'Make it physical', title: 'Define and lay out the PCB', detail: 'Create the real board context, place canonical footprints, route explicit nets, and review DRC in one PCB workspace.', viewId: 'board-designer', label: 'Open PCB' };
-  }
-  if (snapshot.mechanical === 0) {
-    return { eyebrow: 'Package the product', title: 'Create the first mechanical envelope', detail: 'Define enclosure and assembly intent around the real board instead of inventing a separate product model.', viewId: 'mechanical-studio', label: 'Open mechanical' };
-  }
-  if (snapshot.firmware === 0) {
-    return { eyebrow: 'Bring behavior to hardware', title: 'Map firmware responsibility to the product', detail: 'Define software behavior against the same canonical components, pins, and hardware context.', viewId: 'firmware-studio', label: 'Open firmware' };
-  }
-  if (snapshot.tests === 0) {
-    return { eyebrow: 'Prove the design', title: 'Create validation work linked to real requirements', detail: 'Plan tests and evidence against the exact product state rather than marking readiness manually.', viewId: 'validation-studio', label: 'Plan validation' };
-  }
-  if (snapshot.revisions === 0) {
-    return { eyebrow: 'Preserve the state', title: 'Capture a controlled engineering revision', detail: 'Record a meaningful project state before preparing outputs or release evidence.', viewId: 'revisions', label: 'Open revisions' };
-  }
-  return { eyebrow: 'Review before handoff', title: 'Inspect release readiness and unresolved evidence', detail: 'Use the release area to review blockers and supported outputs. Existing evidence—not a progress percentage—decides what can move forward.', viewId: 'readiness', label: 'Review readiness' };
+function stateTone(state: ProjectHomeArea['state']): string {
+  if (state === 'Ready for review') return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+  if (state === 'Evidence present') return 'border-slate-300 bg-slate-100 text-slate-700';
+  if (state === 'In progress') return 'border-amber-200 bg-amber-50 text-amber-800';
+  return 'border-slate-200 bg-white text-slate-500';
 }
 
 export const ProjectDashboard: React.FC = () => {
-  const store = useProjectStore();
-  const { projectName, description, setActiveView } = store;
-  const project = store as unknown as Record<string, unknown>;
-  const snapshot = deriveSnapshot(project);
-  const nextAction = deriveNextAction(snapshot);
-
-  const areas: LifecycleArea[] = [
-    {
-      id: 'define',
-      label: 'Define',
-      description: 'Requirements and architecture',
-      viewId: snapshot.requirements === 0 ? 'requirements' : 'product-architecture',
-      evidence: `${snapshot.requirements} requirements · ${snapshot.architecture} architecture items`,
-      ready: snapshot.requirements > 0 && snapshot.architecture > 0,
-      icon: Network,
-    },
-    {
-      id: 'electronics',
-      label: 'Electronics',
-      description: 'Components, schematic, PCB, BOM',
-      viewId: snapshot.components === 0 ? 'component-library' : snapshot.schematic === 0 || snapshot.nets === 0 ? 'schematic-editor' : 'board-designer',
-      evidence: `${snapshot.components} components · ${snapshot.nets} nets · ${snapshot.boards} boards`,
-      ready: snapshot.components > 0 && snapshot.schematic > 0 && snapshot.nets > 0 && snapshot.boards > 0,
-      icon: CircuitBoard,
-    },
-    {
-      id: 'mechanical',
-      label: 'Mechanical',
-      description: 'Envelope and assembly intent',
-      viewId: 'mechanical-studio',
-      evidence: `${snapshot.mechanical} mechanical objects`,
-      ready: snapshot.mechanical > 0,
-      icon: Box,
-    },
-    {
-      id: 'firmware',
-      label: 'Firmware',
-      description: 'Behavior, mapping, source',
-      viewId: 'firmware-studio',
-      evidence: `${snapshot.firmware} firmware items`,
-      ready: snapshot.firmware > 0,
-      icon: Binary,
-    },
-    {
-      id: 'validation',
-      label: 'Validate',
-      description: 'Tests, evidence, coverage',
-      viewId: 'validation-studio',
-      evidence: `${snapshot.tests} validation items`,
-      ready: snapshot.tests > 0,
-      icon: TestTube2,
-    },
-    {
-      id: 'release',
-      label: 'Release',
-      description: 'Readiness, outputs, revisions',
-      viewId: 'readiness',
-      evidence: `${snapshot.revisions} revisions`,
-      ready: snapshot.revisions > 0,
-      icon: Package,
-    },
-  ];
-
-  const completedAreas = areas.filter((area) => area.ready).length;
+  const project = useProjectStore();
+  const setActiveView = useProjectStore((state) => state.setActiveView);
+  const storageHealth = useStorageHealthStore((state) => state.health);
+  const model = buildProjectHomeModel(project);
+  const { nextAction, areas, attention, inventory } = model;
+  const storageNeedsAttention = ['failed', 'unavailable', 'memory-fallback'].includes(storageHealth.status);
 
   return (
     <div className="h-full overflow-y-auto bg-[#f7f5ef] px-4 py-5 text-slate-900 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
-        <header className="border-b border-[#d8d2c7] pb-5">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <header className="border-b border-[#d8d2c7] pb-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">Project home</p>
+          <div className="mt-1 flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
             <div className="min-w-0">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">Project</p>
-              <h1 className="mt-1 truncate text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl">{projectName}</h1>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">{description || 'Build one connected product from intent to reviewed release evidence.'}</p>
+              <h1 className="truncate text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl">{project.projectName}</h1>
+              <p className="mt-1 max-w-3xl text-[12px] leading-5 text-slate-500">
+                {project.description || 'One connected product from measurable intent to reviewed release evidence.'}
+              </p>
             </div>
-            <div className="flex shrink-0 items-center gap-2 text-[10px] text-slate-500">
-              <FileCheck2 className="h-4 w-4" aria-hidden="true" />
-              <span>{completedAreas}/{areas.length} lifecycle areas contain evidence</span>
+            <div className="flex shrink-0 items-center gap-1.5 text-[10px] text-slate-500">
+              <FileCheck2 className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>Evidence drives state; counts are inventory only.</span>
             </div>
           </div>
         </header>
 
-        <section className="mt-5 border border-[#d7d1c6] bg-white" aria-labelledby="next-action-title">
-          <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_220px]">
-            <div className="p-5 sm:p-6">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">{nextAction.eyebrow}</p>
-              <h2 id="next-action-title" className="mt-2 max-w-3xl text-xl font-semibold tracking-tight text-slate-950 sm:text-2xl">{nextAction.title}</h2>
-              <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600">{nextAction.detail}</p>
-              <button
-                type="button"
-                onClick={() => setActiveView(nextAction.viewId)}
-                className="mt-5 inline-flex min-h-10 items-center gap-2 bg-slate-950 px-4 text-sm font-semibold text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
-              >
-                {nextAction.label}<ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </button>
+        {storageNeedsAttention && (
+          <section className="mt-4 flex items-start gap-3 border border-amber-300 bg-amber-50 px-4 py-3" aria-label="Project storage warning">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" aria-hidden="true" />
+            <div className="min-w-0">
+              <p className="text-[11px] font-semibold text-amber-900">{storageHealthLabel(storageHealth)}</p>
+              <p className="mt-0.5 text-[10px] leading-4 text-amber-800">{[storageHealth.message, storageHealth.guidance].filter(Boolean).join(' ')}</p>
             </div>
-            <div className="border-t border-[#e2ddd3] bg-[#f4f1ea] p-5 lg:border-l lg:border-t-0">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">V1 rule</p>
-              <p className="mt-2 text-sm font-semibold leading-5 text-slate-900">One product. One identity. One path forward.</p>
-              <p className="mt-2 text-[11px] leading-5 text-slate-500">Supporting tools stay inside the workbench that owns the decision instead of becoming extra places to navigate.</p>
-            </div>
+          </section>
+        )}
+
+        <section className="mt-4 border border-[#d7d1c6] bg-white" aria-labelledby="next-action-title">
+          <div className="p-5 sm:p-6">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">{nextAction.eyebrow}</p>
+            <h2 id="next-action-title" className="mt-2 max-w-4xl text-xl font-semibold tracking-tight text-slate-950 sm:text-2xl">{nextAction.title}</h2>
+            <p className="mt-2 max-w-3xl text-[12px] leading-5 text-slate-600">{nextAction.detail}</p>
+            <button
+              type="button"
+              onClick={() => setActiveView(nextAction.viewId)}
+              className="mt-4 inline-flex min-h-9 items-center gap-2 bg-slate-950 px-3.5 text-[11px] font-semibold text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+            >
+              {nextAction.label}<ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
           </div>
         </section>
 
-        <section className="mt-5" aria-labelledby="lifecycle-title">
-          <div className="flex items-end justify-between gap-3">
-            <div>
-              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">Lifecycle</p>
-              <h2 id="lifecycle-title" className="mt-1 text-base font-semibold text-slate-950">The complete product path</h2>
+        <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(300px,0.75fr)]">
+          <section className="border border-[#d7d1c6] bg-white" aria-labelledby="lifecycle-title">
+            <div className="border-b border-[#e0dbd1] px-4 py-3">
+              <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Lifecycle</p>
+              <h2 id="lifecycle-title" className="mt-0.5 text-sm font-semibold text-slate-950">Product state</h2>
             </div>
-            <p className="hidden text-[10px] text-slate-400 sm:block">Open an area only when that is the work you need.</p>
-          </div>
-
-          <div className="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-            {areas.map((area) => {
-              const Icon = area.icon;
-              return (
-                <button
-                  key={area.id}
-                  type="button"
-                  onClick={() => setActiveView(area.viewId)}
-                  className="group flex min-h-[112px] items-start gap-3 border border-[#d7d1c6] bg-white p-4 text-left transition hover:border-slate-400 hover:bg-[#fbfaf6] focus:outline-none focus:ring-2 focus:ring-slate-400"
-                >
-                  <span className={`grid h-9 w-9 shrink-0 place-items-center border ${area.ready ? 'border-slate-950 bg-slate-950 text-white' : 'border-[#d7d1c6] bg-[#f4f1ea] text-slate-500'}`}>
-                    {area.ready ? <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> : <Icon className="h-4 w-4" aria-hidden="true" />}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="flex items-center justify-between gap-3">
-                      <span className="text-sm font-semibold text-slate-950">{area.label}</span>
-                      <ArrowRight className="h-3.5 w-3.5 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-slate-600" aria-hidden="true" />
+            <div className="divide-y divide-[#ece7de]">
+              {areas.map((area) => {
+                const Icon = areaIcons[area.id];
+                return (
+                  <button
+                    key={area.id}
+                    type="button"
+                    onClick={() => setActiveView(area.viewId)}
+                    className="group grid w-full grid-cols-[28px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left hover:bg-[#fbfaf6] focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400"
+                  >
+                    <span className="grid h-7 w-7 place-items-center border border-[#d7d1c6] bg-[#f7f5ef] text-slate-500">
+                      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
                     </span>
-                    <span className="mt-1 block text-[11px] leading-5 text-slate-500">{area.description}</span>
-                    <span className="mt-2 block text-[9px] font-medium text-slate-400">{area.evidence}</span>
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </section>
+                    <span className="min-w-0">
+                      <span className="flex flex-wrap items-center gap-2">
+                        <span className="text-[11px] font-semibold text-slate-950">{area.label}</span>
+                        <span className={`border px-1.5 py-0.5 text-[8px] font-semibold ${stateTone(area.state)}`}>{area.state}</span>
+                      </span>
+                      <span className="mt-0.5 block text-[9px] leading-4 text-slate-500">{area.description}</span>
+                      <span className="mt-0.5 block truncate text-[8px] text-slate-400">{area.evidence}</span>
+                    </span>
+                    <ArrowRight className="h-3.5 w-3.5 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-slate-600" aria-hidden="true" />
+                  </button>
+                );
+              })}
+            </div>
+          </section>
 
-        <section className="mt-5 border-t border-[#d8d2c7] pt-4" aria-label="Project inventory">
-          <div className="flex flex-wrap gap-x-5 gap-y-2 text-[10px] text-slate-500">
-            <span className="inline-flex items-center gap-1.5"><Boxes className="h-3.5 w-3.5" aria-hidden="true" /> {snapshot.components} components</span>
-            <span>{snapshot.nets} nets</span>
-            <span>{snapshot.traces} traces</span>
-            <span>{snapshot.tests} tests</span>
-            <span>{snapshot.revisions} revisions</span>
+          <section className="border border-[#d7d1c6] bg-white" aria-labelledby="attention-title">
+            <div className="border-b border-[#e0dbd1] px-4 py-3">
+              <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Review queue</p>
+              <h2 id="attention-title" className="mt-0.5 text-sm font-semibold text-slate-950">Needs attention</h2>
+            </div>
+            {attention.length > 0 ? (
+              <div className="divide-y divide-[#ece7de]">
+                {attention.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setActiveView(item.viewId)}
+                    className="group flex w-full items-start gap-2.5 px-4 py-3 text-left hover:bg-[#fbfaf6] focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400"
+                  >
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600" aria-hidden="true" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-[10px] font-semibold text-slate-900">{item.label}</span>
+                      <span className="mt-0.5 block text-[9px] leading-4 text-slate-500">{item.detail}</span>
+                    </span>
+                    <ArrowRight className="mt-0.5 h-3 w-3 shrink-0 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-slate-600" aria-hidden="true" />
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="px-4 py-5">
+                <p className="text-[11px] font-semibold text-slate-900">No immediate blocker surfaced here.</p>
+                <p className="mt-1 text-[9px] leading-4 text-slate-500">This is not a release approval. Use Validation and Release for explicit evidence and gate review.</p>
+              </div>
+            )}
+          </section>
+        </div>
+
+        <section className="mt-4 border-t border-[#d8d2c7] pt-3" aria-label="Project inventory">
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-[9px] text-slate-400">
+            <span>{inventory.requirements} requirements</span>
+            <span>{inventory.architecture} architecture items</span>
+            <span>{inventory.components} components</span>
+            <span>{inventory.nets} nets</span>
+            <span>{inventory.traces} traces</span>
+            <span>{inventory.mechanicalObjects} mechanical objects</span>
+            <span>{inventory.firmwareModules} firmware modules</span>
+            <span>{inventory.validationTests} tests</span>
+            <span>{inventory.validationRuns} runs</span>
+            <span>{inventory.revisions} revisions</span>
           </div>
         </section>
       </div>

--- a/src/lib/projectHome.ts
+++ b/src/lib/projectHome.ts
@@ -1,0 +1,278 @@
+import type { Project } from '../types';
+import { evaluateElectronicsWorkflow } from './electronics/electronicsWorkflow';
+import { evaluateFirmwareEvidence } from './firmware/firmwareEvidence';
+
+export type ProjectHomeAreaState = 'Not started' | 'In progress' | 'Evidence present' | 'Ready for review';
+
+export interface ProjectHomeAction {
+  eyebrow: string;
+  title: string;
+  detail: string;
+  viewId: string;
+  label: string;
+}
+
+export interface ProjectHomeArea {
+  id: 'define' | 'electronics' | 'mechanical' | 'firmware' | 'validation' | 'release';
+  label: string;
+  description: string;
+  viewId: string;
+  state: ProjectHomeAreaState;
+  evidence: string;
+}
+
+export interface ProjectHomeAttention {
+  id: string;
+  label: string;
+  detail: string;
+  viewId: string;
+}
+
+export interface ProjectHomeModel {
+  nextAction: ProjectHomeAction;
+  areas: ProjectHomeArea[];
+  attention: ProjectHomeAttention[];
+  inventory: {
+    requirements: number;
+    architecture: number;
+    components: number;
+    nets: number;
+    traces: number;
+    mechanicalObjects: number;
+    firmwareModules: number;
+    validationTests: number;
+    validationRuns: number;
+    revisions: number;
+  };
+}
+
+function count<T>(value: T[] | undefined): number {
+  return value?.length || 0;
+}
+
+function electronicsAction(project: Project): ProjectHomeAction {
+  const electronics = evaluateElectronicsWorkflow(project);
+  const byStage: Record<typeof electronics.nextStage, Pick<ProjectHomeAction, 'eyebrow' | 'title' | 'label'>> = {
+    'component-library': { eyebrow: 'Resolve component identity', title: 'Complete authoritative component data', label: 'Open components' },
+    'schematic-editor': { eyebrow: 'Connect the electronics', title: 'Complete schematic placement and connectivity', label: 'Open schematic' },
+    'board-settings': { eyebrow: 'Define the physical board', title: 'Create the real PCB boundary', label: 'Open board setup' },
+    'board-designer': { eyebrow: 'Place the physical design', title: 'Complete explicit PCB placement', label: 'Open PCB' },
+    'pcb-drc': { eyebrow: 'Review PCB evidence', title: 'Resolve blocking PCB findings', label: 'Open DRC' },
+    bom: { eyebrow: 'Finish electronics identity', title: 'Link every project component to the BOM', label: 'Open BOM' },
+  };
+  const copy = byStage[electronics.nextStage];
+  return {
+    ...copy,
+    detail: electronics.blockers[0] || 'Review the current Electronics evidence before planning downstream validation.',
+    viewId: electronics.nextStage,
+  };
+}
+
+export function buildProjectHomeModel(project: Project): ProjectHomeModel {
+  const requirements = count(project.requirements);
+  const architecture = Math.max(count(project.architectureNodes), count(project.nodes));
+  const components = count(project.boardComponents);
+  const nets = count(project.nets);
+  const traces = count(project.traces);
+  const mechanicalObjects = count(project.mechanicalObjects);
+  const firmwareModules = count(project.firmwareModules);
+  const validationTests = count(project.validationTests);
+  const validationRuns = count(project.validationRuns);
+  const revisions = count(project.revisions);
+  const electronics = evaluateElectronicsWorkflow(project);
+  const firmwareEvidence = evaluateFirmwareEvidence(project);
+
+  let nextAction: ProjectHomeAction;
+  if (requirements === 0) {
+    nextAction = {
+      eyebrow: 'Start with intent',
+      title: 'Write the first measurable requirement',
+      detail: 'Define what the product must achieve before choosing parts or drawing geometry.',
+      viewId: 'requirements',
+      label: 'Define requirements',
+    };
+  } else if (architecture === 0) {
+    nextAction = {
+      eyebrow: 'Define the system',
+      title: 'Turn requirements into a simple product architecture',
+      detail: 'Describe the major functions, devices, and interfaces that will satisfy the requirements.',
+      viewId: 'product-architecture',
+      label: 'Build architecture',
+    };
+  } else if (!electronics.readyForValidation) {
+    nextAction = electronicsAction(project);
+  } else if (mechanicalObjects === 0) {
+    nextAction = {
+      eyebrow: 'Package the product',
+      title: 'Create the first explicit mechanical design object',
+      detail: 'Define physical envelope and assembly intent around the real board. Missing geometry should remain unresolved rather than inferred.',
+      viewId: 'mechanical-studio',
+      label: 'Open mechanical',
+    };
+  } else if (firmwareModules === 0) {
+    nextAction = {
+      eyebrow: 'Bring behavior to hardware',
+      title: 'Define the first firmware responsibility',
+      detail: 'Create firmware modules against the same canonical component, pin, and net context used by the hardware design.',
+      viewId: 'firmware-studio',
+      label: 'Open firmware',
+    };
+  } else if (firmwareEvidence.verificationReadyModuleIds.length < firmwareModules) {
+    const firstBlockedModule = (project.firmwareModules || []).find(
+      (firmwareModule) => !firmwareEvidence.verificationReadyModuleIds.includes(firmwareModule.id),
+    );
+    const blocker = firstBlockedModule ? firmwareEvidence.blockersByModuleId[firstBlockedModule.id]?.[0] : undefined;
+    nextAction = {
+      eyebrow: 'Complete firmware evidence',
+      title: 'Connect firmware source, hardware mapping, build, and device evidence',
+      detail: blocker || 'At least one firmware module still lacks the evidence required for review.',
+      viewId: 'firmware-evidence',
+      label: 'Review firmware evidence',
+    };
+  } else if (validationTests === 0) {
+    nextAction = {
+      eyebrow: 'Prove the product',
+      title: 'Create validation work linked to real requirements',
+      detail: 'Author explicit procedures and evidence requirements instead of marking readiness manually.',
+      viewId: 'validation-studio',
+      label: 'Plan validation',
+    };
+  } else if (validationRuns === 0) {
+    nextAction = {
+      eyebrow: 'Capture validation evidence',
+      title: 'Record the first validation run',
+      detail: 'Test definitions alone are not evidence. Execute a supported check or record an explicit evidence-backed engineering verdict.',
+      viewId: 'validation-studio',
+      label: 'Open validation',
+    };
+  } else if (revisions === 0) {
+    nextAction = {
+      eyebrow: 'Preserve the engineering state',
+      title: 'Capture a controlled revision before handoff',
+      detail: 'Record a meaningful project state before preparing outputs or release evidence.',
+      viewId: 'revisions',
+      label: 'Open revisions',
+    };
+  } else {
+    nextAction = {
+      eyebrow: 'Review before handoff',
+      title: 'Inspect release readiness and unresolved evidence',
+      detail: 'Existing evidence—not a progress percentage—decides what can move forward.',
+      viewId: 'readiness',
+      label: 'Review readiness',
+    };
+  }
+
+  const areas: ProjectHomeArea[] = [
+    {
+      id: 'define',
+      label: 'Define',
+      description: 'Requirements and architecture',
+      viewId: requirements === 0 ? 'requirements' : 'product-architecture',
+      state: requirements === 0 ? 'Not started' : architecture === 0 ? 'In progress' : 'Evidence present',
+      evidence: `${requirements} requirements · ${architecture} architecture items`,
+    },
+    {
+      id: 'electronics',
+      label: 'Electronics',
+      description: 'Components, schematic, PCB, BOM',
+      viewId: electronics.readyForValidation ? 'board-designer' : electronics.nextStage,
+      state: components === 0 ? 'Not started' : electronics.readyForValidation ? 'Ready for review' : 'In progress',
+      evidence: `${components} components · ${electronics.schematicPlacedCount}/${components} schematic placed · ${electronics.pcbPlacedCount}/${components} PCB placed`,
+    },
+    {
+      id: 'mechanical',
+      label: 'Mechanical',
+      description: 'Physical design and assembly intent',
+      viewId: 'mechanical-studio',
+      state: mechanicalObjects === 0 ? 'Not started' : 'In progress',
+      evidence: `${mechanicalObjects} explicit mechanical objects`,
+    },
+    {
+      id: 'firmware',
+      label: 'Firmware',
+      description: 'Behavior, mapping, source, build, device evidence',
+      viewId: 'firmware-studio',
+      state: firmwareModules === 0
+        ? 'Not started'
+        : firmwareEvidence.verificationReadyModuleIds.length === firmwareModules
+          ? 'Ready for review'
+          : 'In progress',
+      evidence: `${firmwareModules} modules · ${firmwareEvidence.verificationReadyModuleIds.length} reviewable`,
+    },
+    {
+      id: 'validation',
+      label: 'Validate',
+      description: 'Test definitions, runs, and evidence',
+      viewId: 'validation-studio',
+      state: validationTests === 0 ? 'Not started' : validationRuns === 0 ? 'In progress' : 'Evidence present',
+      evidence: `${validationTests} tests · ${validationRuns} recorded runs`,
+    },
+    {
+      id: 'release',
+      label: 'Release',
+      description: 'Revisions, readiness, exact outputs, controlled handoff',
+      viewId: 'readiness',
+      state: revisions === 0 ? 'Not started' : 'In progress',
+      evidence: `${revisions} revisions · release status requires explicit readiness review`,
+    },
+  ];
+
+  const attention: ProjectHomeAttention[] = [];
+  const addAttention = (item: ProjectHomeAttention) => {
+    if (!attention.some((candidate) => candidate.id === item.id)) attention.push(item);
+  };
+
+  if (requirements === 0) {
+    addAttention({ id: 'requirements-missing', label: 'Product intent is not measurable yet', detail: 'Create at least one measurable requirement.', viewId: 'requirements' });
+  } else if (architecture === 0) {
+    addAttention({ id: 'architecture-missing', label: 'Requirements have no architecture yet', detail: 'Describe the functions, devices, and interfaces that satisfy the current requirements.', viewId: 'product-architecture' });
+  }
+
+  electronics.blockers.slice(0, 3).forEach((blocker, index) => {
+    addAttention({ id: `electronics-${index}`, label: 'Electronics needs attention', detail: blocker, viewId: electronics.nextStage });
+  });
+
+  if (electronics.readyForValidation && mechanicalObjects === 0) {
+    addAttention({ id: 'mechanical-missing', label: 'Physical design has not started', detail: 'Create explicit enclosure or assembly geometry around the real board.', viewId: 'mechanical-studio' });
+  }
+
+  if (firmwareModules > 0 && firmwareEvidence.verificationReadyModuleIds.length < firmwareModules) {
+    const firstBlockedModule = (project.firmwareModules || []).find(
+      (firmwareModule) => !firmwareEvidence.verificationReadyModuleIds.includes(firmwareModule.id),
+    );
+    const blocker = firstBlockedModule ? firmwareEvidence.blockersByModuleId[firstBlockedModule.id]?.[0] : undefined;
+    addAttention({
+      id: 'firmware-evidence',
+      label: 'Firmware evidence is incomplete',
+      detail: blocker || `${firmwareModules - firmwareEvidence.verificationReadyModuleIds.length} module(s) still need review evidence.`,
+      viewId: 'firmware-evidence',
+    });
+  }
+
+  if (firmwareModules > 0 && validationTests === 0) {
+    addAttention({ id: 'validation-missing', label: 'No validation plan exists', detail: 'Create validation work linked to the current engineering requirements and evidence.', viewId: 'validation-studio' });
+  }
+
+  if (validationTests > 0 && validationRuns === 0) {
+    addAttention({ id: 'validation-runs-missing', label: 'Validation definitions have no run evidence', detail: 'Execute a supported check or record an explicit evidence-backed engineering verdict.', viewId: 'validation-studio' });
+  }
+
+  return {
+    nextAction,
+    areas,
+    attention: attention.slice(0, 5),
+    inventory: {
+      requirements,
+      architecture,
+      components,
+      nets,
+      traces,
+      mechanicalObjects,
+      firmwareModules,
+      validationTests,
+      validationRuns,
+      revisions,
+    },
+  };
+}


### PR DESCRIPTION
Parent: #86
Execution authority: `docs/development/STUDIO_UX_CONVERGENCE_EXECUTION_PLAN.md`

## User problem

Project Home should answer three things immediately: where the project is, what blocks it, and what the next meaningful engineering action is. The previous dashboard still treated counts as a proxy for lifecycle readiness and presented the lifecycle as a grid of dashboard cards.

## Replaces

- count-driven `ready` booleans in Project Home;
- large lifecycle-card presentation;
- duplicated Electronics progression logic inside the dashboard;
- the implication that one mechanical object, one firmware module, one validation definition, or one revision proves readiness.

## New model

- `buildProjectHomeModel(project)` is a pure, testable Home guidance model;
- Electronics progression reuses `evaluateElectronicsWorkflow`;
- Firmware reviewability reuses `evaluateFirmwareEvidence`;
- counts are shown only as inventory/evidence summaries;
- lifecycle language is limited to `Not started`, `In progress`, `Evidence present`, and `Ready for review` where the domain can actually justify it;
- Home shows one recommended action, one compact lifecycle list, and up to five navigable attention items;
- validation test definitions are explicitly distinguished from recorded run evidence;
- Release never becomes ready merely because a revision exists.

## Truth boundary

This PR intentionally does not fabricate recent activity. Durable recent-change history belongs to the typed command/repository convergence work (#39/#38) and should be added only when a trustworthy event source exists.

## Tests

Adds direct model-level coverage for empty-project guidance, Define → Electronics transition, footprint/package blockers, mechanical/release non-readiness, validation definitions vs run evidence, and firmware modules without verification evidence.

## Completion gate

Do not merge until the exact PR head passes lint, typecheck, full tests, production build, and deployment verification. UI presence alone is not completion.