### PR TITLE
U3.1: Preserve Electronics identity without guessed context

### DIFF
--- a/src/__tests__/electronicsIdentityTruth.test.ts
+++ b/src/__tests__/electronicsIdentityTruth.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { useStudioContextStore } from '../store/studioContextStore';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('Electronics canonical identity and representation truth', () => {
+  it('keeps component identity alive while a net becomes the immediate selected context', () => {
+    const context = useStudioContextStore.getState();
+    context.clearContext();
+    context.setActiveBoard('board-main');
+    context.setActiveComponent('component-u1');
+    context.setActiveNet('VDD_3V3');
+
+    const state = useStudioContextStore.getState();
+    expect(state.activeBoardId).toBe('board-main');
+    expect(state.activeComponentId).toBe('component-u1');
+    expect(state.activeNetName).toBe('VDD_3V3');
+    expect(state.selected).toEqual({ entity: 'net', id: 'VDD_3V3', label: 'VDD_3V3' });
+
+    state.clearContext();
+  });
+
+  it('makes Component Library own definition and project-instance context explicitly', () => {
+    const library = source('../components/component-library/ComponentLibraryWorkbench.tsx');
+    const adapters = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
+
+    expect(library).toContain('setActiveComponentDefinition(libraryId)');
+    expect(library).toContain('setContextBoard(component.boardId)');
+    expect(library).toContain('setActiveComponent(component.id)');
+    expect(library).toContain("focusProjectInstance(instance.id, 'schematic-editor')");
+    expect(library).toContain("focusProjectInstance(instance.id, 'board-designer')");
+    expect(library).toContain("focusProjectInstance(instance.id, 'bom')");
+    expect(library).toContain('<option value="">Select a board…</option>');
+    expect(library).not.toContain("setSelectedBoardId(boards[0]?.id ?? '')");
+
+    expect(adapters).not.toContain('previousIds');
+    expect(adapters).not.toContain('useEffect');
+    expect(adapters).not.toContain('useProjectStore');
+  });
+
+  it('never invents a selected BOM component and stores canonical BOM linkage', () => {
+    const bom = source('../components/studio/UnifiedBOMWorkbench.tsx');
+
+    expect(bom).not.toContain('|| contextualComponents[0]');
+    expect(bom).toContain('componentId: selectedComponent.id');
+    expect(bom).toContain('component.bomItemId === item.id');
+    expect(bom).toContain('focusComponent(linkedComponent.id)');
+    expect(bom).toContain('No canonical component is selected');
+  });
+
+  it('requires explicit board ownership for standalone DRC', () => {
+    const drc = source('../components/studio/UnifiedBoardDRCWorkbench.tsx');
+
+    expect(drc).toContain('const board = boards.find((candidate) => candidate.id === activeBoardId);');
+    expect(drc).not.toContain('|| boards[0]');
+    expect(drc).toContain('if (!boardId) return;');
+    expect(drc).toContain('activeBoardId: boardId');
+    expect(drc).toContain('Select a real board before running PCB checks');
+  });
+
+  it('does not fabricate board, placement, package, or mechanical geometry in 3D', () => {
+    const view3d = source('../components/mechanical/UnifiedBoard3DView.tsx');
+
+    expect(view3d).toContain('const board = boards.find((candidate) => candidate.id === activeBoardId);');
+    expect(view3d).not.toContain('|| boards[0]');
+    expect(view3d).toContain('return null;');
+    expect(view3d).toContain('new THREE.PlaneGeometry(size.width, size.height)');
+    expect(view3d).toContain('renderable: hasPlacement && hasDimensions');
+    expect(view3d).toContain('dimensions.widthMm, dimensions.heightZMm, dimensions.heightMm');
+    expect(view3d).not.toContain('return { width: 50, height: 30');
+    expect(view3d).not.toContain('dimensions?.widthMm || 6');
+    expect(view3d).not.toContain('index * 7');
+    expect(view3d).not.toContain("obj.name.toLowerCase().includes('boss')");
+    expect(view3d).toContain('Board outline is unresolved');
+    expect(view3d).toContain('not rendered because exact positive package dimensions are missing');
+  });
+});

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -80,14 +80,20 @@ describe('golden-path regression guards', () => {
 
   it('adapts editors to selected canonical context without mutating the schematic on open', () => {
     const adapters = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
+    const library = source('../components/component-library/ComponentLibraryWorkbench.tsx');
     const schematic = source('../components/schematic/EngineeringSchematicWorkbench.tsx');
     const appShell = source('../components/AppShell.tsx');
     expect(adapters).not.toContain('placeComponentOnSchematic');
     expect(appShell).not.toContain('placeComponentOnSchematic');
     expect(adapters).toContain('<EngineeringSchematicWorkbench />');
-    expect(adapters).toContain('setActiveComponentDefinition(added.libraryId || null)');
-    expect(adapters).toContain('setActiveComponent(added.id)');
     expect(adapters).toContain('<EngineeringBoardWorkbench />');
+    expect(adapters).not.toContain('useEffect');
+    expect(adapters).not.toContain('previousIds');
+    expect(adapters).not.toContain('useProjectStore');
+    expect(library).toContain('setActiveComponentDefinition(selectedComponent.libraryId)');
+    expect(library).toContain('setContextBoard(effectiveBoard.id)');
+    expect(library).toContain('setActiveComponent(component.id)');
+    expect(library).toContain('focusProjectInstance');
     expect(schematic).toContain('placingComponentId');
     expect(schematic).toContain('placeAtPointer');
     expect(schematic).toContain('placeComponentOnSchematic(componentId, x, y)');
@@ -108,8 +114,11 @@ describe('golden-path regression guards', () => {
   it('keeps BOM records linked to the selected canonical component', () => {
     const bom = source('../components/studio/UnifiedBOMWorkbench.tsx');
     expect(bom).toContain('activeComponentId');
-    expect(bom).toContain('selectedComponent?.bomItemId');
+    expect(bom).toContain('item.id === selectedComponent.bomItemId');
+    expect(bom).toContain('item.componentId === selectedComponent.id');
+    expect(bom).toContain('componentId: selectedComponent.id');
     expect(bom).toContain('updateBoardComponent(selectedComponent.id, { bomItemId: id })');
+    expect(bom).not.toContain('|| contextualComponents[0]');
   });
 
   it('links validation to the selected component and its actual net IDs', () => {

--- a/src/components/component-library/ComponentLibraryWorkbench.tsx
+++ b/src/components/component-library/ComponentLibraryWorkbench.tsx
@@ -16,6 +16,7 @@ import {
   X,
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
 import {
   ComponentPinDefinition,
   defaultComponents,
@@ -182,9 +183,16 @@ export const ComponentLibraryWorkbench: React.FC = () => {
     addCustomComponentDefinition,
     updateCustomComponentDefinition,
     duplicateComponentDefinition,
-    setActiveBoard,
+    setActiveBoard: setProjectActiveBoard,
     setActiveView,
   } = useProjectStore();
+  const {
+    activeBoardId: contextBoardId,
+    activeComponentId,
+    setActiveBoard: setContextBoard,
+    setActiveComponentDefinition,
+    setActiveComponent,
+  } = useStudioContextStore();
   const { notify } = useFeedback();
   const { openKnowledgeForComponent } = useKnowledge();
 
@@ -227,12 +235,33 @@ export const ComponentLibraryWorkbench: React.FC = () => {
     ?? fullLibrary[0];
   const selectedIsCustom = Boolean(selectedComponent && customComponents.some((component) => component.libraryId === selectedComponent.libraryId));
   const selectedKnowledgeId = selectedComponent ? resolveKnowledgeIdForComponent(selectedComponent) : undefined;
+  const projectInstances = useMemo(
+    () => selectedComponent
+      ? boardComponents.filter((component) => component.libraryId === selectedComponent.libraryId)
+      : [],
+    [boardComponents, selectedComponent],
+  );
 
-  const effectiveBoard = boards.find((board) => board.id === selectedBoardId) ?? boards[0];
+  const effectiveBoard = boards.find((board) => board.id === selectedBoardId);
   const blocksForBoard = effectiveBoard
     ? circuitBlocks.filter((block) => block.boardId === effectiveBoard.id)
     : [];
   const effectiveCircuitBlock = blocksForBoard.find((block) => block.id === selectedCircuitBlockId);
+
+  const selectDefinition = (libraryId: string) => {
+    setSelectedId(libraryId);
+    setActiveComponentDefinition(libraryId);
+  };
+
+  const focusProjectInstance = (componentId: string, targetView?: string) => {
+    const component = boardComponents.find((candidate) => candidate.id === componentId);
+    if (!component) return;
+    setProjectActiveBoard(component.boardId);
+    setContextBoard(component.boardId);
+    setActiveComponentDefinition(component.libraryId || null);
+    setActiveComponent(component.id);
+    if (targetView) setActiveView(targetView);
+  };
 
   const openCreate = () => {
     setEditingId(null);
@@ -248,7 +277,10 @@ export const ComponentLibraryWorkbench: React.FC = () => {
   };
 
   const openAdd = () => {
-    setSelectedBoardId(boards[0]?.id ?? '');
+    const explicitBoardId = contextBoardId && boards.some((board) => board.id === contextBoardId)
+      ? contextBoardId
+      : '';
+    setSelectedBoardId(explicitBoardId);
     setSelectedCircuitBlockId('');
     setIsAddOpen(true);
   };
@@ -286,7 +318,7 @@ export const ComponentLibraryWorkbench: React.FC = () => {
       addCustomComponentDefinition(definition);
       notify({ tone: 'success', title: 'Custom component created', detail: `${definition.name} is available in this project library.` });
     }
-    setSelectedId(definition.libraryId);
+    selectDefinition(definition.libraryId);
     setIsEditorOpen(false);
   };
 
@@ -306,7 +338,7 @@ export const ComponentLibraryWorkbench: React.FC = () => {
       tags: [...selectedComponent.tags, 'custom-copy'],
     };
     addCustomComponentDefinition(copy);
-    setSelectedId(copy.libraryId);
+    selectDefinition(copy.libraryId);
     notify({ tone: 'success', title: 'Built-in definition copied', detail: 'The copy is now project-owned and can be edited without changing the built-in library.' });
   };
 
@@ -315,7 +347,7 @@ export const ComponentLibraryWorkbench: React.FC = () => {
     if (!effectiveBoard) {
       notify({
         tone: 'warning',
-        title: 'Create a real board first',
+        title: 'Select a real board first',
         detail: 'A project component must have an explicit board identity before it can enter PCB placement.',
       });
       return;
@@ -326,7 +358,10 @@ export const ComponentLibraryWorkbench: React.FC = () => {
       effectiveBoard.id,
       effectiveCircuitBlock?.id,
     );
-    setActiveBoard(effectiveBoard.id);
+    setProjectActiveBoard(effectiveBoard.id);
+    setContextBoard(effectiveBoard.id);
+    setActiveComponentDefinition(selectedComponent.libraryId);
+    setActiveComponent(component.id);
 
     if (component.bomItemId) {
       updateBOMItem(component.bomItemId, {
@@ -359,7 +394,7 @@ export const ComponentLibraryWorkbench: React.FC = () => {
                 {fullLibrary.length} definitions
               </span>
             </div>
-            <p className="mt-0.5 text-xs text-slate-500">Choose reviewed device metadata, then create one canonical project component shared by schematic, PCB, BOM, and validation.</p>
+            <p className="mt-0.5 text-xs text-slate-500">Choose reviewed device metadata, then create or focus one canonical project component shared by schematic, PCB, BOM, and validation.</p>
           </div>
         </div>
         <button type="button" onClick={openCreate} className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50">
@@ -400,7 +435,7 @@ export const ComponentLibraryWorkbench: React.FC = () => {
                 <button
                   key={component.libraryId}
                   type="button"
-                  onClick={() => setSelectedId(component.libraryId)}
+                  onClick={() => selectDefinition(component.libraryId)}
                   className={`mb-1 w-full border px-3 py-2.5 text-left transition ${isSelected ? 'border-indigo-300 bg-indigo-50' : 'border-transparent hover:border-slate-200 hover:bg-slate-50'}`}
                 >
                   <div className="flex items-start justify-between gap-2">
@@ -514,9 +549,30 @@ export const ComponentLibraryWorkbench: React.FC = () => {
                   <section className="border border-slate-200 bg-white p-4">
                     <div className="flex items-start gap-2">
                       <Info className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" />
-                      <div>
+                      <div className="min-w-0 flex-1">
                         <div className="text-xs font-semibold text-slate-700">Project usage</div>
-                        <p className="mt-1 text-xs leading-5 text-slate-500">{boardComponents.filter((component) => component.libraryId === selectedComponent.libraryId).length} canonical project instance(s) currently use this definition.</p>
+                        <p className="mt-1 text-xs leading-5 text-slate-500">{projectInstances.length} canonical project instance(s) currently use this definition.</p>
+                        {projectInstances.length > 0 && (
+                          <div className="mt-3 space-y-1.5">
+                            {projectInstances.map((instance) => {
+                              const instanceBoard = boards.find((board) => board.id === instance.boardId);
+                              const active = instance.id === activeComponentId;
+                              return (
+                                <div key={instance.id} className={`border p-2 ${active ? 'border-indigo-300 bg-indigo-50' : 'border-slate-200 bg-slate-50'}`}>
+                                  <div className="flex items-start justify-between gap-2">
+                                    <div className="min-w-0"><p className="text-[10px] font-semibold text-slate-900">{instance.referenceDesignator} · {instance.componentName}</p><p className="mt-0.5 truncate font-mono text-[9px] text-slate-500">{instanceBoard?.name || instance.boardId} · {instance.id}</p></div>
+                                    <button type="button" onClick={() => focusProjectInstance(instance.id)} className="h-7 shrink-0 border border-slate-300 bg-white px-2 text-[9px] font-semibold text-slate-700 hover:border-indigo-300 hover:text-indigo-700">{active ? 'Focused' : 'Focus'}</button>
+                                  </div>
+                                  <div className="mt-2 grid grid-cols-3 gap-1">
+                                    <button type="button" onClick={() => focusProjectInstance(instance.id, 'schematic-editor')} className="h-7 border border-slate-200 bg-white text-[9px] font-semibold text-slate-600 hover:bg-slate-100">Schematic</button>
+                                    <button type="button" onClick={() => focusProjectInstance(instance.id, 'board-designer')} className="h-7 border border-slate-200 bg-white text-[9px] font-semibold text-slate-600 hover:bg-slate-100">PCB</button>
+                                    <button type="button" onClick={() => focusProjectInstance(instance.id, 'bom')} className="h-7 border border-slate-200 bg-white text-[9px] font-semibold text-slate-600 hover:bg-slate-100">BOM</button>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
                       </div>
                     </div>
                   </section>
@@ -566,18 +622,19 @@ export const ComponentLibraryWorkbench: React.FC = () => {
                     }}
                     className={inputClass}
                   >
+                    <option value="">Select a board…</option>
                     {boards.map((board) => <option key={board.id} value={board.id}>{board.name}</option>)}
                   </select>
                 </Field>
 
                 <Field label="Circuit block (optional)" htmlFor="component-target-block">
-                  <select id="component-target-block" value={effectiveCircuitBlock?.id || ''} onChange={(event) => setSelectedCircuitBlockId(event.target.value)} className={inputClass}>
+                  <select id="component-target-block" value={effectiveCircuitBlock?.id || ''} onChange={(event) => setSelectedCircuitBlockId(event.target.value)} className={inputClass} disabled={!effectiveBoard}>
                     <option value="">Unassigned</option>
                     {blocksForBoard.map((block) => <option key={block.id} value={block.id}>{block.name}</option>)}
                   </select>
                 </Field>
 
-                {blocksForBoard.length === 0 && (
+                {effectiveBoard && blocksForBoard.length === 0 && (
                   <p className="text-xs leading-5 text-slate-500">This board has no circuit blocks yet. That is valid—the component will remain explicitly unassigned at the block level.</p>
                 )}
               </div>

--- a/src/components/mechanical/UnifiedBoard3DView.tsx
+++ b/src/components/mechanical/UnifiedBoard3DView.tsx
@@ -23,22 +23,51 @@ const pixelRatioByQuality: Record<Board3DQuality, number> = {
   high: 1.7,
 };
 
-function outlineSize(outline: { points?: { x: number; y: number }[]; width?: number; height?: number } | undefined) {
-  if (outline?.points?.length) {
+interface BoardOutlineSize {
+  width: number;
+  height: number;
+  minX: number;
+  minY: number;
+}
+
+function outlineSize(outline: { points?: { x: number; y: number }[]; width?: number; height?: number } | undefined): BoardOutlineSize | null {
+  if (outline?.points && outline.points.length >= 2) {
     const xs = outline.points.map((point) => point.x);
     const ys = outline.points.map((point) => point.y);
-    return {
-      width: Math.max(1, Math.max(...xs) - Math.min(...xs)),
-      height: Math.max(1, Math.max(...ys) - Math.min(...ys)),
-      minX: Math.min(...xs),
-      minY: Math.min(...ys),
-      assumed: false,
-    };
+    const width = Math.max(...xs) - Math.min(...xs);
+    const height = Math.max(...ys) - Math.min(...ys);
+    if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+      return {
+        width,
+        height,
+        minX: Math.min(...xs),
+        minY: Math.min(...ys),
+      };
+    }
   }
-  if (outline?.width && outline?.height) {
-    return { width: outline.width, height: outline.height, minX: 0, minY: 0, assumed: false };
+  if (
+    outline?.width != null
+    && outline?.height != null
+    && Number.isFinite(outline.width)
+    && Number.isFinite(outline.height)
+    && outline.width > 0
+    && outline.height > 0
+  ) {
+    return { width: outline.width, height: outline.height, minX: 0, minY: 0 };
   }
-  return { width: 50, height: 30, minX: 0, minY: 0, assumed: true };
+  return null;
+}
+
+function positiveDimensions(dimensions: { widthMm: number; heightMm: number; heightZMm: number } | undefined) {
+  return Boolean(
+    dimensions
+    && Number.isFinite(dimensions.widthMm)
+    && Number.isFinite(dimensions.heightMm)
+    && Number.isFinite(dimensions.heightZMm)
+    && dimensions.widthMm > 0
+    && dimensions.heightMm > 0
+    && dimensions.heightZMm > 0,
+  );
 }
 
 function disposeObject(object: THREE.Object3D) {
@@ -68,8 +97,8 @@ export const UnifiedBoard3DView: React.FC = () => {
   const [quality, setQuality] = useState<Board3DQuality>('balanced');
   const [showEnclosure, setShowEnclosure] = useState(true);
 
-  const board = boards.find((candidate) => candidate.id === activeBoardId) || boards[0];
-  const boardId = board?.id || activeBoardId || '';
+  const board = boards.find((candidate) => candidate.id === activeBoardId);
+  const boardId = board?.id || '';
   const outline = boardOutlines.find((candidate) => candidate.boardId === boardId);
   const size = useMemo(() => outlineSize(outline), [outline]);
   const components = useMemo(
@@ -77,13 +106,27 @@ export const UnifiedBoard3DView: React.FC = () => {
     [boardComponents, boardId],
   );
   const selectedComponent = components.find((component) => component.id === activeComponentId);
-  const placedComponents = components.filter((component) => component.pcb?.placed || component.placementStatus === 'Placed' || component.placementX != null || component.placementY != null);
-  const unresolvedDimensions = components.filter((component) => !component.packageDimensions?.widthMm || !component.packageDimensions?.heightMm || !component.packageDimensions?.heightZMm);
-  const unplaced = components.filter((component) => !placedComponents.includes(component));
+  const componentRepresentations = useMemo(() => components.map((component) => {
+    const xMm = component.pcb?.xMm ?? component.placementX;
+    const yMm = component.pcb?.yMm ?? component.placementY;
+    const hasPlacement = xMm != null && yMm != null && Number.isFinite(xMm) && Number.isFinite(yMm);
+    const hasDimensions = positiveDimensions(component.packageDimensions);
+    return {
+      component,
+      xMm,
+      yMm,
+      hasPlacement,
+      hasDimensions,
+      renderable: hasPlacement && hasDimensions,
+    };
+  }), [components]);
+  const renderableComponents = componentRepresentations.filter((representation) => representation.renderable);
+  const unresolvedDimensions = componentRepresentations.filter((representation) => representation.hasPlacement && !representation.hasDimensions);
+  const unplaced = componentRepresentations.filter((representation) => !representation.hasPlacement);
 
   useEffect(() => {
     const mount = mountRef.current;
-    if (!mount || !board) return;
+    if (!mount || !board || !size) return;
 
     let renderer: THREE.WebGLRenderer;
     try {
@@ -121,8 +164,11 @@ export const UnifiedBoard3DView: React.FC = () => {
     const group = new THREE.Group();
     group.rotation.x = -0.08;
 
-    const boardGeometry = new THREE.BoxGeometry(size.width, 1.6, size.height);
-    const boardMaterial = new THREE.MeshStandardMaterial({ color: 0x047857, roughness: 0.48, metalness: 0.04 });
+    // Board thickness is not available in the canonical project model here, so render only the
+    // authoritative 2D outline as a plane rather than inventing a common PCB thickness.
+    const boardGeometry = new THREE.PlaneGeometry(size.width, size.height);
+    boardGeometry.rotateX(-Math.PI / 2);
+    const boardMaterial = new THREE.MeshStandardMaterial({ color: 0x047857, roughness: 0.48, metalness: 0.04, side: THREE.DoubleSide });
     const boardMesh = new THREE.Mesh(boardGeometry, boardMaterial);
     boardMesh.position.set(0, 0, 0);
     group.add(boardMesh);
@@ -134,23 +180,23 @@ export const UnifiedBoard3DView: React.FC = () => {
     edgeLines.position.copy(boardMesh.position);
     group.add(edgeLines);
 
-    placedComponents.forEach((component, index) => {
-      const dimensions = component.packageDimensions;
-      const width = dimensions?.widthMm || 6;
-      const depth = dimensions?.heightMm || 6;
-      const height = dimensions?.heightZMm || 2;
-      const x = (component.pcb?.xMm ?? component.placementX ?? size.minX + 6 + index * 7) - size.minX - size.width / 2;
-      const z = (component.pcb?.yMm ?? component.placementY ?? size.minY + 6 + index * 5) - size.minY - size.height / 2;
+    renderableComponents.forEach(({ component, xMm, yMm }) => {
+      const dimensions = component.packageDimensions!;
+      const x = xMm! - size.minX - size.width / 2;
+      const z = yMm! - size.minY - size.height / 2;
       const selected = component.id === activeComponentId;
       const material = new THREE.MeshStandardMaterial({
-        color: selected ? 0xf59e0b : dimensions ? 0x1e293b : 0x94a3b8,
+        color: selected ? 0xf59e0b : 0x1e293b,
         roughness: 0.4,
         metalness: selected ? 0.18 : 0.08,
         emissive: selected ? 0x78350f : 0x000000,
         emissiveIntensity: selected ? 0.35 : 0,
       });
-      const mesh = new THREE.Mesh(new THREE.BoxGeometry(width, height, depth), material);
-      mesh.position.set(x, 0.8 + height / 2, z);
+      const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(dimensions.widthMm, dimensions.heightZMm, dimensions.heightMm),
+        material,
+      );
+      mesh.position.set(x, dimensions.heightZMm / 2, z);
       mesh.userData.componentId = component.id;
       group.add(mesh);
 
@@ -166,35 +212,20 @@ export const UnifiedBoard3DView: React.FC = () => {
 
     if (showEnclosure) {
       mechanicalObjects.forEach((obj) => {
-        // A. 3D SCREW STANDOFF BOSS / MOUNTING POINT
-        if (obj.type === 'Mounting Point' || obj.name.toLowerCase().includes('boss') || obj.name.toLowerCase().includes('standoff')) {
-          const outerR = obj.radiusMm || 3.2;
-          const height = obj.depthMm || 8;
-          const x = (obj.xMm || 0) - size.width / 2;
-          const z = (obj.yMm || 0) - size.height / 2;
-
+        if (obj.type === 'Mounting Point' && obj.radiusMm != null && obj.radiusMm > 0 && obj.depthMm != null && obj.depthMm > 0) {
           const bossMesh = new THREE.Mesh(
-            new THREE.CylinderGeometry(outerR, outerR, height, 16),
-            new THREE.MeshStandardMaterial({ color: 0x94a3b8, roughness: 0.3, metalness: 0.6 })
+            new THREE.CylinderGeometry(obj.radiusMm, obj.radiusMm, obj.depthMm, 16),
+            new THREE.MeshStandardMaterial({ color: 0x94a3b8, roughness: 0.3, metalness: 0.6 }),
           );
-          bossMesh.position.set(x, height / 2 + 0.8, z);
+          bossMesh.position.set(obj.xMm - size.width / 2, obj.depthMm / 2, obj.yMm - size.height / 2);
           group.add(bossMesh);
-
-          // Inner pilot hole
-          const holeMesh = new THREE.Mesh(
-            new THREE.CylinderGeometry(outerR * 0.45, outerR * 0.45, height + 0.2, 16),
-            new THREE.MeshStandardMaterial({ color: 0x0f172a })
-          );
-          holeMesh.position.set(x, height / 2 + 0.9, z);
-          group.add(holeMesh);
-        }
-        // B. 3D ENCLOSURE CASING SHELL
-        else if (obj.type === 'Outer Profile' || obj.layer === 'Enclosure') {
-          const w = obj.widthMm || size.width + 10;
-          const h = obj.heightMm || size.height + 10;
-          const d = obj.depthMm || 22;
-
-          const geometry = new THREE.BoxGeometry(w, d, h);
+        } else if (
+          obj.type === 'Outer Profile'
+          && obj.widthMm != null && obj.widthMm > 0
+          && obj.heightMm != null && obj.heightMm > 0
+          && obj.depthMm != null && obj.depthMm > 0
+        ) {
+          const geometry = new THREE.BoxGeometry(obj.widthMm, obj.depthMm, obj.heightMm);
           const material = new THREE.MeshStandardMaterial({
             color: 0x38bdf8,
             transparent: true,
@@ -205,29 +236,34 @@ export const UnifiedBoard3DView: React.FC = () => {
             side: THREE.DoubleSide,
           });
           const mesh = new THREE.Mesh(geometry, material);
-          mesh.position.set(0, d / 2 - 1, 0);
+          mesh.position.set(
+            obj.xMm - size.minX - size.width / 2 + obj.widthMm / 2,
+            obj.depthMm / 2,
+            obj.yMm - size.minY - size.height / 2 + obj.heightMm / 2,
+          );
           group.add(mesh);
 
           const casingEdges = new THREE.LineSegments(
             new THREE.EdgesGeometry(geometry),
-            new THREE.LineBasicMaterial({ color: 0x0284c7 })
+            new THREE.LineBasicMaterial({ color: 0x0284c7 }),
           );
           casingEdges.position.copy(mesh.position);
           group.add(casingEdges);
-        }
-        // C. 3D BATTERY CAVITY
-        else if (obj.type === 'Battery Cavity') {
-          const w = obj.widthMm || 40;
-          const h = obj.heightMm || 20;
-          const d = obj.depthMm || 10;
-          const x = (obj.xMm || 0) - size.width / 2 + w / 2;
-          const z = (obj.yMm || 0) - size.height / 2 + h / 2;
-
+        } else if (
+          obj.type === 'Battery Cavity'
+          && obj.widthMm != null && obj.widthMm > 0
+          && obj.heightMm != null && obj.heightMm > 0
+          && obj.depthMm != null && obj.depthMm > 0
+        ) {
           const battMesh = new THREE.Mesh(
-            new THREE.BoxGeometry(w, d, h),
-            new THREE.MeshStandardMaterial({ color: 0xf59e0b, roughness: 0.4, metalness: 0.2 })
+            new THREE.BoxGeometry(obj.widthMm, obj.depthMm, obj.heightMm),
+            new THREE.MeshStandardMaterial({ color: 0xf59e0b, roughness: 0.4, metalness: 0.2 }),
           );
-          battMesh.position.set(x, d / 2 + 0.8, z);
+          battMesh.position.set(
+            obj.xMm - size.minX - size.width / 2 + obj.widthMm / 2,
+            obj.depthMm / 2,
+            obj.yMm - size.minY - size.height / 2 + obj.heightMm / 2,
+          );
           group.add(battMesh);
         }
       });
@@ -278,12 +314,20 @@ export const UnifiedBoard3DView: React.FC = () => {
       renderer.forceContextLoss();
       if (renderer.domElement.parentElement === mount) mount.removeChild(renderer.domElement);
     };
-  }, [activeComponentId, board, mechanicalObjects, placedComponents, quality, showEnclosure, size]);
+  }, [activeComponentId, board, mechanicalObjects, quality, renderableComponents, showEnclosure, size]);
 
   if (!board) {
     return (
       <div className="grid h-full place-items-center bg-slate-950 p-6 text-center text-slate-300">
-        <div><CircuitBoard className="mx-auto h-8 w-8 text-slate-500" /><h2 className="mt-3 text-lg font-bold text-white">No board selected</h2><p className="mt-2 text-sm text-slate-400">Create a board before opening the connected 3D view.</p><button type="button" onClick={() => setActiveView('board-settings')} className="mt-4 rounded-lg bg-indigo-500 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-400">Open board settings</button></div>
+        <div><CircuitBoard className="mx-auto h-8 w-8 text-slate-500" /><h2 className="mt-3 text-lg font-bold text-white">No board selected</h2><p className="mt-2 text-sm text-slate-400">Select an explicit project board before opening the connected 3D view. Hardware Studio will not substitute the first board.</p><button type="button" onClick={() => setActiveView('board-settings')} className="mt-4 rounded-lg bg-indigo-500 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-400">Open board settings</button></div>
+      </div>
+    );
+  }
+
+  if (!size) {
+    return (
+      <div className="grid h-full place-items-center bg-slate-950 p-6 text-center text-slate-300">
+        <div><AlertTriangle className="mx-auto h-8 w-8 text-amber-400" /><h2 className="mt-3 text-lg font-bold text-white">Board outline is unresolved</h2><p className="mt-2 max-w-lg text-sm leading-6 text-slate-400">The 3D representation needs explicit board geometry. No 50 × 30 mm preview envelope or other guessed outline will be created.</p><button type="button" onClick={() => setActiveView('board-settings')} className="mt-4 rounded-lg bg-indigo-500 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-400">Define board outline</button></div>
       </div>
     );
   }
@@ -291,10 +335,10 @@ export const UnifiedBoard3DView: React.FC = () => {
   return (
     <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-950 text-slate-200" aria-label="Connected lightweight board 3D view">
       <header className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-slate-800 bg-slate-900 px-3 py-2">
-        <div className="min-w-0"><p className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-indigo-300">Lightweight board-context 3D</p><h1 className="truncate text-sm font-bold text-white">{board.name} · {selectedComponent ? `${selectedComponent.referenceDesignator} selected` : 'board overview'}</h1></div>
+        <div className="min-w-0"><p className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-indigo-300">Evidence-backed board-context 3D</p><h1 className="truncate text-sm font-bold text-white">{board.name} · {selectedComponent ? `${selectedComponent.referenceDesignator} selected` : 'board overview'}</h1></div>
         <div className="flex flex-wrap items-center gap-2">
           <label className="inline-flex h-8 items-center gap-2 rounded-lg border border-slate-700 bg-slate-800 px-2.5 text-[10px] font-semibold text-slate-300"><Gauge className="h-3.5 w-3.5" /> Quality<select value={quality} onChange={(event) => setQuality(event.target.value as Board3DQuality)} className="bg-transparent text-white outline-none"><option value="low">Low</option><option value="balanced">Balanced</option><option value="high">High</option></select></label>
-          <button type="button" onClick={() => setShowEnclosure((value) => !value)} aria-pressed={showEnclosure} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-800 px-2.5 text-[10px] font-semibold text-slate-300 hover:bg-slate-700"><Eye className="h-3.5 w-3.5" /> {showEnclosure ? 'Hide enclosure' : 'Show enclosure'}</button>
+          <button type="button" onClick={() => setShowEnclosure((value) => !value)} aria-pressed={showEnclosure} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-700 bg-slate-800 px-2.5 text-[10px] font-semibold text-slate-300 hover:bg-slate-700"><Eye className="h-3.5 w-3.5" /> {showEnclosure ? 'Hide mechanical evidence' : 'Show mechanical evidence'}</button>
           <button type="button" onClick={() => setActiveView('board-designer')} className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-indigo-500 px-2.5 text-[10px] font-bold text-white hover:bg-indigo-400"><CircuitBoard className="h-3.5 w-3.5" /> Back to PCB</button>
         </div>
       </header>
@@ -302,15 +346,15 @@ export const UnifiedBoard3DView: React.FC = () => {
       <div className="flex min-h-0 flex-1">
         <div className="relative min-w-0 flex-1"><div ref={mountRef} className="absolute inset-0" /></div>
         <aside className="w-72 shrink-0 overflow-y-auto border-l border-slate-800 bg-slate-900/80 p-3">
-          <div className="flex items-center gap-2"><Layers3 className="h-4 w-4 text-indigo-400" /><h2 className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Preview context</h2></div>
-          <dl className="mt-3 space-y-2 rounded-xl border border-slate-800 bg-slate-950/50 p-3 text-xs"><div><dt className="text-[9px] uppercase text-slate-500">Board</dt><dd className="mt-0.5 font-semibold text-slate-200">{size.width.toFixed(1)} × {size.height.toFixed(1)} mm · {board.layerCount} layers</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Placed components</dt><dd className="mt-0.5 text-slate-300">{placedComponents.length} of {components.length}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Selected object</dt><dd className="mt-0.5 text-slate-300">{selectedComponent ? `${selectedComponent.referenceDesignator} · ${selectedComponent.componentName}` : 'None'}</dd></div></dl>
+          <div className="flex items-center gap-2"><Layers3 className="h-4 w-4 text-indigo-400" /><h2 className="text-[9px] font-extrabold uppercase tracking-[0.14em] text-slate-500">Representation evidence</h2></div>
+          <dl className="mt-3 space-y-2 rounded-xl border border-slate-800 bg-slate-950/50 p-3 text-xs"><div><dt className="text-[9px] uppercase text-slate-500">Board outline</dt><dd className="mt-0.5 font-semibold text-slate-200">{size.width.toFixed(1)} × {size.height.toFixed(1)} mm{board.layerCount ? ` · ${board.layerCount} layers recorded` : ' · layer count unresolved'}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Renderable components</dt><dd className="mt-0.5 text-slate-300">{renderableComponents.length} of {components.length}</dd></div><div><dt className="text-[9px] uppercase text-slate-500">Selected object</dt><dd className="mt-0.5 text-slate-300">{selectedComponent ? `${selectedComponent.referenceDesignator} · ${selectedComponent.componentName}` : 'None'}</dd></div></dl>
 
           <p className="mt-4 text-[9px] font-bold uppercase tracking-wide text-slate-500">Components on this board</p>
-          <div className="mt-2 space-y-1.5">{components.map((component) => <button key={component.id} type="button" onClick={() => setActiveComponent(component.id)} className={`flex w-full items-center gap-2 rounded-lg border p-2 text-left focus:outline-none focus:ring-2 focus:ring-indigo-500 ${component.id === activeComponentId ? 'border-amber-500 bg-amber-950/50' : 'border-slate-800 bg-slate-950/40 hover:border-slate-700'}`}><Boxes className="h-3.5 w-3.5 shrink-0 text-slate-500" /><span className="min-w-0 flex-1"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{component.componentName}</span></span><Focus className="h-3.5 w-3.5 text-slate-500" /></button>)}</div>
+          <div className="mt-2 space-y-1.5">{componentRepresentations.map(({ component, hasPlacement, hasDimensions, renderable }) => <button key={component.id} type="button" onClick={() => setActiveComponent(component.id)} className={`flex w-full items-center gap-2 rounded-lg border p-2 text-left focus:outline-none focus:ring-2 focus:ring-indigo-500 ${component.id === activeComponentId ? 'border-amber-500 bg-amber-950/50' : 'border-slate-800 bg-slate-950/40 hover:border-slate-700'}`}><Boxes className="h-3.5 w-3.5 shrink-0 text-slate-500" /><span className="min-w-0 flex-1"><span className="block text-[10px] font-bold text-slate-200">{component.referenceDesignator}</span><span className="block truncate text-[9px] text-slate-500">{renderable ? 'Placement + package dimensions available' : !hasPlacement ? 'Placement unresolved' : !hasDimensions ? 'Package dimensions unresolved' : 'Representation unresolved'}</span></span><Focus className="h-3.5 w-3.5 text-slate-500" /></button>)}</div>
 
-          {(size.assumed || unresolvedDimensions.length > 0 || unplaced.length > 0) && <div className="mt-4 rounded-xl border border-amber-700/60 bg-amber-950/50 p-3 text-[10px] leading-5 text-amber-200"><div className="flex gap-2"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" /><div><p className="font-bold text-amber-300">Preview assumptions remain</p>{size.assumed && <p>Board outline is missing; a 50 × 30 mm preview envelope is shown and is not authoritative.</p>}{unresolvedDimensions.length > 0 && <p>{unresolvedDimensions.length} component(s) use provisional 6 × 6 × 2 mm bodies because exact package dimensions are missing.</p>}{unplaced.length > 0 && <p>{unplaced.length} unplaced component(s) are listed but not rendered on the board.</p>}</div></div></div>}
+          {(unresolvedDimensions.length > 0 || unplaced.length > 0) && <div className="mt-4 rounded-xl border border-amber-700/60 bg-amber-950/50 p-3 text-[10px] leading-5 text-amber-200"><div className="flex gap-2"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" /><div><p className="font-bold text-amber-300">Unresolved representation data</p>{unresolvedDimensions.length > 0 && <p>{unresolvedDimensions.length} placed component(s) are not rendered because exact positive package dimensions are missing.</p>}{unplaced.length > 0 && <p>{unplaced.length} component(s) are not rendered because explicit PCB coordinates are missing.</p>}</div></div></div>}
 
-          <div className="mt-4 rounded-xl border border-sky-800 bg-sky-950/40 p-3 text-[10px] leading-5 text-sky-200">This event-driven GL preview is for recognition and assembly context only. It is not exact STEP/B-Rep geometry and cannot authorize clearance, interference, mass, or manufacturing.</div>
+          <div className="mt-4 rounded-xl border border-sky-800 bg-sky-950/40 p-3 text-[10px] leading-5 text-sky-200">Only recorded outline, placement, package dimensions, and mechanical feature dimensions are visualized. This is still a recognition/context preview, not STEP/B-Rep geometry and not manufacturing clearance evidence.</div>
         </aside>
       </div>
     </section>

--- a/src/components/studio/UnifiedBOMWorkbench.tsx
+++ b/src/components/studio/UnifiedBOMWorkbench.tsx
@@ -26,11 +26,13 @@ export const UnifiedBOMWorkbench: React.FC = () => {
     updateProjectState,
     updateBOMItem,
     updateBoardComponent,
+    setActiveBoard,
     setActiveView,
   } = store;
   const {
     activeComponentId,
     activeBoardId,
+    setActiveBoard: setContextBoard,
     setActiveComponent,
     beginHandoff,
   } = useStudioContextStore();
@@ -39,21 +41,39 @@ export const UnifiedBOMWorkbench: React.FC = () => {
     () => boardComponents.filter((component) => !activeBoardId || component.boardId === activeBoardId),
     [activeBoardId, boardComponents],
   );
-  const selectedComponent = boardComponents.find((component) => component.id === activeComponentId)
-    || contextualComponents[0];
-  const selectedBomItem = selectedComponent?.bomItemId
-    ? bom.find((item) => item.id === selectedComponent.bomItemId)
+  const selectedComponent = boardComponents.find(
+    (component) => component.id === activeComponentId && (!activeBoardId || component.boardId === activeBoardId),
+  );
+  const selectedBomItem = selectedComponent
+    ? bom.find((item) => item.id === selectedComponent.bomItemId || item.componentId === selectedComponent.id)
     : undefined;
   const orderedBom = useMemo(() => {
     if (!selectedBomItem) return bom;
     return [selectedBomItem, ...bom.filter((item) => item.id !== selectedBomItem.id)];
   }, [bom, selectedBomItem]);
 
+  const focusComponent = (componentId: string) => {
+    const component = boardComponents.find((candidate) => candidate.id === componentId);
+    if (!component) return;
+    setContextBoard(component.boardId);
+    setActiveBoard(component.boardId);
+    setActiveComponent(component.id);
+  };
+
+  const componentForBomItem = (item: BOMItem) => {
+    if (item.componentId) {
+      const linked = boardComponents.find((component) => component.id === item.componentId);
+      if (linked) return linked;
+    }
+    return boardComponents.find((component) => component.bomItemId === item.id);
+  };
+
   const ensureLinkedBom = () => {
     if (!selectedComponent || selectedBomItem) return;
     const id = `bom_${Date.now()}`;
     const item: BOMItem = {
       id,
+      componentId: selectedComponent.id,
       blockName: selectedComponent.componentName,
       candidateComponent: selectedComponent.value || selectedComponent.componentName,
       partNumber: selectedComponent.partNumber || '',
@@ -92,7 +112,7 @@ export const UnifiedBOMWorkbench: React.FC = () => {
             <div>
               <p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">Connected sourcing record</p>
               <h1 id="unified-bom-title" className="mt-1 text-2xl font-bold tracking-tight text-slate-950">Bill of Materials</h1>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">BOM records stay attached to the same component instance used in Schematic, PCB, and 3D. Selecting a component above brings its linked sourcing row to the top.</p>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">BOM records stay attached to the same component instance used in Schematic and PCB. Hardware Studio does not guess a selected component when shared context is absent.</p>
             </div>
             <div className="flex flex-wrap gap-2">
               <button type="button" onClick={() => navigate('component-library')} className="inline-flex h-9 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 hover:bg-slate-100"><Boxes className="h-4 w-4" /> Components</button>
@@ -112,20 +132,21 @@ export const UnifiedBOMWorkbench: React.FC = () => {
                 {selectedBomItem ? <div className="flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" /><p><strong>Linked BOM record:</strong> {selectedBomItem.id}. Editing the highlighted row updates this component’s sourcing record.</p></div> : <button type="button" onClick={ensureLinkedBom} className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-3 text-sm font-semibold text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"><Plus className="h-4 w-4" /> Create linked BOM record</button>}
               </div>
             ) : (
-              <div className="mt-3 rounded-xl border border-dashed border-slate-300 p-4 text-center"><PackageSearch className="mx-auto h-6 w-6 text-slate-400" /><p className="mt-2 text-xs text-slate-500">No canonical component instance exists in this board context.</p><button type="button" onClick={() => setActiveView('component-library')} className="mt-3 rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-100">Open Component Library</button></div>
+              <div className="mt-3 rounded-xl border border-dashed border-slate-300 p-4 text-center"><PackageSearch className="mx-auto h-6 w-6 text-slate-400" /><p className="mt-2 text-xs text-slate-500">No canonical component is selected in this board context. Choose an explicit project instance below or return to Components.</p><button type="button" onClick={() => setActiveView('component-library')} className="mt-3 rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-100">Open Component Library</button></div>
             )}
 
-            {contextualComponents.length > 1 && <div className="mt-4"><p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Other board components</p><div className="mt-2 max-h-48 space-y-1 overflow-y-auto">{contextualComponents.map((component) => <button key={component.id} type="button" onClick={() => setActiveComponent(component.id)} className={`flex w-full items-center justify-between rounded-lg border px-2.5 py-2 text-left text-xs ${component.id === selectedComponent?.id ? 'border-indigo-300 bg-indigo-50' : 'border-slate-200 bg-white hover:bg-slate-50'}`}><span className="font-bold text-slate-800">{component.referenceDesignator}</span><span className="max-w-[190px] truncate text-slate-500">{component.componentName}</span></button>)}</div></div>}
+            {contextualComponents.length > 0 && <div className="mt-4"><p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">{selectedComponent ? 'Other board components' : 'Choose a board component'}</p><div className="mt-2 max-h-48 space-y-1 overflow-y-auto">{contextualComponents.map((component) => <button key={component.id} type="button" onClick={() => focusComponent(component.id)} className={`flex w-full items-center justify-between rounded-lg border px-2.5 py-2 text-left text-xs ${component.id === selectedComponent?.id ? 'border-indigo-300 bg-indigo-50' : 'border-slate-200 bg-white hover:bg-slate-50'}`}><span className="font-bold text-slate-800">{component.referenceDesignator}</span><span className="max-w-[190px] truncate text-slate-500">{component.componentName}</span></button>)}</div></div>}
           </aside>
 
           <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
             <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-4 py-3"><div className="flex items-center gap-2"><FileSpreadsheet className="h-4 w-4 text-slate-600" /><h2 className="text-sm font-bold text-slate-950">Project BOM records</h2></div><span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[10px] font-bold text-slate-600">{bom.length} records</span></div>
             <div className="overflow-x-auto">
-              <table className="min-w-[980px] w-full border-collapse text-left text-xs">
+              <table className="min-w-[1040px] w-full border-collapse text-left text-xs">
                 <thead className="bg-white text-[9px] font-bold uppercase tracking-wide text-slate-500"><tr className="border-b border-slate-200"><th className="px-3 py-2.5">Component</th><th className="px-3 py-2.5">Part number</th><th className="px-3 py-2.5">Package</th><th className="px-3 py-2.5">Qty</th><th className="px-3 py-2.5">Supplier</th><th className="px-3 py-2.5">Unit cost</th><th className="px-3 py-2.5">Status</th></tr></thead>
                 <tbody className="divide-y divide-slate-100">{orderedBom.map((item) => {
                   const highlighted = item.id === selectedBomItem?.id;
-                  return <tr key={item.id} className={highlighted ? 'bg-indigo-50' : 'hover:bg-slate-50'}><td className="px-3 py-2"><input value={item.blockName} onChange={(event) => updateBOMItem(item.id, { blockName: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-semibold text-slate-900 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" /></td><td className="px-3 py-2"><input value={item.partNumber || ''} onChange={(event) => updateBOMItem(item.id, { partNumber: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Manufacturer PN" /></td><td className="px-3 py-2"><input value={item.packageSize || ''} onChange={(event) => updateBOMItem(item.id, { packageSize: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Footprint/package" /></td><td className="px-3 py-2"><input type="number" min={1} value={item.quantity} onChange={(event) => updateBOMItem(item.id, { quantity: Math.max(1, Number(event.target.value) || 1) })} className="w-16 rounded border border-slate-200 bg-white px-2 py-1 text-center" /></td><td className="px-3 py-2"><input value={item.supplier || ''} onChange={(event) => updateBOMItem(item.id, { supplier: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Supplier" /></td><td className="px-3 py-2"><input value={item.costEstimate || ''} onChange={(event) => updateBOMItem(item.id, { costEstimate: event.target.value })} className="w-24 rounded border border-slate-200 bg-white px-2 py-1 text-right font-mono" placeholder="0.00" /></td><td className="px-3 py-2"><select value={item.status} onChange={(event) => updateBOMItem(item.id, { status: event.target.value as NonNullable<BOMItem['status']> })} className="rounded border border-slate-200 bg-white px-2 py-1">{statusOptions.map((status) => <option key={status} value={status}>{status}</option>)}</select></td></tr>;
+                  const linkedComponent = componentForBomItem(item);
+                  return <tr key={item.id} className={highlighted ? 'bg-indigo-50' : 'hover:bg-slate-50'}><td className="px-3 py-2"><div className="flex min-w-[13rem] items-center gap-1.5">{linkedComponent && <button type="button" onClick={() => focusComponent(linkedComponent.id)} className="inline-flex h-7 shrink-0 items-center gap-1 rounded border border-slate-300 bg-white px-2 text-[9px] font-semibold text-slate-600 hover:border-indigo-300 hover:text-indigo-700" title={`Focus ${linkedComponent.referenceDesignator}`}><Link2 className="h-3 w-3" /> {linkedComponent.referenceDesignator}</button>}<input value={item.blockName} onChange={(event) => updateBOMItem(item.id, { blockName: event.target.value })} className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1.5 py-1 font-semibold text-slate-900 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" /></div></td><td className="px-3 py-2"><input value={item.partNumber || ''} onChange={(event) => updateBOMItem(item.id, { partNumber: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Manufacturer PN" /></td><td className="px-3 py-2"><input value={item.packageSize || ''} onChange={(event) => updateBOMItem(item.id, { packageSize: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 font-mono text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Footprint/package" /></td><td className="px-3 py-2"><input type="number" min={1} value={item.quantity} onChange={(event) => updateBOMItem(item.id, { quantity: Math.max(1, Number(event.target.value) || 1) })} className="w-16 rounded border border-slate-200 bg-white px-2 py-1 text-center" /></td><td className="px-3 py-2"><input value={item.supplier || ''} onChange={(event) => updateBOMItem(item.id, { supplier: event.target.value })} className="w-full rounded border border-transparent bg-transparent px-1.5 py-1 text-slate-700 hover:border-slate-200 focus:border-indigo-400 focus:bg-white focus:outline-none" placeholder="Supplier" /></td><td className="px-3 py-2"><input value={item.costEstimate || ''} onChange={(event) => updateBOMItem(item.id, { costEstimate: event.target.value })} className="w-24 rounded border border-slate-200 bg-white px-2 py-1 text-right font-mono" placeholder="0.00" /></td><td className="px-3 py-2"><select value={item.status} onChange={(event) => updateBOMItem(item.id, { status: event.target.value as NonNullable<BOMItem['status']> })} className="rounded border border-slate-200 bg-white px-2 py-1">{statusOptions.map((status) => <option key={status} value={status}>{status}</option>)}</select></td></tr>;
                 })}</tbody>
               </table>
               {bom.length === 0 && <div className="p-10 text-center"><FileSpreadsheet className="mx-auto h-7 w-7 text-slate-400" /><p className="mt-2 text-sm font-bold text-slate-800">No BOM records yet</p><p className="mt-1 text-xs text-slate-500">Select a project component and create its linked sourcing record. Generic architecture blocks are not silently converted into purchasable parts.</p></div>}

--- a/src/components/studio/UnifiedBoardDRCWorkbench.tsx
+++ b/src/components/studio/UnifiedBoardDRCWorkbench.tsx
@@ -41,21 +41,21 @@ export const UnifiedBoardDRCWorkbench: React.FC = () => {
     setActiveNet,
     beginHandoff,
   } = useStudioContextStore();
-  const [results, setResults] = useState<ReviewResult[]>(() => runBoardDRC(useProjectStore.getState()));
+  const [results, setResults] = useState<ReviewResult[]>(() => runBoardDRC({ ...useProjectStore.getState(), activeBoardId: activeBoardId || '' }));
 
-  const board = boards.find((candidate) => candidate.id === activeBoardId) || boards[0];
-  const boardId = board?.id || activeBoardId || '';
+  const board = boards.find((candidate) => candidate.id === activeBoardId);
+  const boardId = board?.id || '';
   const boardComponentIds = useMemo(
-    () => new Set(boardComponents.filter((component) => !boardId || component.boardId === boardId).map((component) => component.id)),
+    () => new Set(boardComponents.filter((component) => component.boardId === boardId).map((component) => component.id)),
     [boardComponents, boardId],
   );
   const boardTraceIds = useMemo(
-    () => new Set(traces.filter((trace) => !boardId || trace.boardId === boardId).map((trace) => trace.id)),
+    () => new Set(traces.filter((trace) => trace.boardId === boardId).map((trace) => trace.id)),
     [boardId, traces],
   );
 
   const boardResults = useMemo(() => results.filter((result) => {
-    if (!boardId) return true;
+    if (!boardId) return false;
     if (result.linkedObjectType === 'board') return result.linkedObjectId === boardId;
     if (result.linkedObjectType === 'component') return boardComponentIds.has(result.linkedObjectId);
     if (result.linkedObjectType === 'trace') return boardTraceIds.has(result.linkedObjectId);
@@ -73,12 +73,16 @@ export const UnifiedBoardDRCWorkbench: React.FC = () => {
     info: boardResults.filter((result) => result.severity === 'Info').length,
   }), [boardResults]);
 
+  const runChecks = () => {
+    if (!boardId) return;
+    setResults(runBoardDRC({ ...useProjectStore.getState(), activeBoardId: boardId }));
+  };
+
   const openFinding = (result: ReviewResult) => {
+    if (!boardId) return;
     beginHandoff('pcb-drc', 'pcb-drc');
-    if (boardId) {
-      setContextBoard(boardId);
-      setActiveBoard(boardId);
-    }
+    setContextBoard(boardId);
+    setActiveBoard(boardId);
 
     if (result.linkedObjectType === 'component') {
       setActiveComponent(result.linkedObjectId);
@@ -86,7 +90,7 @@ export const UnifiedBoardDRCWorkbench: React.FC = () => {
       const net = nets.find((candidate) => candidate.id === result.linkedObjectId || candidate.netName === result.linkedObjectId);
       setActiveNet(net?.netName || result.linkedObjectId);
     } else if (result.linkedObjectType === 'trace') {
-      const trace = traces.find((candidate) => candidate.id === result.linkedObjectId);
+      const trace = traces.find((candidate) => candidate.id === result.linkedObjectId && candidate.boardId === boardId);
       if (trace?.netName) setActiveNet(trace.netName);
     }
 
@@ -98,8 +102,8 @@ export const UnifiedBoardDRCWorkbench: React.FC = () => {
       <section className="grid h-full place-items-center overflow-y-auto bg-slate-50 p-6 text-center">
         <div className="max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
           <CircuitBoard className="mx-auto h-8 w-8 text-slate-400" aria-hidden="true" />
-          <h1 className="mt-3 text-xl font-bold text-slate-950">Create a board before running PCB checks</h1>
-          <p className="mt-2 text-sm leading-6 text-slate-600">DRC evaluates canonical board geometry, component placement, traces, nets, and constraints. There is no board context to inspect yet.</p>
+          <h1 className="mt-3 text-xl font-bold text-slate-950">Select a real board before running PCB checks</h1>
+          <p className="mt-2 text-sm leading-6 text-slate-600">DRC needs explicit shared board context. Hardware Studio will not substitute the first board in the project or run checks against an ambiguous physical target.</p>
           <button type="button" onClick={() => setActiveView('board-settings')} className="mt-4 inline-flex h-10 items-center gap-2 rounded-lg bg-slate-950 px-4 text-sm font-semibold text-white hover:bg-slate-800">Open board settings <ArrowRight className="h-4 w-4" /></button>
         </div>
       </section>
@@ -114,10 +118,10 @@ export const UnifiedBoardDRCWorkbench: React.FC = () => {
             <div>
               <div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-indigo-600" aria-hidden="true" /><p className="text-[10px] font-extrabold uppercase tracking-[0.14em] text-indigo-700">PCB checks in shared context</p></div>
               <h1 id="unified-drc-title" className="mt-2 text-2xl font-bold tracking-tight text-slate-950">{board.name} design-rule findings</h1>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">Findings reference the same board components, nets, and traces used by Schematic and PCB. Open a finding to carry its responsible object back into Board Designer.</p>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">Findings reference the same explicit board components, nets, and traces used by Schematic and PCB. Open a finding to carry its responsible object back into Board Designer.</p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <button type="button" onClick={() => setResults(runBoardDRC(useProjectStore.getState()))} className="inline-flex h-9 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 hover:bg-slate-100"><RefreshCw className="h-4 w-4" /> Run checks again</button>
+              <button type="button" onClick={runChecks} className="inline-flex h-9 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 hover:bg-slate-100"><RefreshCw className="h-4 w-4" /> Run checks again</button>
               <button type="button" onClick={() => setActiveView('board-designer')} className="inline-flex h-9 items-center gap-2 rounded-lg bg-slate-950 px-3 text-xs font-semibold text-white hover:bg-slate-800"><CircuitBoard className="h-4 w-4" /> Open PCB <ArrowRight className="h-4 w-4" /></button>
             </div>
           </div>
@@ -138,7 +142,7 @@ export const UnifiedBoardDRCWorkbench: React.FC = () => {
           <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-8 text-center text-emerald-950 shadow-sm">
             <CheckCircle2 className="mx-auto h-8 w-8 text-emerald-600" aria-hidden="true" />
             <h2 className="mt-3 text-lg font-bold">No current board-rule findings</h2>
-            <p className="mt-1 text-sm text-emerald-800">This means the implemented DRC checks passed for the current project state. It is not a substitute for manufacturer review or a qualified external CAD tool.</p>
+            <p className="mt-1 text-sm text-emerald-800">This means the implemented DRC checks passed for the explicit current board state. It is not a substitute for manufacturer review or a qualified external CAD tool.</p>
           </div>
         ) : (
           <div className="space-y-2">

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
-import { useProjectStore } from '../../store/projectStore';
+import React from 'react';
 import { useStudioContextStore, type MechanicalWorkbenchMode } from '../../store/studioContextStore';
 import { ComponentLibraryWorkbench } from '../component-library/ComponentLibraryWorkbench';
 import { EngineeringBoardWorkbench } from '../board/EngineeringBoardWorkbench';
@@ -9,25 +8,7 @@ import { EngineeringSchematicWorkbench } from '../schematic/EngineeringSchematic
 import { EngineeringMechanicalWorkbench } from '../mechanical/EngineeringMechanicalWorkbench';
 import { UnifiedBoard3DView } from '../mechanical/UnifiedBoard3DView';
 
-export const UnifiedComponentLibraryWorkbench: React.FC = () => {
-  const boardComponents = useProjectStore((state) => state.boardComponents || []);
-  const previousIds = useRef(new Set(boardComponents.map((component) => component.id)));
-  const setActiveBoard = useStudioContextStore((state) => state.setActiveBoard);
-  const setActiveComponentDefinition = useStudioContextStore((state) => state.setActiveComponentDefinition);
-  const setActiveComponent = useStudioContextStore((state) => state.setActiveComponent);
-
-  useEffect(() => {
-    const previous = previousIds.current;
-    const added = boardComponents.find((component) => !previous.has(component.id));
-    previousIds.current = new Set(boardComponents.map((component) => component.id));
-    if (!added) return;
-    setActiveBoard(added.boardId || null);
-    setActiveComponentDefinition(added.libraryId || null);
-    setActiveComponent(added.id);
-  }, [boardComponents, setActiveBoard, setActiveComponent, setActiveComponentDefinition]);
-
-  return <ComponentLibraryWorkbench />;
-};
+export const UnifiedComponentLibraryWorkbench: React.FC = () => <ComponentLibraryWorkbench />;
 
 export const UnifiedSchematicWorkbench: React.FC = () => <EngineeringSchematicWorkbench />;
 


### PR DESCRIPTION
Parent: #93 / #66
Execution spec: `docs/development/STUDIO_UX_CONVERGENCE_EXECUTION_PLAN.md`

## What this converges

This slice removes implicit context and plausible-looking fallback geometry from the connected Electronics path.

### Component Library
- definition selection updates shared definition context explicitly;
- adding a canonical project instance immediately sets the real board + definition + component context;
- existing instances for the selected definition can be focused or opened directly in Schematic, PCB, or BOM;
- adding a part requires an explicit board selection unless an already-explicit shared board context exists;
- the adapter-side `useEffect`/`previousIds` new-record detector is removed.

### BOM
- no fallback to `contextualComponents[0]`;
- no component appears selected unless `activeComponentId` actually resolves in the active board context;
- newly created linked BOM rows store `componentId`;
- historical rows can still resolve through the component's `bomItemId` compatibility link;
- linked rows expose an explicit canonical-component focus action.

### DRC
- standalone PCB checks require a valid explicit `activeBoardId`;
- no `boards[0]` fallback;
- reruns are scoped to that board and finding navigation carries the linked component/net context back to PCB.

### Connected 3D
- no first-board fallback;
- no synthetic 50×30 board envelope;
- no invented PCB thickness: the authoritative outline is rendered as a plane because thickness is not available here;
- no 6×6×2 component bodies or guessed indexed positions;
- components render only with explicit coordinates + positive package dimensions;
- mechanical preview features render only with their required explicit dimensions;
- unresolved representation data remains visible and is not rendered as fake geometry.

## Tests

Adds `electronicsIdentityTruth.test.ts` to protect shared component/net context semantics, explicit Library ownership, BOM linkage/cross-probe, DRC board ownership, and no-guess 3D behavior.

## Completion gate

Do not merge until exact-head lint, typecheck, full tests, production build and deployment-status inspection complete. Vercel quota failure is recorded separately from code correctness.