### PR TITLE
U1.2: Converge shared Inspector and diagnostics dock

### DIFF
--- a/src/__tests__/sharedInspectorDock.test.ts
+++ b/src/__tests__/sharedInspectorDock.test.ts
@@ -10,7 +10,8 @@ describe('shared Inspector and diagnostics dock contracts', () => {
     const shell = source('../components/editor/EngineeringEditorShell.tsx');
 
     expect(shell).toContain('export const EngineeringInspector');
-    expect(shell).toContain('data-editor-chrome="inspector"');
+    expect(shell).toContain('chromeId="inspector"');
+    expect(shell).toContain('data-editor-chrome={chromeId');
     expect(shell).toContain('export const EngineeringBottomDock');
     expect(shell).toContain('data-editor-chrome="bottom-dock"');
     expect(shell).toContain('closed docks cost no canvas space');

--- a/src/__tests__/sharedInspectorDock.test.ts
+++ b/src/__tests__/sharedInspectorDock.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('shared Inspector and diagnostics dock contracts', () => {
+  it('defines explicit shared Inspector and bottom-dock primitives in one editor-shell authority', () => {
+    const shell = source('../components/editor/EngineeringEditorShell.tsx');
+
+    expect(shell).toContain('export const EngineeringInspector');
+    expect(shell).toContain('data-editor-chrome="inspector"');
+    expect(shell).toContain('export const EngineeringBottomDock');
+    expect(shell).toContain('data-editor-chrome="bottom-dock"');
+    expect(shell).toContain('closed docks cost no canvas space');
+    expect(shell).toContain('export const EngineeringStatusBar');
+  });
+
+  it('keeps Schematic selection in Inspector and ERC in the Problems dock', () => {
+    const schematic = source('../components/schematic/EngineeringSchematicWorkbench.tsx');
+
+    expect(schematic).toContain('<EngineeringInspector');
+    expect(schematic).toContain('<EngineeringBottomDock');
+    expect(schematic).toContain('title="ERC findings"');
+    expect(schematic).toContain('label="Problems"');
+    expect(schematic).toContain('count={ercResults.length}');
+    expect(schematic).not.toContain('Selection & ERC');
+  });
+
+  it('keeps PCB selection/nets in Inspector and DRC in the Problems dock', () => {
+    const pcb = source('../components/board/EngineeringBoardWorkbench.tsx');
+
+    expect(pcb).toContain('<EngineeringInspector');
+    expect(pcb).toContain('<EngineeringBottomDock');
+    expect(pcb).toContain('title="PCB DRC"');
+    expect(pcb).toContain('label="Problems"');
+    expect(pcb).toContain("type InspectorTab = 'selection' | 'nets';");
+    expect(pcb).not.toContain("'drc', 'DRC'");
+    expect(pcb).toContain('setProblemsOpen(true)');
+  });
+
+  it('keeps Mechanical feature editing in Inspector and checks in the Problems dock', () => {
+    const mechanical = source('../components/mechanical/EngineeringMechanicalWorkbench.tsx');
+
+    expect(mechanical).toContain('<EngineeringInspector');
+    expect(mechanical).toContain('<EngineeringBottomDock');
+    expect(mechanical).toContain('title="Mechanical checks"');
+    expect(mechanical).toContain('label="Problems"');
+    expect(mechanical).toContain('Capture dimension & tolerance');
+  });
+
+  it('keeps panel visibility local to workbenches rather than canonical project state', () => {
+    const projectStore = source('../store/projectStore.ts');
+
+    expect(projectStore).not.toContain('problemsOpen');
+    expect(projectStore).not.toContain('inspectorOpen');
+    expect(projectStore).not.toContain('browserOpen');
+    expect(projectStore).not.toContain('bottomDockOpen');
+  });
+});

--- a/src/components/board/EngineeringBoardWorkbench.tsx
+++ b/src/components/board/EngineeringBoardWorkbench.tsx
@@ -6,6 +6,7 @@ import {
   ArrowRight,
   Boxes,
   CircuitBoard,
+  Circle,
   Eye,
   EyeOff,
   Layers,
@@ -16,7 +17,6 @@ import {
   PanelRight,
   RotateCw,
   Route,
-  Circle,
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore } from '../../store/studioContextStore';
@@ -27,13 +27,15 @@ import { getFootprint } from '../../lib/footprints';
 import { EditorDockButton } from '../editor/EditorDockButton';
 import {
   EditorToolButton,
+  EngineeringBottomDock,
   EngineeringDock,
   EngineeringEditorBar,
+  EngineeringInspector,
   EngineeringStatusBar,
 } from '../editor/EngineeringEditorShell';
 
 type BrowserTab = 'components' | 'layers';
-type InspectorTab = 'selection' | 'nets' | 'drc';
+type InspectorTab = 'selection' | 'nets';
 
 const ROUTING_LAYERS = [
   { id: 'top-copper', label: 'Top copper', routable: true },
@@ -53,9 +55,19 @@ function numericRuleValue(value?: string): number | null {
 export const EngineeringBoardWorkbench: React.FC = () => {
   const store = useProjectStore();
   const {
-    boards = [], boardOutlines = [], boardComponents = [], traces = [], vias = [], nets = [],
-    padNetAssignments = [], pcbRules = [], setActiveBoard, updatePCBPlacement,
-    updateBoardComponent, updateTrace, setActiveView,
+    boards = [],
+    boardOutlines = [],
+    boardComponents = [],
+    traces = [],
+    vias = [],
+    nets = [],
+    padNetAssignments = [],
+    pcbRules = [],
+    setActiveBoard,
+    updatePCBPlacement,
+    updateBoardComponent,
+    updateTrace,
+    setActiveView,
   } = store;
   const {
     activeBoardId: contextBoardId,
@@ -69,6 +81,7 @@ export const EngineeringBoardWorkbench: React.FC = () => {
 
   const initialBoardId = [contextBoardId, store.activeBoardId, boards[0]?.id]
     .find((candidate): candidate is string => Boolean(candidate && boards.some((board) => board.id === candidate))) || null;
+
   const [viewState, setViewState] = useState<BoardDesignerUIState>({
     ...DEFAULT_VIEW_STATE,
     activeBoardId: initialBoardId,
@@ -79,6 +92,7 @@ export const EngineeringBoardWorkbench: React.FC = () => {
   const [browserTab, setBrowserTab] = useState<BrowserTab>('components');
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [inspectorTab, setInspectorTab] = useState<InspectorTab>('selection');
+  const [problemsOpen, setProblemsOpen] = useState(false);
   const [drcResults, setDrcResults] = useState(() => runBoardDRC({ ...store, activeBoardId: initialBoardId || '' }));
 
   const activeBoard = boards.find((board) => board.id === viewState.activeBoardId) || null;
@@ -95,7 +109,10 @@ export const EngineeringBoardWorkbench: React.FC = () => {
   const selectedTrace = traces.find((trace) => trace.id === viewState.selectedTraceId) || null;
   const selectedVia = vias.find((via) => via.id === viewState.selectedViaId) || null;
   const netRows = nets.map((net) => {
-    const assignments = padNetAssignments.filter((assignment) => assignment.netName === net.netName && components.some((component) => component.id === assignment.componentId || component.referenceDesignator === assignment.componentId));
+    const assignments = padNetAssignments.filter(
+      (assignment) => assignment.netName === net.netName
+        && components.some((component) => component.id === assignment.componentId || component.referenceDesignator === assignment.componentId),
+    );
     const routed = boardTraces.filter((trace) => trace.netName === net.netName || trace.netId === net.id);
     return { ...net, padCount: assignments.length, traceCount: routed.length };
   });
@@ -111,7 +128,14 @@ export const EngineeringBoardWorkbench: React.FC = () => {
   }, [setActiveBoard, setActiveComponent, setActiveNet, setContextBoard]);
 
   const selectComponent = (componentId: string) => {
-    updateView({ selectedComponentId: componentId, selectedTraceId: null, selectedViaId: null, selectedDrillHoleId: null, selectedKeepoutId: null, activeTool: 'select' });
+    updateView({
+      selectedComponentId: componentId,
+      selectedTraceId: null,
+      selectedViaId: null,
+      selectedDrillHoleId: null,
+      selectedKeepoutId: null,
+      activeTool: 'select',
+    });
     setInspectorTab('selection');
     setInspectorOpen(true);
   };
@@ -119,8 +143,7 @@ export const EngineeringBoardWorkbench: React.FC = () => {
   const runDrc = () => {
     const results = runBoardDRC({ ...useProjectStore.getState(), activeBoardId: viewState.activeBoardId || '' });
     setDrcResults(results);
-    setInspectorTab('drc');
-    setInspectorOpen(true);
+    setProblemsOpen(true);
   };
 
   const rotateSelected = () => {
@@ -136,8 +159,19 @@ export const EngineeringBoardWorkbench: React.FC = () => {
   if (!activeBoard) {
     return (
       <section className="flex h-full min-h-0 flex-col bg-[#f7f5ef]">
-        <EngineeringEditorBar domain="Electronics" title="PCB Layout" meta="No board selected" actions={<button type="button" onClick={() => setActiveView('board-settings')} className="h-8 bg-slate-950 px-3 text-[10px] font-semibold text-white">Board settings</button>} />
-        <div className="grid min-h-0 flex-1 place-items-center bg-white p-6"><div className="max-w-lg text-center"><CircuitBoard className="mx-auto h-8 w-8 text-slate-300" /><h1 className="mt-3 text-base font-semibold text-slate-950">Create or select a board before layout</h1><p className="mt-1 text-xs leading-5 text-slate-500">PCB placement and routing require a real board identity. Hardware Studio will not invent one.</p></div></div>
+        <EngineeringEditorBar
+          domain="Electronics"
+          title="PCB Layout"
+          meta="No board selected"
+          actions={<button type="button" onClick={() => setActiveView('board-settings')} className="h-8 bg-slate-950 px-3 text-[10px] font-semibold text-white">Board settings</button>}
+        />
+        <div className="grid min-h-0 flex-1 place-items-center bg-white p-6">
+          <div className="max-w-lg text-center">
+            <CircuitBoard className="mx-auto h-8 w-8 text-slate-300" />
+            <h1 className="mt-3 text-base font-semibold text-slate-950">Create or select a board before layout</h1>
+            <p className="mt-1 text-xs leading-5 text-slate-500">PCB placement and routing require a real board identity. Hardware Studio will not invent one.</p>
+          </div>
+        </div>
       </section>
     );
   }
@@ -145,8 +179,19 @@ export const EngineeringBoardWorkbench: React.FC = () => {
   if (!outline) {
     return (
       <section className="flex h-full min-h-0 flex-col bg-[#f7f5ef]">
-        <EngineeringEditorBar domain="Electronics" title="PCB Layout" meta={`${activeBoard.name} · outline unresolved`} actions={<button type="button" onClick={() => setActiveView('board-settings')} className="h-8 bg-slate-950 px-3 text-[10px] font-semibold text-white">Define outline</button>} />
-        <div className="grid min-h-0 flex-1 place-items-center bg-white p-6"><div className="max-w-lg text-center"><CircuitBoard className="mx-auto h-8 w-8 text-slate-300" /><h1 className="mt-3 text-base font-semibold text-slate-950">Define the board outline first</h1><p className="mt-1 text-xs leading-5 text-slate-500">The editing canvas stays blocked until the board has explicit physical geometry. No hidden fallback is used as design truth.</p></div></div>
+        <EngineeringEditorBar
+          domain="Electronics"
+          title="PCB Layout"
+          meta={`${activeBoard.name} · outline unresolved`}
+          actions={<button type="button" onClick={() => setActiveView('board-settings')} className="h-8 bg-slate-950 px-3 text-[10px] font-semibold text-white">Define outline</button>}
+        />
+        <div className="grid min-h-0 flex-1 place-items-center bg-white p-6">
+          <div className="max-w-lg text-center">
+            <CircuitBoard className="mx-auto h-8 w-8 text-slate-300" />
+            <h1 className="mt-3 text-base font-semibold text-slate-950">Define the board outline first</h1>
+            <p className="mt-1 text-xs leading-5 text-slate-500">The editing canvas stays blocked until the board has explicit physical geometry. No hidden fallback is used as design truth.</p>
+          </div>
+        </div>
       </section>
     );
   }
@@ -159,32 +204,197 @@ export const EngineeringBoardWorkbench: React.FC = () => {
         domain="Electronics"
         title="PCB Layout"
         meta={`${activeBoard.name} · ${placed.length}/${components.length} placed · ${boardTraces.length} traces · ${hardDrcCount} DRC errors`}
-        tools={<>
-          <EditorToolButton label="Select" active={viewState.activeTool === 'select'} onClick={() => updateView({ activeTool: 'select', isRouting: false, routePreviewPoints: [] })}><MousePointer2 className="h-3.5 w-3.5" /></EditorToolButton>
-          <EditorToolButton label="Pan" active={viewState.activeTool === 'pan'} onClick={() => updateView({ activeTool: 'pan', isRouting: false, routePreviewPoints: [] })}><Move className="h-3.5 w-3.5" /></EditorToolButton>
-          <EditorToolButton label="Route" active={viewState.activeTool === 'route'} onClick={() => updateView({ activeTool: 'route' })}><Route className="h-3.5 w-3.5" /></EditorToolButton>
-          <EditorToolButton label="Via" active={viewState.activeTool === 'via'} disabled={!viewState.selectedNetName} onClick={() => updateView({ activeTool: 'via' })}><Circle className="h-3.5 w-3.5" /></EditorToolButton>
-          <EditorToolButton label="Rotate" disabled={!selectedComponent} onClick={rotateSelected}><RotateCw className="h-3.5 w-3.5" /></EditorToolButton>
-          <span className="mx-1 h-5 w-px bg-slate-200" />
-          <select value={viewState.gridSizeMm} onChange={(event) => updateView({ gridSizeMm: Number.parseFloat(event.target.value) })} className="h-7 border border-slate-300 bg-white px-1.5 font-mono text-[9px] text-slate-700" aria-label="PCB grid size">{GRID_PRESETS.map((grid) => <option key={grid} value={grid}>{grid} mm</option>)}</select>
-          <button type="button" onClick={() => updateView({ snapToGrid: !viewState.snapToGrid })} aria-pressed={viewState.snapToGrid} className={`inline-flex h-7 items-center gap-1 px-2 text-[9px] font-semibold ${viewState.snapToGrid ? 'bg-slate-950 text-white' : 'border border-slate-300 bg-white text-slate-600'}`}><Magnet className="h-3 w-3" /> Snap</button>
-        </>}
-        docks={<><EditorDockButton label="Browser" icon={Boxes} active={browserOpen} count={unplaced.length} onClick={() => setBrowserOpen((value) => !value)} /><EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} count={hardDrcCount} onClick={() => setInspectorOpen((value) => !value)} /></>}
-        actions={<><button type="button" onClick={runDrc} className="inline-flex h-8 items-center gap-1.5 border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100"><AlertTriangle className="h-3.5 w-3.5" /> DRC</button><button type="button" onClick={openSchematic} className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-2.5 text-[10px] font-semibold text-white hover:bg-slate-800">Schematic <ArrowRight className="h-3 w-3" /></button></>}
+        tools={(
+          <>
+            <EditorToolButton label="Select" active={viewState.activeTool === 'select'} onClick={() => updateView({ activeTool: 'select', isRouting: false, routePreviewPoints: [] })}><MousePointer2 className="h-3.5 w-3.5" /></EditorToolButton>
+            <EditorToolButton label="Pan" active={viewState.activeTool === 'pan'} onClick={() => updateView({ activeTool: 'pan', isRouting: false, routePreviewPoints: [] })}><Move className="h-3.5 w-3.5" /></EditorToolButton>
+            <EditorToolButton label="Route" active={viewState.activeTool === 'route'} onClick={() => updateView({ activeTool: 'route' })}><Route className="h-3.5 w-3.5" /></EditorToolButton>
+            <EditorToolButton label="Via" active={viewState.activeTool === 'via'} disabled={!viewState.selectedNetName} onClick={() => updateView({ activeTool: 'via' })}><Circle className="h-3.5 w-3.5" /></EditorToolButton>
+            <EditorToolButton label="Rotate" disabled={!selectedComponent} onClick={rotateSelected}><RotateCw className="h-3.5 w-3.5" /></EditorToolButton>
+            <span className="mx-1 h-5 w-px bg-slate-200" />
+            <select value={viewState.gridSizeMm} onChange={(event) => updateView({ gridSizeMm: Number.parseFloat(event.target.value) })} className="h-7 border border-slate-300 bg-white px-1.5 font-mono text-[9px] text-slate-700" aria-label="PCB grid size">
+              {GRID_PRESETS.map((grid) => <option key={grid} value={grid}>{grid} mm</option>)}
+            </select>
+            <button type="button" onClick={() => updateView({ snapToGrid: !viewState.snapToGrid })} aria-pressed={viewState.snapToGrid} className={`inline-flex h-7 items-center gap-1 px-2 text-[9px] font-semibold ${viewState.snapToGrid ? 'bg-slate-950 text-white' : 'border border-slate-300 bg-white text-slate-600'}`}><Magnet className="h-3 w-3" /> Snap</button>
+          </>
+        )}
+        docks={(
+          <>
+            <EditorDockButton label="Browser" icon={Boxes} active={browserOpen} count={unplaced.length} onClick={() => setBrowserOpen((value) => !value)} />
+            <EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} onClick={() => setInspectorOpen((value) => !value)} />
+            <EditorDockButton label="Problems" icon={AlertTriangle} active={problemsOpen} count={hardDrcCount} onClick={() => setProblemsOpen((value) => !value)} />
+          </>
+        )}
+        actions={(
+          <>
+            <button type="button" onClick={runDrc} className="inline-flex h-8 items-center gap-1.5 border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100"><AlertTriangle className="h-3.5 w-3.5" /> DRC</button>
+            <button type="button" onClick={openSchematic} className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-2.5 text-[10px] font-semibold text-white hover:bg-slate-800">Schematic <ArrowRight className="h-3 w-3" /></button>
+          </>
+        )}
       />
 
       <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
         <BoardCanvas viewState={viewState} onViewStateChange={updateView} drcResults={drcResults} />
 
-        {browserOpen && <EngineeringDock side="left" title="Design browser" subtitle="Components and routing layers" onClose={() => setBrowserOpen(false)} widthClassName="w-[300px]">
-          <div className="flex border-b border-slate-200 bg-white p-1"><button type="button" onClick={() => setBrowserTab('components')} className={`h-7 flex-1 text-[9px] font-semibold ${browserTab === 'components' ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100'}`}><Boxes className="mr-1 inline h-3 w-3" /> Components</button><button type="button" onClick={() => setBrowserTab('layers')} className={`h-7 flex-1 text-[9px] font-semibold ${browserTab === 'layers' ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100'}`}><Layers className="mr-1 inline h-3 w-3" /> Layers</button></div>
-          {browserTab === 'components' ? <div className="p-2"><p className="px-1 pb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Unplaced · {unplaced.length}</p><div className="space-y-1">{unplaced.map((component) => <div key={component.id} draggable onDragStart={(event) => { event.dataTransfer.setData('application/hardware-studio-component', component.id); selectComponent(component.id); }} className="flex cursor-grab items-center gap-2 border border-slate-200 bg-white px-2 py-1.5"><div className="min-w-0 flex-1"><p className="truncate text-[10px] font-semibold text-slate-900">{component.referenceDesignator} · {component.componentName}</p><p className="truncate font-mono text-[8px] text-slate-400">{component.footprint || 'footprint unresolved'}</p></div><span className="text-[8px] text-slate-400">drag to board</span></div>)}{unplaced.length === 0 && <p className="p-3 text-[10px] text-slate-400">All board components are placed.</p>}</div><p className="px-1 pb-1.5 pt-4 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Placed · {placed.length}</p><div className="space-y-0.5">{placed.map((component) => <button key={component.id} type="button" onClick={() => selectComponent(component.id)} className={`flex w-full items-center gap-2 px-2 py-1.5 text-left ${viewState.selectedComponentId === component.id ? 'bg-slate-950 text-white' : 'hover:bg-slate-100'}`}><span className="min-w-0 flex-1 truncate text-[10px] font-semibold">{component.referenceDesignator} · {component.componentName}</span><span className={`font-mono text-[8px] ${viewState.selectedComponentId === component.id ? 'text-white/60' : 'text-slate-400'}`}>{component.placementX?.toFixed(2)}, {component.placementY?.toFixed(2)}</span></button>)}</div></div> : <div className="p-2">{ROUTING_LAYERS.map((layer) => { const visible = viewState.layerVisibility[layer.id] !== false; const active = viewState.activeLayerId === layer.id; return <div key={layer.id} className={`flex min-h-9 items-center gap-2 px-1.5 ${active ? 'bg-slate-100' : ''}`}><button type="button" onClick={() => updateView({ layerVisibility: { ...viewState.layerVisibility, [layer.id]: !visible }, showRatsnest: layer.id === 'ratsnest' ? !visible : viewState.showRatsnest })} className="grid h-7 w-7 place-items-center text-slate-400 hover:text-slate-900">{visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}</button><button type="button" disabled={!layer.routable} onClick={() => updateView({ activeLayerId: layer.id })} className={`min-w-0 flex-1 truncate text-left text-[10px] ${active ? 'font-semibold text-slate-950' : layer.routable ? 'text-slate-600' : 'text-slate-400'}`}>{layer.label}</button></div>; })}<div className="mt-3 border-t border-slate-200 pt-3 text-[9px] leading-4 text-slate-500">Only copper layers can become the active routing layer. Other entries control visibility only.</div></div>}
-        </EngineeringDock>}
+        {browserOpen && (
+          <EngineeringDock side="left" title="Design browser" subtitle="Components and routing layers" onClose={() => setBrowserOpen(false)} widthClassName="w-[300px]">
+            <div className="flex border-b border-slate-200 bg-white p-1">
+              <button type="button" onClick={() => setBrowserTab('components')} className={`h-7 flex-1 text-[9px] font-semibold ${browserTab === 'components' ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100'}`}><Boxes className="mr-1 inline h-3 w-3" /> Components</button>
+              <button type="button" onClick={() => setBrowserTab('layers')} className={`h-7 flex-1 text-[9px] font-semibold ${browserTab === 'layers' ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100'}`}><Layers className="mr-1 inline h-3 w-3" /> Layers</button>
+            </div>
 
-        {inspectorOpen && <EngineeringDock side="right" title="Inspector" subtitle="Selection, nets and design rules" onClose={() => setInspectorOpen(false)} widthClassName="w-[320px]">
-          <div className="flex border-b border-slate-200 bg-white p-1">{([['selection', 'Selection', PanelRight], ['nets', 'Nets', Network], ['drc', 'DRC', AlertTriangle]] as const).map(([id, label, Icon]) => <button key={id} type="button" onClick={() => setInspectorTab(id)} className={`h-7 flex-1 text-[9px] font-semibold ${inspectorTab === id ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100'}`}><Icon className="mr-1 inline h-3 w-3" />{label}</button>)}</div>
-          {inspectorTab === 'selection' ? <div className="p-3">{selectedComponent ? <div className="space-y-3"><div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Footprint</p><p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedComponent.referenceDesignator} · {selectedComponent.componentName}</p><p className="mt-0.5 font-mono text-[9px] text-slate-500">{selectedComponent.footprint}</p></div><div className="grid grid-cols-2 gap-2"><label className="text-[9px] text-slate-500">X mm<input type="number" step={viewState.gridSizeMm} value={selectedComponent.placementX ?? ''} onChange={(event) => updatePCBPlacement(selectedComponent.id, { placementX: Number.parseFloat(event.target.value) })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label><label className="text-[9px] text-slate-500">Y mm<input type="number" step={viewState.gridSizeMm} value={selectedComponent.placementY ?? ''} onChange={(event) => updatePCBPlacement(selectedComponent.id, { placementY: Number.parseFloat(event.target.value) })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label></div><label className="block text-[9px] text-slate-500">Rotation<input type="number" value={selectedComponent.rotationDeg || 0} onChange={(event) => updatePCBPlacement(selectedComponent.id, { rotationDeg: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label><div className="grid grid-cols-2 gap-px border border-slate-200 bg-slate-200 text-[9px]">{[['Side', selectedComponent.side || 'Top'], ['Pads', String(getFootprint(selectedComponent.footprint).pads.length)], ['Criticality', selectedComponent.placementCriticality], ['Status', selectedComponent.placementStatus || 'Placed']].map(([label, value]) => <div key={label} className="bg-white p-2"><p className="text-slate-400">{label}</p><p className="mt-0.5 truncate font-semibold text-slate-800">{value}</p></div>)}</div><div className="flex gap-1"><button type="button" onClick={rotateSelected} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-700">Rotate 90°</button><button type="button" onClick={() => updateBoardComponent(selectedComponent.id, { side: selectedComponent.side === 'Bottom' ? 'Top' : 'Bottom' })} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-700">Flip side</button></div></div> : selectedTrace ? <div className="space-y-3"><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Trace</p><p className="text-[12px] font-semibold text-slate-950">{selectedTrace.netName || 'Unnamed net'}</p><label className="block text-[9px] text-slate-500">Width mm<input type="number" step="0.05" value={selectedTrace.width || 0.25} onChange={(event) => updateTrace(selectedTrace.id, { width: Number.parseFloat(event.target.value) || 0.25 })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label><p className="text-[9px] text-slate-500">{selectedTrace.layerId || 'top-copper'} · {selectedTrace.points?.length || 0} vertices · {selectedTrace.status || 'Draft'}</p></div> : selectedVia ? <div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Via</p><p className="mt-1 font-mono text-[10px] text-slate-700">{selectedVia.x?.toFixed(2)}, {selectedVia.y?.toFixed(2)} mm</p><p className="mt-2 text-[9px] text-slate-500">Ø {selectedVia.outerDiameter || 0.6} / drill {selectedVia.drillDiameter || 0.3} mm</p></div> : <p className="text-[10px] leading-5 text-slate-500">Select a footprint, trace, or via. The inspector edits that object without changing workspaces.</p>}</div> : inspectorTab === 'nets' ? <div className="p-2"><p className="px-1 pb-1.5 text-[9px] text-slate-500">Choose a net to arm routing. A route still starts from a real pad, via, or trace endpoint.</p><div className="space-y-0.5">{netRows.map((net) => <button key={net.id} type="button" onClick={() => { updateView({ selectedNetName: net.netName, activeTool: 'route' }); setInspectorOpen(false); }} className={`flex w-full items-center gap-2 px-2 py-1.5 text-left ${viewState.selectedNetName === net.netName ? 'bg-slate-950 text-white' : 'hover:bg-slate-100'}`}><span className="min-w-0 flex-1 truncate text-[10px] font-semibold">{net.netName}</span><span className={`font-mono text-[8px] ${viewState.selectedNetName === net.netName ? 'text-white/60' : 'text-slate-400'}`}>{net.padCount} pads · {net.traceCount} traces</span></button>)}</div></div> : <div className="p-2"><div className="mb-2 flex items-center justify-between px-1"><span className="text-[9px] text-slate-500">Current board findings</span><button type="button" onClick={runDrc} className="h-7 border border-slate-300 bg-white px-2 text-[9px] font-semibold text-slate-700">Run again</button></div><div className="space-y-1">{drcResults.map((result) => <button key={result.id} type="button" onClick={() => { if (result.linkedObjectType === 'component') selectComponent(result.linkedObjectId); }} className="w-full border-l-2 border-amber-500 bg-amber-50 px-2 py-1.5 text-left"><p className="text-[9px] font-semibold text-amber-950">{result.severity} · {result.title}</p><p className="mt-0.5 text-[9px] leading-4 text-amber-800">{result.description}</p></button>)}{drcResults.length === 0 && <p className="p-3 text-[9px] text-emerald-700">No current DRC findings.</p>}</div></div>}
-        </EngineeringDock>}
+            {browserTab === 'components' ? (
+              <div className="p-2">
+                <p className="px-1 pb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Unplaced · {unplaced.length}</p>
+                <div className="space-y-1">
+                  {unplaced.map((component) => (
+                    <div
+                      key={component.id}
+                      draggable
+                      onDragStart={(event) => {
+                        event.dataTransfer.setData('application/hardware-studio-component', component.id);
+                        selectComponent(component.id);
+                      }}
+                      className="flex cursor-grab items-center gap-2 border border-slate-200 bg-white px-2 py-1.5"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-[10px] font-semibold text-slate-900">{component.referenceDesignator} · {component.componentName}</p>
+                        <p className="truncate font-mono text-[8px] text-slate-400">{component.footprint || 'footprint unresolved'}</p>
+                      </div>
+                      <span className="text-[8px] text-slate-400">drag to board</span>
+                    </div>
+                  ))}
+                  {unplaced.length === 0 && <p className="p-3 text-[10px] text-slate-400">All board components are placed.</p>}
+                </div>
+                <p className="px-1 pb-1.5 pt-4 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Placed · {placed.length}</p>
+                <div className="space-y-0.5">
+                  {placed.map((component) => (
+                    <button key={component.id} type="button" onClick={() => selectComponent(component.id)} className={`flex w-full items-center gap-2 px-2 py-1.5 text-left ${viewState.selectedComponentId === component.id ? 'bg-slate-950 text-white' : 'hover:bg-slate-100'}`}>
+                      <span className="min-w-0 flex-1 truncate text-[10px] font-semibold">{component.referenceDesignator} · {component.componentName}</span>
+                      <span className={`font-mono text-[8px] ${viewState.selectedComponentId === component.id ? 'text-white/60' : 'text-slate-400'}`}>{component.placementX?.toFixed(2)}, {component.placementY?.toFixed(2)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="p-2">
+                {ROUTING_LAYERS.map((layer) => {
+                  const visible = viewState.layerVisibility[layer.id] !== false;
+                  const active = viewState.activeLayerId === layer.id;
+                  return (
+                    <div key={layer.id} className={`flex min-h-9 items-center gap-2 px-1.5 ${active ? 'bg-slate-100' : ''}`}>
+                      <button
+                        type="button"
+                        onClick={() => updateView({
+                          layerVisibility: { ...viewState.layerVisibility, [layer.id]: !visible },
+                          showRatsnest: layer.id === 'ratsnest' ? !visible : viewState.showRatsnest,
+                        })}
+                        className="grid h-7 w-7 place-items-center text-slate-400 hover:text-slate-900"
+                      >
+                        {visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+                      </button>
+                      <button type="button" disabled={!layer.routable} onClick={() => updateView({ activeLayerId: layer.id })} className={`min-w-0 flex-1 truncate text-left text-[10px] ${active ? 'font-semibold text-slate-950' : layer.routable ? 'text-slate-600' : 'text-slate-400'}`}>{layer.label}</button>
+                    </div>
+                  );
+                })}
+                <div className="mt-3 border-t border-slate-200 pt-3 text-[9px] leading-4 text-slate-500">Only copper layers can become the active routing layer. Other entries control visibility only.</div>
+              </div>
+            )}
+          </EngineeringDock>
+        )}
+
+        <EngineeringInspector open={inspectorOpen} subtitle="Selection and nets" onClose={() => setInspectorOpen(false)} widthClassName="w-[320px]">
+          <div className="flex border-b border-slate-200 bg-white p-1">
+            {([['selection', 'Selection', PanelRight], ['nets', 'Nets', Network]] as const).map(([id, label, Icon]) => (
+              <button key={id} type="button" onClick={() => setInspectorTab(id)} className={`h-7 flex-1 text-[9px] font-semibold ${inspectorTab === id ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100'}`}><Icon className="mr-1 inline h-3 w-3" />{label}</button>
+            ))}
+          </div>
+
+          {inspectorTab === 'selection' ? (
+            <div className="p-3">
+              {selectedComponent ? (
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Footprint</p>
+                    <p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedComponent.referenceDesignator} · {selectedComponent.componentName}</p>
+                    <p className="mt-0.5 font-mono text-[9px] text-slate-500">{selectedComponent.footprint}</p>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <label className="text-[9px] text-slate-500">X mm<input type="number" step={viewState.gridSizeMm} value={selectedComponent.placementX ?? ''} onChange={(event) => updatePCBPlacement(selectedComponent.id, { placementX: Number.parseFloat(event.target.value) })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label>
+                    <label className="text-[9px] text-slate-500">Y mm<input type="number" step={viewState.gridSizeMm} value={selectedComponent.placementY ?? ''} onChange={(event) => updatePCBPlacement(selectedComponent.id, { placementY: Number.parseFloat(event.target.value) })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label>
+                  </div>
+                  <label className="block text-[9px] text-slate-500">Rotation<input type="number" value={selectedComponent.rotationDeg || 0} onChange={(event) => updatePCBPlacement(selectedComponent.id, { rotationDeg: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label>
+                  <div className="grid grid-cols-2 gap-px border border-slate-200 bg-slate-200 text-[9px]">
+                    {[
+                      ['Side', selectedComponent.side || 'Top'],
+                      ['Pads', String(getFootprint(selectedComponent.footprint).pads.length)],
+                      ['Criticality', selectedComponent.placementCriticality],
+                      ['Status', selectedComponent.placementStatus || 'Placed'],
+                    ].map(([label, value]) => <div key={label} className="bg-white p-2"><p className="text-slate-400">{label}</p><p className="mt-0.5 truncate font-semibold text-slate-800">{value}</p></div>)}
+                  </div>
+                  <div className="flex gap-1">
+                    <button type="button" onClick={rotateSelected} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-700">Rotate 90°</button>
+                    <button type="button" onClick={() => updateBoardComponent(selectedComponent.id, { side: selectedComponent.side === 'Bottom' ? 'Top' : 'Bottom' })} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-700">Flip side</button>
+                  </div>
+                </div>
+              ) : selectedTrace ? (
+                <div className="space-y-3">
+                  <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Trace</p>
+                  <p className="text-[12px] font-semibold text-slate-950">{selectedTrace.netName || 'Unnamed net'}</p>
+                  <label className="block text-[9px] text-slate-500">Width mm<input type="number" step="0.05" value={selectedTrace.width || 0.25} onChange={(event) => updateTrace(selectedTrace.id, { width: Number.parseFloat(event.target.value) || 0.25 })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label>
+                  <p className="text-[9px] text-slate-500">{selectedTrace.layerId || 'top-copper'} · {selectedTrace.points?.length || 0} vertices · {selectedTrace.status || 'Draft'}</p>
+                </div>
+              ) : selectedVia ? (
+                <div>
+                  <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Via</p>
+                  <p className="mt-1 font-mono text-[10px] text-slate-700">{selectedVia.x?.toFixed(2)}, {selectedVia.y?.toFixed(2)} mm</p>
+                  <p className="mt-2 text-[9px] text-slate-500">Ø {selectedVia.outerDiameter || 0.6} / drill {selectedVia.drillDiameter || 0.3} mm</p>
+                </div>
+              ) : (
+                <p className="text-[10px] leading-5 text-slate-500">Select a footprint, trace, or via. The Inspector edits that object without changing workspaces.</p>
+              )}
+            </div>
+          ) : (
+            <div className="p-2">
+              <p className="px-1 pb-1.5 text-[9px] text-slate-500">Choose a net to arm routing. A route still starts from a real pad, via, or trace endpoint.</p>
+              <div className="space-y-0.5">
+                {netRows.map((net) => (
+                  <button key={net.id} type="button" onClick={() => { updateView({ selectedNetName: net.netName, activeTool: 'route' }); setInspectorOpen(false); }} className={`flex w-full items-center gap-2 px-2 py-1.5 text-left ${viewState.selectedNetName === net.netName ? 'bg-slate-950 text-white' : 'hover:bg-slate-100'}`}>
+                    <span className="min-w-0 flex-1 truncate text-[10px] font-semibold">{net.netName}</span>
+                    <span className={`font-mono text-[8px] ${viewState.selectedNetName === net.netName ? 'text-white/60' : 'text-slate-400'}`}>{net.padCount} pads · {net.traceCount} traces</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </EngineeringInspector>
+
+        <EngineeringBottomDock
+          open={problemsOpen}
+          title="PCB DRC"
+          subtitle={`${hardDrcCount} blocking · ${drcResults.length} total current findings`}
+          onClose={() => setProblemsOpen(false)}
+          actions={<button type="button" onClick={runDrc} className="h-7 border border-slate-300 bg-white px-2 text-[9px] font-semibold text-slate-700">Run again</button>}
+          heightClassName="h-[196px]"
+        >
+          <div className="grid gap-1 p-2 sm:grid-cols-2 xl:grid-cols-3">
+            {drcResults.map((result) => (
+              <button
+                key={result.id}
+                type="button"
+                onClick={() => {
+                  if (result.linkedObjectType === 'component') selectComponent(result.linkedObjectId);
+                  if (result.linkedObjectType === 'net') setActiveNet(result.linkedObjectId);
+                }}
+                className="border-l-2 border-amber-500 bg-amber-50 px-2 py-1.5 text-left"
+              >
+                <p className="text-[9px] font-semibold text-amber-950">{result.severity} · {result.title}</p>
+                <p className="mt-0.5 text-[9px] leading-4 text-amber-800">{result.description}</p>
+              </button>
+            ))}
+            {drcResults.length === 0 && <p className="p-3 text-[9px] text-emerald-700">No current DRC findings.</p>}
+          </div>
+        </EngineeringBottomDock>
       </div>
 
       <EngineeringStatusBar

--- a/src/components/editor/EngineeringEditorShell.tsx
+++ b/src/components/editor/EngineeringEditorShell.tsx
@@ -62,6 +62,7 @@ interface EngineeringDockProps {
   onClose: () => void;
   widthClassName?: string;
   children: React.ReactNode;
+  chromeId?: string;
 }
 
 export const EngineeringDock: React.FC<EngineeringDockProps> = ({
@@ -71,10 +72,11 @@ export const EngineeringDock: React.FC<EngineeringDockProps> = ({
   onClose,
   widthClassName = 'w-[292px]',
   children,
+  chromeId,
 }) => (
   <aside
     className={`absolute bottom-0 top-0 z-30 flex ${widthClassName} flex-col overflow-hidden bg-[#fbfaf6] shadow-[0_12px_32px_rgba(17,17,15,0.10)] ${side === 'left' ? 'left-0 border-r border-[#c9c5bb]' : 'right-0 border-l border-[#c9c5bb]'}`}
-    data-editor-chrome={`${side}-dock`}
+    data-editor-chrome={chromeId || `${side}-dock`}
   >
     <div className="flex min-h-11 shrink-0 items-center justify-between gap-2 border-b border-[#d8d4ca] bg-[#f0eee7] px-3">
       <div className="min-w-0">
@@ -88,6 +90,85 @@ export const EngineeringDock: React.FC<EngineeringDockProps> = ({
     <div className="min-h-0 flex-1 overflow-auto">{children}</div>
   </aside>
 );
+
+interface EngineeringInspectorProps {
+  open: boolean;
+  subtitle?: string;
+  onClose: () => void;
+  widthClassName?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared right-side selection surface. The workbench owns whether it is open and
+ * what the current canonical selection means; the Inspector owns only framing.
+ */
+export const EngineeringInspector: React.FC<EngineeringInspectorProps> = ({
+  open,
+  subtitle,
+  onClose,
+  widthClassName = 'w-[320px]',
+  children,
+}) => {
+  if (!open) return null;
+  return (
+    <EngineeringDock
+      side="right"
+      title="Inspector"
+      subtitle={subtitle}
+      onClose={onClose}
+      widthClassName={widthClassName}
+      chromeId="inspector"
+    >
+      {children}
+    </EngineeringDock>
+  );
+};
+
+interface EngineeringBottomDockProps {
+  open: boolean;
+  title: string;
+  subtitle?: string;
+  onClose: () => void;
+  actions?: React.ReactNode;
+  heightClassName?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared diagnostics/execution surface. It intentionally overlays the lower editor
+ * region so closed docks cost no canvas space and no empty global panel is shown.
+ */
+export const EngineeringBottomDock: React.FC<EngineeringBottomDockProps> = ({
+  open,
+  title,
+  subtitle,
+  onClose,
+  actions,
+  heightClassName = 'h-[184px]',
+  children,
+}) => {
+  if (!open) return null;
+  return (
+    <section
+      className={`absolute inset-x-0 bottom-0 z-40 flex ${heightClassName} flex-col overflow-hidden border-t border-[#c9c5bb] bg-[#fbfaf6] shadow-[0_-12px_28px_rgba(17,17,15,0.08)]`}
+      data-editor-chrome="bottom-dock"
+      aria-label={title}
+    >
+      <div className="flex min-h-10 shrink-0 items-center gap-3 border-b border-[#d8d4ca] bg-[#f0eee7] px-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-[10px] font-semibold tracking-[-0.01em] text-slate-950">{title}</p>
+          {subtitle && <p className="mt-0.5 truncate text-[8px] leading-3 text-slate-500">{subtitle}</p>}
+        </div>
+        {actions && <div className="flex shrink-0 items-center gap-1">{actions}</div>}
+        <button type="button" onClick={onClose} className="grid h-7 w-7 shrink-0 place-items-center text-slate-500 hover:bg-[#dedbd2] hover:text-slate-950 focus:outline-none focus:ring-2 focus:ring-slate-400" aria-label={`Close ${title}`}>
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+    </section>
+  );
+};
 
 export const EditorToolButton: React.FC<{
   label: string;

--- a/src/components/mechanical/EngineeringMechanicalWorkbench.tsx
+++ b/src/components/mechanical/EngineeringMechanicalWorkbench.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 import {
+  AlertTriangle,
   Box,
   Boxes,
   Eye,
@@ -23,8 +24,10 @@ import { validateMechanicalLayout } from '../../lib/mechanical/mechanicalValidat
 import { EditorDockButton } from '../editor/EditorDockButton';
 import {
   EditorToolButton,
+  EngineeringBottomDock,
   EngineeringDock,
   EngineeringEditorBar,
+  EngineeringInspector,
   EngineeringStatusBar,
 } from '../editor/EngineeringEditorShell';
 import { EngineeringMechanicalCanvas, type MechanicalCanvasView } from './EngineeringMechanicalCanvas';
@@ -73,6 +76,7 @@ export const EngineeringMechanicalWorkbench: React.FC<Props> = ({ initialMode })
   const [selectedObjectId, setSelectedObjectId] = useState<string | null>(objects[0]?.id || null);
   const [browserOpen, setBrowserOpen] = useState(true);
   const [inspectorOpen, setInspectorOpen] = useState(false);
+  const [problemsOpen, setProblemsOpen] = useState(false);
   const [panMode, setPanMode] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [view, setView] = useState<MechanicalCanvasView>({ offsetX: 70, offsetY: 70, scale: 6, mouseXmm: 0, mouseYmm: 0 });
@@ -170,7 +174,9 @@ export const EngineeringMechanicalWorkbench: React.FC<Props> = ({ initialMode })
     const context = evaluateMechanicalBoardContext(current, preferredBoardId);
     if (!envelope || !context.boardId) return;
     current.executeProjectCommand('SYNC_BOARD_ENVELOPE', 'Sync PCB outline into mechanical workspace', () => {
-      const existing = (useProjectStore.getState().mechanicalObjects || []).find((object) => object.type === 'Board Zone' && object.linkedBoardId === context.boardId);
+      const existing = (useProjectStore.getState().mechanicalObjects || []).find(
+        (object) => object.type === 'Board Zone' && object.linkedBoardId === context.boardId,
+      );
       if (existing) useProjectStore.getState().updateMechanicalObject(existing.id, envelope);
       else useProjectStore.getState().addMechanicalObject(envelope);
     });
@@ -183,12 +189,48 @@ export const EngineeringMechanicalWorkbench: React.FC<Props> = ({ initialMode })
           domain="Mechanical"
           title="Assembly"
           meta={`${orderedLayers.length} physical layers · ${boardContext.boardName || 'no PCB context'}`}
-          actions={<button type="button" onClick={() => store.addAssemblyLayer({ name: `Layer ${orderedLayers.length + 1}`, order: orderedLayers.length + 1, layerType: 'Casing', material: '', fasteningMethod: 'Screw Thread', inspectionNote: '', notes: '' })} className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-2.5 text-[10px] font-semibold text-white"><Plus className="h-3.5 w-3.5" /> Add layer</button>}
+          actions={(
+            <button
+              type="button"
+              onClick={() => store.addAssemblyLayer({
+                name: `Layer ${orderedLayers.length + 1}`,
+                order: orderedLayers.length + 1,
+                layerType: 'Casing',
+                material: '',
+                fasteningMethod: 'Screw Thread',
+                inspectionNote: '',
+                notes: '',
+              })}
+              className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-2.5 text-[10px] font-semibold text-white"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add layer
+            </button>
+          )}
         />
         <div className="min-h-0 flex-1 overflow-auto bg-white">
-          <div className="sticky top-0 z-10 grid min-w-[760px] grid-cols-[3rem_minmax(12rem,1.3fr)_10rem_11rem_minmax(14rem,1fr)_4rem] border-b border-slate-300 bg-[#f1efe8] px-3 py-2 text-[9px] font-semibold uppercase tracking-[0.1em] text-slate-500"><span>#</span><span>Layer / inspection</span><span>Material</span><span>Fastening</span><span>Notes</span><span /></div>
-          {orderedLayers.map((layer, index) => <div key={layer.id} className="grid min-w-[760px] grid-cols-[3rem_minmax(12rem,1.3fr)_10rem_11rem_minmax(14rem,1fr)_4rem] items-center border-b border-slate-100 px-3 py-2 text-[10px]"><span className="font-mono text-slate-400">{String(index + 1).padStart(2, '0')}</span><div className="pr-2"><input value={layer.name} onChange={(event) => store.updateAssemblyLayer(layer.id, { name: event.target.value })} className="h-7 w-full border-0 bg-transparent px-1 font-semibold text-slate-900 outline-none focus:bg-slate-50" /><input value={layer.inspectionNote} onChange={(event) => store.updateAssemblyLayer(layer.id, { inspectionNote: event.target.value })} placeholder="Inspection criterion" className="h-6 w-full border-0 bg-transparent px-1 text-[9px] text-slate-500 outline-none focus:bg-slate-50" /></div><input value={layer.material} onChange={(event) => store.updateAssemblyLayer(layer.id, { material: event.target.value })} placeholder="Unresolved" className="h-8 border border-slate-300 bg-white px-2 text-[10px]" /><select value={layer.fasteningMethod} onChange={(event) => store.updateAssemblyLayer(layer.id, { fasteningMethod: event.target.value })} className="h-8 border border-slate-300 bg-white px-2 text-[10px]">{['Screw Thread', 'Snap Fit', 'Adhesive', 'Press Fit', 'Gasket', 'Welded', 'Soldered'].map((method) => <option key={method}>{method}</option>)}</select><input value={layer.notes || ''} onChange={(event) => store.updateAssemblyLayer(layer.id, { notes: event.target.value })} placeholder="Thickness, finish, process…" className="h-8 border border-slate-300 bg-white px-2 text-[10px]" /><button type="button" onClick={() => store.deleteAssemblyLayer(layer.id)} className="grid h-8 w-8 place-items-center text-red-600 hover:bg-red-50"><Trash2 className="h-3.5 w-3.5" /></button></div>)}
-          {orderedLayers.length === 0 && <div className="grid min-h-[22rem] place-items-center text-center"><div><Boxes className="mx-auto h-7 w-7 text-slate-300" /><p className="mt-2 text-xs font-semibold text-slate-800">No assembly layers</p><p className="mt-1 text-[10px] text-slate-500">Add physical parts/layers only when their material and fastening intent is known.</p></div></div>}
+          <div className="sticky top-0 z-10 grid min-w-[760px] grid-cols-[3rem_minmax(12rem,1.3fr)_10rem_11rem_minmax(14rem,1fr)_4rem] border-b border-slate-300 bg-[#f1efe8] px-3 py-2 text-[9px] font-semibold uppercase tracking-[0.1em] text-slate-500">
+            <span>#</span><span>Layer / inspection</span><span>Material</span><span>Fastening</span><span>Notes</span><span />
+          </div>
+          {orderedLayers.map((layer, index) => (
+            <div key={layer.id} className="grid min-w-[760px] grid-cols-[3rem_minmax(12rem,1.3fr)_10rem_11rem_minmax(14rem,1fr)_4rem] items-center border-b border-slate-100 px-3 py-2 text-[10px]">
+              <span className="font-mono text-slate-400">{String(index + 1).padStart(2, '0')}</span>
+              <div className="pr-2">
+                <input value={layer.name} onChange={(event) => store.updateAssemblyLayer(layer.id, { name: event.target.value })} className="h-7 w-full border-0 bg-transparent px-1 font-semibold text-slate-900 outline-none focus:bg-slate-50" />
+                <input value={layer.inspectionNote} onChange={(event) => store.updateAssemblyLayer(layer.id, { inspectionNote: event.target.value })} placeholder="Inspection criterion" className="h-6 w-full border-0 bg-transparent px-1 text-[9px] text-slate-500 outline-none focus:bg-slate-50" />
+              </div>
+              <input value={layer.material} onChange={(event) => store.updateAssemblyLayer(layer.id, { material: event.target.value })} placeholder="Unresolved" className="h-8 border border-slate-300 bg-white px-2 text-[10px]" />
+              <select value={layer.fasteningMethod} onChange={(event) => store.updateAssemblyLayer(layer.id, { fasteningMethod: event.target.value })} className="h-8 border border-slate-300 bg-white px-2 text-[10px]">
+                {['Screw Thread', 'Snap Fit', 'Adhesive', 'Press Fit', 'Gasket', 'Welded', 'Soldered'].map((method) => <option key={method}>{method}</option>)}
+              </select>
+              <input value={layer.notes || ''} onChange={(event) => store.updateAssemblyLayer(layer.id, { notes: event.target.value })} placeholder="Thickness, finish, process…" className="h-8 border border-slate-300 bg-white px-2 text-[10px]" />
+              <button type="button" onClick={() => store.deleteAssemblyLayer(layer.id)} className="grid h-8 w-8 place-items-center text-red-600 hover:bg-red-50"><Trash2 className="h-3.5 w-3.5" /></button>
+            </div>
+          ))}
+          {orderedLayers.length === 0 && (
+            <div className="grid min-h-[22rem] place-items-center text-center">
+              <div><Boxes className="mx-auto h-7 w-7 text-slate-300" /><p className="mt-2 text-xs font-semibold text-slate-800">No assembly layers</p><p className="mt-1 text-[10px] text-slate-500">Add physical parts/layers only when their material and fastening intent is known.</p></div>
+            </div>
+          )}
         </div>
         <EngineeringStatusBar left="Assembly order is physical evidence, not a decorative layer stack." center={boardContext.syncState === 'synced' ? 'PCB envelope linked' : 'PCB envelope not synchronized'} right={`${orderedLayers.length} layers`} />
       </section>
@@ -205,40 +247,151 @@ export const EngineeringMechanicalWorkbench: React.FC<Props> = ({ initialMode })
           <>
             <EditorToolButton label="Select" active={!panMode} onClick={() => setPanMode(false)}><Box className="h-3.5 w-3.5" /></EditorToolButton>
             <EditorToolButton label="Pan" active={panMode} onClick={() => setPanMode(true)}><Move className="h-3.5 w-3.5" /></EditorToolButton>
-            <EditorToolButton label="Dimension" disabled={!selectedObject} onClick={() => { setInspectorOpen(true); }}><Ruler className="h-3.5 w-3.5" /></EditorToolButton>
+            <EditorToolButton label="Dimension" disabled={!selectedObject} onClick={() => setInspectorOpen(true)}><Ruler className="h-3.5 w-3.5" /></EditorToolButton>
           </>
         )}
         docks={(
           <>
             <EditorDockButton label="Browser" icon={Boxes} active={browserOpen} count={objects.length} onClick={() => setBrowserOpen((value) => !value)} />
-            <EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} count={warnings.length} onClick={() => setInspectorOpen((value) => !value)} />
+            <EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} onClick={() => setInspectorOpen((value) => !value)} />
+            <EditorDockButton label="Problems" icon={AlertTriangle} active={problemsOpen} count={warnings.length} onClick={() => setProblemsOpen((value) => !value)} />
           </>
         )}
-        actions={<button type="button" onClick={syncBoardEnvelope} disabled={boardContext.syncState === 'missing-board' || boardContext.syncState === 'missing-outline'} className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-2.5 text-[10px] font-semibold text-white disabled:opacity-30"><ShieldCheck className="h-3.5 w-3.5" /> {boardContext.syncState === 'synced' ? 'Refresh PCB reference' : 'Link PCB reference'}</button>}
+        actions={(
+          <button
+            type="button"
+            onClick={syncBoardEnvelope}
+            disabled={boardContext.syncState === 'missing-board' || boardContext.syncState === 'missing-outline'}
+            className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-2.5 text-[10px] font-semibold text-white disabled:opacity-30"
+          >
+            <ShieldCheck className="h-3.5 w-3.5" /> {boardContext.syncState === 'synced' ? 'Refresh PCB reference' : 'Link PCB reference'}
+          </button>
+        )}
       />
 
       <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
-        <EngineeringMechanicalCanvas selectedObjectId={selectedObjectId} onSelectObject={(id) => { setSelectedObjectId(id); if (id) setInspectorOpen(true); }} panMode={panMode} view={view} onViewChange={(patch) => setView((previous) => ({ ...previous, ...patch }))} />
+        <EngineeringMechanicalCanvas
+          selectedObjectId={selectedObjectId}
+          onSelectObject={(id) => {
+            setSelectedObjectId(id);
+            if (id) setInspectorOpen(true);
+          }}
+          panMode={panMode}
+          view={view}
+          onViewChange={(patch) => setView((previous) => ({ ...previous, ...patch }))}
+        />
 
         {browserOpen && (
           <EngineeringDock side="left" title="Design browser" subtitle="Physical features" onClose={() => setBrowserOpen(false)} widthClassName="w-[300px]">
-            <div className="border-b border-slate-200 p-2"><button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex h-8 w-full items-center justify-center gap-1.5 bg-slate-950 text-[10px] font-semibold text-white"><Plus className="h-3.5 w-3.5" /> New physical feature</button></div>
-            {showCreate && <div className="border-b border-slate-300 bg-[#f7f5ef] p-3"><div className="grid grid-cols-2 gap-2"><label className="col-span-2"><FieldLabel>Feature type</FieldLabel><select value={featureType} onChange={(event) => { const type = event.target.value as FeatureType; setFeatureType(type); setFeatureName(type); }} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 text-[10px]">{FEATURE_TYPES.map((type) => <option key={type}>{type}</option>)}</select></label><label className="col-span-2"><FieldLabel>Name</FieldLabel><input value={featureName} onChange={(event) => setFeatureName(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 text-[10px]" /></label><label><FieldLabel>X mm</FieldLabel><input type="number" value={featureX} onChange={(event) => setFeatureX(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label><label><FieldLabel>Y mm</FieldLabel><input type="number" value={featureY} onChange={(event) => setFeatureY(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>{defaultShape(featureType) === 'rect' ? <><label><FieldLabel>Width mm</FieldLabel><input type="number" value={featureWidth} onChange={(event) => setFeatureWidth(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label><label><FieldLabel>Height mm</FieldLabel><input type="number" value={featureHeight} onChange={(event) => setFeatureHeight(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label></> : <label className="col-span-2"><FieldLabel>Radius mm</FieldLabel><input type="number" value={featureRadius} onChange={(event) => setFeatureRadius(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>}<label><FieldLabel>Depth mm</FieldLabel><input type="number" value={featureDepth} onChange={(event) => setFeatureDepth(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label><label><FieldLabel>Clearance mm</FieldLabel><input type="number" value={featureClearance} onChange={(event) => setFeatureClearance(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label><label className="col-span-2"><FieldLabel>Material</FieldLabel><input value={featureMaterial} onChange={(event) => setFeatureMaterial(event.target.value)} placeholder="Optional until known" className="mt-1 h-8 w-full border border-slate-300 px-2 text-[10px]" /></label></div><div className="mt-3 flex gap-1"><button type="button" onClick={() => setShowCreate(false)} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-600">Cancel</button><button type="button" onClick={createFeature} className="h-8 flex-1 bg-slate-950 text-[9px] font-semibold text-white">Create feature</button></div></div>}
-            <div className="p-2"><div className="space-y-0.5">{objects.map((object) => <div key={object.id} className={`flex items-center gap-1 px-1 py-1 ${selectedObjectId === object.id ? 'bg-slate-950 text-white' : 'hover:bg-slate-100'}`}><button type="button" onClick={() => store.updateMechanicalObject(object.id, { visible: !object.visible })} className={`grid h-7 w-7 place-items-center ${selectedObjectId === object.id ? 'text-white/60' : 'text-slate-400'}`}>{object.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}</button><button type="button" onClick={() => { setSelectedObjectId(object.id); setInspectorOpen(true); }} className="min-w-0 flex-1 text-left"><span className="block truncate text-[10px] font-semibold">{object.name}</span><span className={`block truncate text-[8px] ${selectedObjectId === object.id ? 'text-white/55' : 'text-slate-400'}`}>{object.type}</span></button><button type="button" onClick={() => store.updateMechanicalObject(object.id, { locked: !object.locked })} className={`grid h-7 w-7 place-items-center ${selectedObjectId === object.id ? 'text-white/60' : 'text-slate-400'}`}>{object.locked ? <Lock className="h-3 w-3" /> : <Unlock className="h-3 w-3" />}</button></div>)}{objects.length === 0 && <p className="p-3 text-[10px] leading-5 text-slate-400">Create the first physical feature with exact geometry. The canvas does not create generic zones from arbitrary shapes.</p>}</div></div>
-          </EngineeringDock>
-        )}
-
-        {inspectorOpen && (
-          <EngineeringDock side="right" title="Inspector" subtitle={selectedObject?.name || 'Select a physical feature'} onClose={() => setInspectorOpen(false)} widthClassName="w-[320px]">
-            <div className="p-3">
-              {selectedObject ? <div className="space-y-3"><div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Physical feature</p><input value={selectedObject.name} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { name: event.target.value })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 text-[11px] font-semibold" /><p className="mt-1 text-[9px] text-slate-500">{selectedObject.type} · {selectedObject.shape}</p></div><div className="grid grid-cols-2 gap-2"><label><FieldLabel>X mm</FieldLabel><input type="number" step="0.1" value={selectedObject.xMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { xMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label><label><FieldLabel>Y mm</FieldLabel><input type="number" step="0.1" value={selectedObject.yMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { yMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>{selectedObject.widthMm != null && <label><FieldLabel>Width mm</FieldLabel><input type="number" step="0.1" value={selectedObject.widthMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { widthMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>}{selectedObject.heightMm != null && <label><FieldLabel>Height mm</FieldLabel><input type="number" step="0.1" value={selectedObject.heightMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { heightMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>}{selectedObject.radiusMm != null && <label><FieldLabel>Radius mm</FieldLabel><input type="number" step="0.1" value={selectedObject.radiusMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { radiusMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>}<label><FieldLabel>Depth mm</FieldLabel><input type="number" step="0.1" value={selectedObject.depthMm ?? ''} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { depthMm: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label></div><label className="block"><FieldLabel>Material</FieldLabel><input value={selectedObject.material || ''} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { material: event.target.value || undefined })} className="mt-1 h-8 w-full border border-slate-300 px-2 text-[10px]" /></label><label className="block"><FieldLabel>Clearance mm</FieldLabel><input type="number" step="0.1" value={selectedObject.clearanceMm ?? ''} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { clearanceMm: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label><div className="border-t border-slate-200 pt-3"><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Driving evidence</p><div className="mt-2 grid grid-cols-3 gap-1"><select value={dimensionKind} onChange={(event) => setDimensionKind(event.target.value as DimensionKind)} className="h-8 border border-slate-300 bg-white px-1 text-[9px]"><option>Width</option><option>Height</option><option>Radius</option></select><input value={tolPlus} onChange={(event) => setTolPlus(event.target.value)} title="Positive tolerance" className="h-8 border border-slate-300 px-2 font-mono text-[9px]" placeholder="+ tol" /><input value={tolMinus} onChange={(event) => setTolMinus(event.target.value)} title="Negative tolerance" className="h-8 border border-slate-300 px-2 font-mono text-[9px]" placeholder="- tol" /></div><button type="button" onClick={addDimension} className="mt-1.5 inline-flex h-8 w-full items-center justify-center gap-1.5 bg-slate-950 text-[9px] font-semibold text-white"><Ruler className="h-3.5 w-3.5" /> Capture dimension & tolerance</button><div className="mt-2 space-y-1">{dimensions.filter((dimension) => dimension.linkedObjectIds.includes(selectedObject.id)).map((dimension) => <div key={dimension.id} className="flex items-center gap-2 border border-slate-200 bg-white px-2 py-1.5"><span className="min-w-0 flex-1 truncate font-mono text-[9px] text-slate-700">{dimension.name} · {dimension.valueMm.toFixed(2)} mm +{dimension.tolerancePlusMm ?? 0}/-{dimension.toleranceMinusMm ?? 0}</span><button type="button" onClick={() => store.deleteMechanicalDimension(dimension.id)} className="text-red-600"><Trash2 className="h-3 w-3" /></button></div>)}</div></div><button type="button" onClick={() => { store.deleteMechanicalObject(selectedObject.id); setSelectedObjectId(null); }} className="inline-flex h-8 w-full items-center justify-center gap-1.5 border border-red-300 bg-white text-[9px] font-semibold text-red-700"><Trash2 className="h-3.5 w-3.5" /> Delete feature</button></div> : <p className="text-[10px] leading-5 text-slate-500">Select a physical feature to edit exact geometry, material, clearance, and dimensional evidence.</p>}
-              {warnings.length > 0 && <div className="mt-4 border-t border-slate-200 pt-3"><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Mechanical checks</p><div className="mt-1.5 space-y-1">{warnings.slice(0, 8).map((warning, index) => <div key={`${warning.message}-${index}`} className="border-l-2 border-amber-500 bg-amber-50 px-2 py-1.5 text-[9px] leading-4 text-amber-900">{warning.message}</div>)}</div></div>}
+            <div className="border-b border-slate-200 p-2">
+              <button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex h-8 w-full items-center justify-center gap-1.5 bg-slate-950 text-[10px] font-semibold text-white"><Plus className="h-3.5 w-3.5" /> New physical feature</button>
+            </div>
+            {showCreate && (
+              <div className="border-b border-slate-300 bg-[#f7f5ef] p-3">
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="col-span-2"><FieldLabel>Feature type</FieldLabel><select value={featureType} onChange={(event) => { const type = event.target.value as FeatureType; setFeatureType(type); setFeatureName(type); }} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 text-[10px]">{FEATURE_TYPES.map((type) => <option key={type}>{type}</option>)}</select></label>
+                  <label className="col-span-2"><FieldLabel>Name</FieldLabel><input value={featureName} onChange={(event) => setFeatureName(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 text-[10px]" /></label>
+                  <label><FieldLabel>X mm</FieldLabel><input type="number" value={featureX} onChange={(event) => setFeatureX(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                  <label><FieldLabel>Y mm</FieldLabel><input type="number" value={featureY} onChange={(event) => setFeatureY(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                  {defaultShape(featureType) === 'rect' ? (
+                    <>
+                      <label><FieldLabel>Width mm</FieldLabel><input type="number" value={featureWidth} onChange={(event) => setFeatureWidth(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                      <label><FieldLabel>Height mm</FieldLabel><input type="number" value={featureHeight} onChange={(event) => setFeatureHeight(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                    </>
+                  ) : (
+                    <label className="col-span-2"><FieldLabel>Radius mm</FieldLabel><input type="number" value={featureRadius} onChange={(event) => setFeatureRadius(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                  )}
+                  <label><FieldLabel>Depth mm</FieldLabel><input type="number" value={featureDepth} onChange={(event) => setFeatureDepth(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                  <label><FieldLabel>Clearance mm</FieldLabel><input type="number" value={featureClearance} onChange={(event) => setFeatureClearance(event.target.value)} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                  <label className="col-span-2"><FieldLabel>Material</FieldLabel><input value={featureMaterial} onChange={(event) => setFeatureMaterial(event.target.value)} placeholder="Optional until known" className="mt-1 h-8 w-full border border-slate-300 px-2 text-[10px]" /></label>
+                </div>
+                <div className="mt-3 flex gap-1">
+                  <button type="button" onClick={() => setShowCreate(false)} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-600">Cancel</button>
+                  <button type="button" onClick={createFeature} className="h-8 flex-1 bg-slate-950 text-[9px] font-semibold text-white">Create feature</button>
+                </div>
+              </div>
+            )}
+            <div className="p-2">
+              <div className="space-y-0.5">
+                {objects.map((object) => (
+                  <div key={object.id} className={`flex items-center gap-1 px-1 py-1 ${selectedObjectId === object.id ? 'bg-slate-950 text-white' : 'hover:bg-slate-100'}`}>
+                    <button type="button" onClick={() => store.updateMechanicalObject(object.id, { visible: !object.visible })} className={`grid h-7 w-7 place-items-center ${selectedObjectId === object.id ? 'text-white/60' : 'text-slate-400'}`}>{object.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}</button>
+                    <button type="button" onClick={() => { setSelectedObjectId(object.id); setInspectorOpen(true); }} className="min-w-0 flex-1 text-left"><span className="block truncate text-[10px] font-semibold">{object.name}</span><span className={`block truncate text-[8px] ${selectedObjectId === object.id ? 'text-white/55' : 'text-slate-400'}`}>{object.type}</span></button>
+                    <button type="button" onClick={() => store.updateMechanicalObject(object.id, { locked: !object.locked })} className={`grid h-7 w-7 place-items-center ${selectedObjectId === object.id ? 'text-white/60' : 'text-slate-400'}`}>{object.locked ? <Lock className="h-3 w-3" /> : <Unlock className="h-3 w-3" />}</button>
+                  </div>
+                ))}
+                {objects.length === 0 && <p className="p-3 text-[10px] leading-5 text-slate-400">Create the first physical feature with exact geometry. The canvas does not create generic zones from arbitrary shapes.</p>}
+              </div>
             </div>
           </EngineeringDock>
         )}
+
+        <EngineeringInspector open={inspectorOpen} subtitle={selectedObject?.name || 'Select a physical feature'} onClose={() => setInspectorOpen(false)} widthClassName="w-[320px]">
+          <div className="p-3">
+            {selectedObject ? (
+              <div className="space-y-3">
+                <div>
+                  <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Physical feature</p>
+                  <input value={selectedObject.name} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { name: event.target.value })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 text-[11px] font-semibold" />
+                  <p className="mt-1 text-[9px] text-slate-500">{selectedObject.type} · {selectedObject.shape}</p>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <label><FieldLabel>X mm</FieldLabel><input type="number" step="0.1" value={selectedObject.xMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { xMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                  <label><FieldLabel>Y mm</FieldLabel><input type="number" step="0.1" value={selectedObject.yMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { yMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                  {selectedObject.widthMm != null && <label><FieldLabel>Width mm</FieldLabel><input type="number" step="0.1" value={selectedObject.widthMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { widthMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>}
+                  {selectedObject.heightMm != null && <label><FieldLabel>Height mm</FieldLabel><input type="number" step="0.1" value={selectedObject.heightMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { heightMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>}
+                  {selectedObject.radiusMm != null && <label><FieldLabel>Radius mm</FieldLabel><input type="number" step="0.1" value={selectedObject.radiusMm} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { radiusMm: Number.parseFloat(event.target.value) || 0 })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>}
+                  <label><FieldLabel>Depth mm</FieldLabel><input type="number" step="0.1" value={selectedObject.depthMm ?? ''} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { depthMm: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+                </div>
+                <label className="block"><FieldLabel>Material</FieldLabel><input value={selectedObject.material || ''} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { material: event.target.value || undefined })} className="mt-1 h-8 w-full border border-slate-300 px-2 text-[10px]" /></label>
+                <label className="block"><FieldLabel>Clearance mm</FieldLabel><input type="number" step="0.1" value={selectedObject.clearanceMm ?? ''} onChange={(event) => store.updateMechanicalObject(selectedObject.id, { clearanceMm: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className="mt-1 h-8 w-full border border-slate-300 px-2 font-mono text-[10px]" /></label>
+
+                <div className="border-t border-slate-200 pt-3">
+                  <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Driving evidence</p>
+                  <div className="mt-2 grid grid-cols-3 gap-1">
+                    <select value={dimensionKind} onChange={(event) => setDimensionKind(event.target.value as DimensionKind)} className="h-8 border border-slate-300 bg-white px-1 text-[9px]"><option>Width</option><option>Height</option><option>Radius</option></select>
+                    <input value={tolPlus} onChange={(event) => setTolPlus(event.target.value)} title="Positive tolerance" className="h-8 border border-slate-300 px-2 font-mono text-[9px]" placeholder="+ tol" />
+                    <input value={tolMinus} onChange={(event) => setTolMinus(event.target.value)} title="Negative tolerance" className="h-8 border border-slate-300 px-2 font-mono text-[9px]" placeholder="- tol" />
+                  </div>
+                  <button type="button" onClick={addDimension} className="mt-1.5 inline-flex h-8 w-full items-center justify-center gap-1.5 bg-slate-950 text-[9px] font-semibold text-white"><Ruler className="h-3.5 w-3.5" /> Capture dimension & tolerance</button>
+                  <div className="mt-2 space-y-1">
+                    {dimensions.filter((dimension) => dimension.linkedObjectIds.includes(selectedObject.id)).map((dimension) => (
+                      <div key={dimension.id} className="flex items-center gap-2 border border-slate-200 bg-white px-2 py-1.5">
+                        <span className="min-w-0 flex-1 truncate font-mono text-[9px] text-slate-700">{dimension.name} · {dimension.valueMm.toFixed(2)} mm +{dimension.tolerancePlusMm ?? 0}/-{dimension.toleranceMinusMm ?? 0}</span>
+                        <button type="button" onClick={() => store.deleteMechanicalDimension(dimension.id)} className="text-red-600"><Trash2 className="h-3 w-3" /></button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <button type="button" onClick={() => { store.deleteMechanicalObject(selectedObject.id); setSelectedObjectId(null); }} className="inline-flex h-8 w-full items-center justify-center gap-1.5 border border-red-300 bg-white text-[9px] font-semibold text-red-700"><Trash2 className="h-3.5 w-3.5" /> Delete feature</button>
+              </div>
+            ) : (
+              <p className="text-[10px] leading-5 text-slate-500">Select a physical feature to edit exact geometry, material, clearance, and dimensional evidence.</p>
+            )}
+          </div>
+        </EngineeringInspector>
+
+        <EngineeringBottomDock
+          open={problemsOpen}
+          title="Mechanical checks"
+          subtitle={`${warnings.length} current finding${warnings.length === 1 ? '' : 's'}`}
+          onClose={() => setProblemsOpen(false)}
+        >
+          <div className="grid gap-1 p-2 sm:grid-cols-2 xl:grid-cols-3">
+            {warnings.slice(0, 12).map((warning, index) => (
+              <div key={`${warning.message}-${index}`} className="border-l-2 border-amber-500 bg-amber-50 px-2 py-1.5 text-[9px] leading-4 text-amber-900">{warning.message}</div>
+            ))}
+            {warnings.length === 0 && <p className="p-3 text-[9px] text-emerald-700">No current mechanical findings.</p>}
+          </div>
+        </EngineeringBottomDock>
       </div>
 
-      <EngineeringStatusBar left={panMode ? 'Pan: drag the canvas · wheel zooms' : 'Select: drag unlocked physical features · exact values belong in Inspector'} center={boardContext.syncState === 'synced' ? `${boardContext.boardName} PCB reference synchronized` : boardContext.blockers[0] || 'PCB reference unresolved'} right={`${view.mouseXmm.toFixed(1)}, ${view.mouseYmm.toFixed(1)} mm · ${Math.round(view.scale * 16.67)}%`} />
+      <EngineeringStatusBar
+        left={panMode ? 'Pan: drag the canvas · wheel zooms' : 'Select: drag unlocked physical features · exact values belong in Inspector'}
+        center={boardContext.syncState === 'synced' ? `${boardContext.boardName} PCB reference synchronized` : boardContext.blockers[0] || 'PCB reference unresolved'}
+        right={`${view.mouseXmm.toFixed(1)}, ${view.mouseYmm.toFixed(1)} mm · ${Math.round(view.scale * 16.67)}%`}
+      />
     </section>
   );
 };

--- a/src/components/schematic/EngineeringSchematicWorkbench.tsx
+++ b/src/components/schematic/EngineeringSchematicWorkbench.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  AlertTriangle,
   ArrowRight,
   Boxes,
   CircuitBoard,
@@ -13,7 +14,6 @@ import {
   RotateCw,
   Route,
   Trash2,
-  X,
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore } from '../../store/studioContextStore';
@@ -23,8 +23,10 @@ import { initialSchematicUIState, type SchematicUIState } from './schematicInter
 import { EditorDockButton } from '../editor/EditorDockButton';
 import {
   EditorToolButton,
+  EngineeringBottomDock,
   EngineeringDock,
   EngineeringEditorBar,
+  EngineeringInspector,
   EngineeringStatusBar,
 } from '../editor/EngineeringEditorShell';
 
@@ -80,6 +82,7 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
   });
   const [browserOpen, setBrowserOpen] = useState(true);
   const [inspectorOpen, setInspectorOpen] = useState(false);
+  const [problemsOpen, setProblemsOpen] = useState(false);
   const [panDrag, setPanDrag] = useState<{ x: number; y: number; panX: number; panY: number } | null>(null);
   const canvasHostRef = useRef<HTMLDivElement>(null);
 
@@ -192,7 +195,8 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
         docks={(
           <>
             <EditorDockButton label="Browser" icon={Boxes} active={browserOpen} count={unplacedComponents.length} onClick={() => setBrowserOpen((value) => !value)} />
-            <EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} count={ercResults.length} onClick={() => setInspectorOpen((value) => !value)} />
+            <EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} onClick={() => setInspectorOpen((value) => !value)} />
+            <EditorDockButton label="Problems" icon={AlertTriangle} active={problemsOpen} count={ercResults.length} onClick={() => setProblemsOpen((value) => !value)} />
           </>
         )}
         actions={<button type="button" onClick={openPcb} className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-2.5 text-[10px] font-semibold text-white hover:bg-slate-800"><CircuitBoard className="h-3.5 w-3.5" /> PCB <ArrowRight className="h-3 w-3" /></button>}
@@ -257,50 +261,62 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
           </EngineeringDock>
         )}
 
-        {inspectorOpen && (
-          <EngineeringDock side="right" title="Inspector" subtitle={selectedComponent ? selectedComponent.referenceDesignator : selectedWire ? selectedWire.netName : 'Selection & ERC'} onClose={() => setInspectorOpen(false)} widthClassName="w-[300px]">
-            <div className="p-3">
-              {selectedComponent ? (
-                <div className="space-y-3">
-                  <div>
-                    <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Component</p>
-                    <p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedComponent.referenceDesignator} · {selectedComponent.componentName}</p>
-                    <p className="mt-0.5 font-mono text-[9px] text-slate-500">{selectedComponent.partNumber || selectedComponent.libraryId || selectedComponent.id}</p>
-                  </div>
-                  <div className="grid grid-cols-2 gap-px overflow-hidden border border-slate-200 bg-slate-200 text-[9px]">
-                    {[
-                      ['Value', selectedComponent.value || '—'],
-                      ['Footprint', selectedComponent.footprint || 'Unresolved'],
-                      ['X', selectedComponent.schematic?.x != null ? `${selectedComponent.schematic.x}` : '—'],
-                      ['Y', selectedComponent.schematic?.y != null ? `${selectedComponent.schematic.y}` : '—'],
-                      ['Rotation', `${selectedComponent.schematic?.rotation || 0}°`],
-                      ['Pins', `${selectedComponent.pins?.length || 0}`],
-                    ].map(([label, value]) => <div key={label} className="bg-white p-2"><p className="text-slate-400">{label}</p><p className="mt-0.5 truncate font-semibold text-slate-800">{value}</p></div>)}
-                  </div>
-                  <div>
-                    <p className="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Pins</p>
-                    <div className="max-h-48 overflow-y-auto border-y border-slate-200">
-                      {(selectedComponent.pins || []).map((pin) => <div key={pin.id} className="grid grid-cols-[2.5rem_minmax(0,1fr)_5rem] gap-2 border-b border-slate-100 px-1 py-1.5 text-[9px] last:border-b-0"><span className="font-mono text-slate-500">{pin.pinNumber}</span><span className="truncate font-semibold text-slate-800">{pin.pinName}</span><span className="truncate text-right text-slate-400">{pin.netName || 'unconnected'}</span></div>)}
-                    </div>
-                  </div>
-                  <button type="button" onClick={() => unplaceComponentFromSchematic(selectedComponent.id)} className="h-8 w-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-700 hover:bg-slate-100">Remove symbol from sheet</button>
+        <EngineeringInspector
+          open={inspectorOpen}
+          subtitle={selectedComponent ? selectedComponent.referenceDesignator : selectedWire ? selectedWire.netName : 'Select a symbol or wire'}
+          onClose={() => setInspectorOpen(false)}
+          widthClassName="w-[300px]"
+        >
+          <div className="p-3">
+            {selectedComponent ? (
+              <div className="space-y-3">
+                <div>
+                  <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Component</p>
+                  <p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedComponent.referenceDesignator} · {selectedComponent.componentName}</p>
+                  <p className="mt-0.5 font-mono text-[9px] text-slate-500">{selectedComponent.partNumber || selectedComponent.libraryId || selectedComponent.id}</p>
                 </div>
-              ) : selectedWire ? (
-                <div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Net</p><p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedWire.netName}</p><p className="mt-2 text-[10px] leading-5 text-slate-500">{selectedWire.status || 'Connected'} · {selectedWire.points.length} route points</p></div>
-              ) : (
-                <p className="text-[10px] leading-5 text-slate-500">Select a symbol or wire. The inspector describes engineering data; it does not navigate away from the sheet.</p>
-              )}
-
-              <div className="mt-4 border-t border-slate-200 pt-3">
-                <div className="flex items-center justify-between"><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">ERC</p><span className="font-mono text-[9px] text-slate-500">{ercResults.length}</span></div>
-                <div className="mt-1.5 space-y-1">
-                  {ercResults.slice(0, 8).map((result) => <div key={result.id} className="border-l-2 border-amber-500 bg-amber-50 px-2 py-1.5"><p className="text-[9px] font-semibold text-amber-950">{result.title}</p><p className="mt-0.5 text-[9px] leading-4 text-amber-800">{result.description}</p></div>)}
-                  {ercResults.length === 0 && <p className="text-[9px] text-emerald-700">No current ERC findings.</p>}
+                <div className="grid grid-cols-2 gap-px overflow-hidden border border-slate-200 bg-slate-200 text-[9px]">
+                  {[
+                    ['Value', selectedComponent.value || '—'],
+                    ['Footprint', selectedComponent.footprint || 'Unresolved'],
+                    ['X', selectedComponent.schematic?.x != null ? `${selectedComponent.schematic.x}` : '—'],
+                    ['Y', selectedComponent.schematic?.y != null ? `${selectedComponent.schematic.y}` : '—'],
+                    ['Rotation', `${selectedComponent.schematic?.rotation || 0}°`],
+                    ['Pins', `${selectedComponent.pins?.length || 0}`],
+                  ].map(([label, value]) => <div key={label} className="bg-white p-2"><p className="text-slate-400">{label}</p><p className="mt-0.5 truncate font-semibold text-slate-800">{value}</p></div>)}
                 </div>
+                <div>
+                  <p className="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Pins</p>
+                  <div className="max-h-48 overflow-y-auto border-y border-slate-200">
+                    {(selectedComponent.pins || []).map((pin) => <div key={pin.id} className="grid grid-cols-[2.5rem_minmax(0,1fr)_5rem] gap-2 border-b border-slate-100 px-1 py-1.5 text-[9px] last:border-b-0"><span className="font-mono text-slate-500">{pin.pinNumber}</span><span className="truncate font-semibold text-slate-800">{pin.pinName}</span><span className="truncate text-right text-slate-400">{pin.netName || 'unconnected'}</span></div>)}
+                  </div>
+                </div>
+                <button type="button" onClick={() => unplaceComponentFromSchematic(selectedComponent.id)} className="h-8 w-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-700 hover:bg-slate-100">Remove symbol from sheet</button>
               </div>
-            </div>
-          </EngineeringDock>
-        )}
+            ) : selectedWire ? (
+              <div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Net</p><p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedWire.netName}</p><p className="mt-2 text-[10px] leading-5 text-slate-500">{selectedWire.status || 'Connected'} · {selectedWire.points.length} route points</p></div>
+            ) : (
+              <p className="text-[10px] leading-5 text-slate-500">Select a symbol or wire. The Inspector describes engineering data; it does not navigate away from the sheet.</p>
+            )}
+          </div>
+        </EngineeringInspector>
+
+        <EngineeringBottomDock
+          open={problemsOpen}
+          title="ERC findings"
+          subtitle={`${ercResults.length} current schematic finding${ercResults.length === 1 ? '' : 's'}`}
+          onClose={() => setProblemsOpen(false)}
+        >
+          <div className="grid gap-1 p-2 sm:grid-cols-2 xl:grid-cols-3">
+            {ercResults.slice(0, 12).map((result) => (
+              <div key={result.id} className="border-l-2 border-amber-500 bg-amber-50 px-2 py-1.5">
+                <p className="text-[9px] font-semibold text-amber-950">{result.title}</p>
+                <p className="mt-0.5 text-[9px] leading-4 text-amber-800">{result.description}</p>
+              </div>
+            ))}
+            {ercResults.length === 0 && <p className="p-3 text-[9px] text-emerald-700">No current ERC findings.</p>}
+          </div>
+        </EngineeringBottomDock>
       </div>
 
       <EngineeringStatusBar


### PR DESCRIPTION
Parent: #90 / #43
Execution spec: `docs/development/STUDIO_UX_CONVERGENCE_EXECUTION_PLAN.md`

## Goal

Make the editor anatomy explicit and reusable without adding empty global chrome:

- Inspector = selected canonical object / representation details;
- bottom dock = diagnostics, checks, execution, evidence;
- status bar = high-frequency low-level context.

## Current implementation

- `EngineeringEditorShell.tsx` now exposes `EngineeringInspector` and `EngineeringBottomDock` on top of the existing shared dock/status primitives;
- Schematic migrated first: component/wire details stay in the Inspector, ERC findings moved to a real `Problems` bottom dock;
- open/close state remains local UI state only;
- canonical selection still flows through `studioContextStore`;
- no empty AppShell-level Inspector or fake diagnostics tabs were added.

## Remaining in this PR

- migrate PCB selection/nets vs DRC;
- migrate Mechanical selection vs mechanical checks;
- add regression contracts for the shared primitive boundary;
- exact-head lint/typecheck/tests/build/status inspection.

Do not merge until those remaining items are complete.