### PR TITLE
U3.2: Cross-probe Electronics representations through shared context

### DIFF
--- a/src/__tests__/electronicsCrossProbe.test.ts
+++ b/src/__tests__/electronicsCrossProbe.test.ts
@@ -71,9 +71,10 @@ describe('Electronics representation cross-probing', () => {
     const projectStore = source('../store/projectStore.ts');
     const contextStore = source('../store/studioContextStore.ts');
 
-    expect(contextStore).toContain("entity: 'component-pin'");
-    expect(contextStore).toContain("entity: 'pcb-pad'");
-    expect(contextStore).toContain("entity: 'via'");
+    expect(contextStore).toContain("| 'component-pin'");
+    expect(contextStore).toContain("| 'pcb-pad'");
+    expect(contextStore).toContain("| 'via'");
+    expect(contextStore).toContain('selected: StudioSelection | null');
     expect(projectStore).not.toContain('StudioSelection');
     expect(projectStore).not.toContain('activeComponentDefinitionId');
   });

--- a/src/__tests__/electronicsCrossProbe.test.ts
+++ b/src/__tests__/electronicsCrossProbe.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { useStudioContextStore } from '../store/studioContextStore';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('Electronics representation cross-probing', () => {
+  beforeEach(() => useStudioContextStore.getState().clearContext());
+
+  it('attaches representation selection to existing board, component and net context', () => {
+    const store = useStudioContextStore.getState();
+    store.select({
+      entity: 'component-pin',
+      id: 'pin-u1-3',
+      label: 'U1.3 SDA',
+      boardId: 'board-main',
+      componentId: 'component-u1',
+      netName: 'I2C_SDA',
+    });
+
+    expect(useStudioContextStore.getState()).toMatchObject({
+      activeBoardId: 'board-main',
+      activeComponentId: 'component-u1',
+      activeNetName: 'I2C_SDA',
+      selected: {
+        entity: 'component-pin',
+        id: 'pin-u1-3',
+        boardId: 'board-main',
+        componentId: 'component-u1',
+        netName: 'I2C_SDA',
+      },
+    });
+  });
+
+  it('can change immediate representation without dropping canonical parent component context', () => {
+    const store = useStudioContextStore.getState();
+    store.setActiveComponent('component-u1');
+    store.select({ entity: 'wire', id: 'wire-7', boardId: 'board-main', netName: 'I2C_SDA' });
+
+    expect(useStudioContextStore.getState().activeComponentId).toBe('component-u1');
+    expect(useStudioContextStore.getState().selected?.entity).toBe('wire');
+    expect(useStudioContextStore.getState().activeNetName).toBe('I2C_SDA');
+  });
+
+  it('keeps Schematic cross-probing explicit and visually inspectable', () => {
+    const schematic = source('../components/schematic/EngineeringSchematicWorkbench.tsx');
+
+    expect(schematic).not.toContain("boards[0]?.id");
+    expect(schematic).toContain("entity: 'wire'");
+    expect(schematic).toContain("entity: 'component-pin'");
+    expect(schematic).toContain('Pins · select to cross-probe');
+    expect(schematic).toContain('selectPin(selectedComponent.id, pin.id)');
+    expect(schematic).toContain("netName: pin.netName || null");
+  });
+
+  it('keeps PCB pad, trace and via cross-probing inside the existing shared selection model', () => {
+    const pcb = source('../components/board/EngineeringBoardWorkbench.tsx');
+
+    expect(pcb).not.toContain('boards[0]?.id');
+    expect(pcb).toContain("entity: 'pcb-pad'");
+    expect(pcb).toContain("entity: 'trace'");
+    expect(pcb).toContain("entity: 'via'");
+    expect(pcb).toContain('Pads · select to cross-probe');
+    expect(pcb).toContain('selectPad(selectedComponent.id, pad.name)');
+    expect(pcb).toContain('assignment?.netName || null');
+  });
+
+  it('does not persist representation selection into canonical project storage', () => {
+    const projectStore = source('../store/projectStore.ts');
+    const contextStore = source('../store/studioContextStore.ts');
+
+    expect(contextStore).toContain("entity: 'component-pin'");
+    expect(contextStore).toContain("entity: 'pcb-pad'");
+    expect(contextStore).toContain("entity: 'via'");
+    expect(projectStore).not.toContain('StudioSelection');
+    expect(projectStore).not.toContain('activeComponentDefinitionId');
+  });
+});

--- a/src/__tests__/electronicsIdentityTruth.test.ts
+++ b/src/__tests__/electronicsIdentityTruth.test.ts
@@ -18,7 +18,7 @@ describe('Electronics canonical identity and representation truth', () => {
     expect(state.activeBoardId).toBe('board-main');
     expect(state.activeComponentId).toBe('component-u1');
     expect(state.activeNetName).toBe('VDD_3V3');
-    expect(state.selected).toEqual({ entity: 'net', id: 'VDD_3V3', label: 'VDD_3V3' });
+    expect(state.selected).toEqual({ entity: 'net', id: 'VDD_3V3', label: 'VDD_3V3', netName: 'VDD_3V3' });
 
     state.clearContext();
   });

--- a/src/components/board/EngineeringBoardWorkbench.tsx
+++ b/src/components/board/EngineeringBoardWorkbench.tsx
@@ -135,15 +135,19 @@ export const EngineeringBoardWorkbench: React.FC = () => {
       setActiveBoard(patch.activeBoardId || '');
     }
 
+    const latestProject = useProjectStore.getState();
+    const latestContext = useStudioContextStore.getState();
+    const boardIdForSelection = patch.activeBoardId ?? latestContext.activeBoardId ?? latestProject.activeBoardId ?? null;
+
     if (patch.selectedTraceId) {
-      const trace = traces.find((candidate) => candidate.id === patch.selectedTraceId);
+      const trace = (latestProject.traces || []).find((candidate) => candidate.id === patch.selectedTraceId);
       const parentComponentId = trace?.sourceAnchor?.componentId || trace?.targetAnchor?.componentId || undefined;
-      const netName = trace?.netName || (trace?.netId ? nets.find((net) => net.id === trace.netId)?.netName : undefined) || null;
+      const netName = trace?.netName || (trace?.netId ? (latestProject.nets || []).find((net) => net.id === trace.netId)?.netName : undefined) || null;
       select({
         entity: 'trace',
         id: patch.selectedTraceId,
         label: netName || patch.selectedTraceId,
-        boardId: trace?.boardId || viewState.activeBoardId || null,
+        boardId: trace?.boardId || boardIdForSelection,
         componentId: parentComponentId,
         netName,
       });
@@ -153,13 +157,13 @@ export const EngineeringBoardWorkbench: React.FC = () => {
     }
 
     if (patch.selectedViaId) {
-      const via = vias.find((candidate) => candidate.id === patch.selectedViaId);
-      const netName = via?.netId ? nets.find((net) => net.id === via.netId)?.netName || null : null;
+      const via = (latestProject.vias || []).find((candidate) => candidate.id === patch.selectedViaId);
+      const netName = via?.netId ? (latestProject.nets || []).find((net) => net.id === via.netId)?.netName || null : null;
       select({
         entity: 'via',
         id: patch.selectedViaId,
         label: netName ? `Via · ${netName}` : 'Via',
-        boardId: via?.boardId || viewState.activeBoardId || null,
+        boardId: via?.boardId || boardIdForSelection,
         netName,
       });
       setInspectorTab('selection');
@@ -168,12 +172,12 @@ export const EngineeringBoardWorkbench: React.FC = () => {
     }
 
     if (patch.selectedComponentId) {
-      const component = boardComponents.find((candidate) => candidate.id === patch.selectedComponentId);
+      const component = (latestProject.boardComponents || []).find((candidate) => candidate.id === patch.selectedComponentId);
       select({
         entity: 'component-instance',
         id: patch.selectedComponentId,
         label: component?.referenceDesignator || patch.selectedComponentId,
-        boardId: component?.boardId || viewState.activeBoardId || null,
+        boardId: component?.boardId || boardIdForSelection,
         componentId: patch.selectedComponentId,
         netName: patch.selectedNetName !== undefined ? patch.selectedNetName : undefined,
       });
@@ -187,7 +191,7 @@ export const EngineeringBoardWorkbench: React.FC = () => {
         entity: 'net',
         id: patch.selectedNetName,
         label: patch.selectedNetName,
-        boardId: viewState.activeBoardId || null,
+        boardId: boardIdForSelection,
         netName: patch.selectedNetName,
       });
       return;
@@ -201,7 +205,7 @@ export const EngineeringBoardWorkbench: React.FC = () => {
     ) {
       select(null);
     }
-  }, [boardComponents, nets, select, setActiveBoard, setContextBoard, traces, vias, viewState.activeBoardId]);
+  }, [select, setActiveBoard, setContextBoard]);
 
   const selectComponent = useCallback((componentId: string) => {
     updateView({

--- a/src/components/board/EngineeringBoardWorkbench.tsx
+++ b/src/components/board/EngineeringBoardWorkbench.tsx
@@ -73,13 +73,13 @@ export const EngineeringBoardWorkbench: React.FC = () => {
     activeBoardId: contextBoardId,
     activeComponentId,
     activeNetName,
+    selected: sharedSelection,
     setActiveBoard: setContextBoard,
-    setActiveComponent,
-    setActiveNet,
+    select,
     beginHandoff,
   } = useStudioContextStore();
 
-  const initialBoardId = [contextBoardId, store.activeBoardId, boards[0]?.id]
+  const initialBoardId = [contextBoardId, store.activeBoardId]
     .find((candidate): candidate is string => Boolean(candidate && boards.some((board) => board.id === candidate))) || null;
 
   const [viewState, setViewState] = useState<BoardDesignerUIState>({
@@ -108,6 +108,16 @@ export const EngineeringBoardWorkbench: React.FC = () => {
   const selectedComponent = boardComponents.find((component) => component.id === viewState.selectedComponentId) || null;
   const selectedTrace = traces.find((trace) => trace.id === viewState.selectedTraceId) || null;
   const selectedVia = vias.find((via) => via.id === viewState.selectedViaId) || null;
+  const selectedFootprint = selectedComponent ? getFootprint(selectedComponent.footprint) : null;
+  const selectedPad = sharedSelection?.entity === 'pcb-pad' && selectedComponent && selectedFootprint
+    ? selectedFootprint.pads.find((pad) => `${selectedComponent.id}:${pad.name}` === sharedSelection.id) || null
+    : null;
+  const selectedPadAssignment = selectedPad && selectedComponent
+    ? padNetAssignments.find((assignment) => (
+      (assignment.componentId === selectedComponent.id || assignment.referenceDesignator === selectedComponent.referenceDesignator)
+      && assignment.padName === selectedPad.name
+    )) || null
+    : null;
   const netRows = nets.map((net) => {
     const assignments = padNetAssignments.filter(
       (assignment) => assignment.netName === net.netName
@@ -119,15 +129,81 @@ export const EngineeringBoardWorkbench: React.FC = () => {
 
   const updateView = useCallback((patch: Partial<BoardDesignerUIState>) => {
     setViewState((previous) => ({ ...previous, ...patch }));
+
     if (patch.activeBoardId !== undefined) {
       setContextBoard(patch.activeBoardId);
       setActiveBoard(patch.activeBoardId || '');
     }
-    if (patch.selectedComponentId !== undefined) setActiveComponent(patch.selectedComponentId);
-    if (patch.selectedNetName !== undefined) setActiveNet(patch.selectedNetName);
-  }, [setActiveBoard, setActiveComponent, setActiveNet, setContextBoard]);
 
-  const selectComponent = (componentId: string) => {
+    if (patch.selectedTraceId) {
+      const trace = traces.find((candidate) => candidate.id === patch.selectedTraceId);
+      const parentComponentId = trace?.sourceAnchor?.componentId || trace?.targetAnchor?.componentId || undefined;
+      const netName = trace?.netName || (trace?.netId ? nets.find((net) => net.id === trace.netId)?.netName : undefined) || null;
+      select({
+        entity: 'trace',
+        id: patch.selectedTraceId,
+        label: netName || patch.selectedTraceId,
+        boardId: trace?.boardId || viewState.activeBoardId || null,
+        componentId: parentComponentId,
+        netName,
+      });
+      setInspectorTab('selection');
+      setInspectorOpen(true);
+      return;
+    }
+
+    if (patch.selectedViaId) {
+      const via = vias.find((candidate) => candidate.id === patch.selectedViaId);
+      const netName = via?.netId ? nets.find((net) => net.id === via.netId)?.netName || null : null;
+      select({
+        entity: 'via',
+        id: patch.selectedViaId,
+        label: netName ? `Via · ${netName}` : 'Via',
+        boardId: via?.boardId || viewState.activeBoardId || null,
+        netName,
+      });
+      setInspectorTab('selection');
+      setInspectorOpen(true);
+      return;
+    }
+
+    if (patch.selectedComponentId) {
+      const component = boardComponents.find((candidate) => candidate.id === patch.selectedComponentId);
+      select({
+        entity: 'component-instance',
+        id: patch.selectedComponentId,
+        label: component?.referenceDesignator || patch.selectedComponentId,
+        boardId: component?.boardId || viewState.activeBoardId || null,
+        componentId: patch.selectedComponentId,
+        netName: patch.selectedNetName !== undefined ? patch.selectedNetName : undefined,
+      });
+      setInspectorTab('selection');
+      setInspectorOpen(true);
+      return;
+    }
+
+    if (patch.selectedNetName) {
+      select({
+        entity: 'net',
+        id: patch.selectedNetName,
+        label: patch.selectedNetName,
+        boardId: viewState.activeBoardId || null,
+        netName: patch.selectedNetName,
+      });
+      return;
+    }
+
+    if (
+      patch.selectedComponentId === null
+      || patch.selectedTraceId === null
+      || patch.selectedViaId === null
+      || patch.selectedNetName === null
+    ) {
+      select(null);
+    }
+  }, [boardComponents, nets, select, setActiveBoard, setContextBoard, traces, vias, viewState.activeBoardId]);
+
+  const selectComponent = useCallback((componentId: string) => {
     updateView({
       selectedComponentId: componentId,
       selectedTraceId: null,
@@ -138,7 +214,33 @@ export const EngineeringBoardWorkbench: React.FC = () => {
     });
     setInspectorTab('selection');
     setInspectorOpen(true);
-  };
+  }, [updateView]);
+
+  const selectPad = useCallback((componentId: string, padName: string) => {
+    const component = boardComponents.find((candidate) => candidate.id === componentId);
+    if (!component) return;
+    const assignment = padNetAssignments.find((candidate) => (
+      (candidate.componentId === component.id || candidate.referenceDesignator === component.referenceDesignator)
+      && candidate.padName === padName
+    ));
+    setViewState((previous) => ({
+      ...previous,
+      selectedComponentId: component.id,
+      selectedTraceId: null,
+      selectedViaId: null,
+      selectedNetName: assignment?.netName || null,
+    }));
+    select({
+      entity: 'pcb-pad',
+      id: `${component.id}:${padName}`,
+      label: `${component.referenceDesignator}.${padName}`,
+      boardId: component.boardId,
+      componentId: component.id,
+      netName: assignment?.netName || null,
+    });
+    setInspectorTab('selection');
+    setInspectorOpen(true);
+  }, [boardComponents, padNetAssignments, select]);
 
   const runDrc = () => {
     const results = runBoardDRC({ ...useProjectStore.getState(), activeBoardId: viewState.activeBoardId || '' });
@@ -303,7 +405,7 @@ export const EngineeringBoardWorkbench: React.FC = () => {
           </EngineeringDock>
         )}
 
-        <EngineeringInspector open={inspectorOpen} subtitle="Selection and nets" onClose={() => setInspectorOpen(false)} widthClassName="w-[320px]">
+        <EngineeringInspector open={inspectorOpen} subtitle={selectedPad ? `${selectedComponent?.referenceDesignator}.${selectedPad.name}` : selectedTrace ? `Trace · ${selectedTrace.netName || 'unassigned'}` : selectedVia ? 'Via' : selectedComponent ? selectedComponent.referenceDesignator : 'Selection and nets'} onClose={() => setInspectorOpen(false)} widthClassName="w-[320px]">
           <div className="flex border-b border-slate-200 bg-white p-1">
             {([['selection', 'Selection', PanelRight], ['nets', 'Nets', Network]] as const).map(([id, label, Icon]) => (
               <button key={id} type="button" onClick={() => setInspectorTab(id)} className={`h-7 flex-1 text-[9px] font-semibold ${inspectorTab === id ? 'bg-slate-950 text-white' : 'text-slate-600 hover:bg-slate-100'}`}><Icon className="mr-1 inline h-3 w-3" />{label}</button>
@@ -327,11 +429,37 @@ export const EngineeringBoardWorkbench: React.FC = () => {
                   <div className="grid grid-cols-2 gap-px border border-slate-200 bg-slate-200 text-[9px]">
                     {[
                       ['Side', selectedComponent.side || 'Top'],
-                      ['Pads', String(getFootprint(selectedComponent.footprint).pads.length)],
+                      ['Pads', String(selectedFootprint?.pads.length || 0)],
                       ['Criticality', selectedComponent.placementCriticality],
                       ['Status', selectedComponent.placementStatus || 'Placed'],
                     ].map(([label, value]) => <div key={label} className="bg-white p-2"><p className="text-slate-400">{label}</p><p className="mt-0.5 truncate font-semibold text-slate-800">{value}</p></div>)}
                   </div>
+                  {selectedFootprint && selectedFootprint.pads.length > 0 && (
+                    <div>
+                      <p className="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Pads · select to cross-probe</p>
+                      <div className="max-h-44 overflow-y-auto border-y border-slate-200">
+                        {selectedFootprint.pads.map((pad) => {
+                          const assignment = padNetAssignments.find((candidate) => (
+                            (candidate.componentId === selectedComponent.id || candidate.referenceDesignator === selectedComponent.referenceDesignator)
+                            && candidate.padName === pad.name
+                          ));
+                          const active = selectedPad?.name === pad.name;
+                          return (
+                            <button key={pad.name} type="button" onClick={() => selectPad(selectedComponent.id, pad.name)} className={`grid w-full grid-cols-[3rem_minmax(0,1fr)_5.5rem] gap-2 border-b border-slate-100 px-1 py-1.5 text-left text-[9px] last:border-b-0 ${active ? 'bg-indigo-50' : 'hover:bg-slate-50'}`}>
+                              <span className={`font-mono ${active ? 'font-bold text-indigo-700' : 'text-slate-500'}`}>{pad.name}</span>
+                              <span className="truncate text-slate-600">{pad.widthMm.toFixed(2)} × {pad.heightMm.toFixed(2)} mm</span>
+                              <span className={`truncate text-right ${assignment?.netName ? 'text-slate-600' : 'text-slate-400'}`}>{assignment?.netName || 'unassigned'}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                      {selectedPad && (
+                        <div className="mt-2 border-l-2 border-indigo-500 bg-indigo-50 px-2 py-1.5 text-[9px] leading-4 text-indigo-900">
+                          <strong>Pad {selectedPad.name}</strong> · {selectedPadAssignment?.netName ? `net ${selectedPadAssignment.netName}` : 'no project net assignment'}
+                        </div>
+                      )}
+                    </div>
+                  )}
                   <div className="flex gap-1">
                     <button type="button" onClick={rotateSelected} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-700">Rotate 90°</button>
                     <button type="button" onClick={() => updateBoardComponent(selectedComponent.id, { side: selectedComponent.side === 'Bottom' ? 'Top' : 'Bottom' })} className="h-8 flex-1 border border-slate-300 bg-white text-[9px] font-semibold text-slate-700">Flip side</button>
@@ -342,16 +470,16 @@ export const EngineeringBoardWorkbench: React.FC = () => {
                   <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Trace</p>
                   <p className="text-[12px] font-semibold text-slate-950">{selectedTrace.netName || 'Unnamed net'}</p>
                   <label className="block text-[9px] text-slate-500">Width mm<input type="number" step="0.05" value={selectedTrace.width || 0.25} onChange={(event) => updateTrace(selectedTrace.id, { width: Number.parseFloat(event.target.value) || 0.25 })} className="mt-1 h-8 w-full border border-slate-300 bg-white px-2 font-mono text-[10px]" /></label>
-                  <p className="text-[9px] text-slate-500">{selectedTrace.layerId || 'top-copper'} · {selectedTrace.points?.length || 0} vertices · {selectedTrace.status || 'Draft'}</p>
+                  <p className="text-[9px] text-slate-500">{selectedTrace.layerId || 'top-copper'} · {selectedTrace.points?.length || 0} vertices · {selectedTrace.status || 'Draft'} · shared trace {selectedTrace.id}</p>
                 </div>
               ) : selectedVia ? (
                 <div>
                   <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Via</p>
                   <p className="mt-1 font-mono text-[10px] text-slate-700">{selectedVia.x?.toFixed(2)}, {selectedVia.y?.toFixed(2)} mm</p>
-                  <p className="mt-2 text-[9px] text-slate-500">Ø {selectedVia.outerDiameter || 0.6} / drill {selectedVia.drillDiameter || 0.3} mm</p>
+                  <p className="mt-2 text-[9px] text-slate-500">Ø {selectedVia.outerDiameter || 0.6} / drill {selectedVia.drillDiameter || 0.3} mm · {sharedSelection?.entity === 'via' && sharedSelection.netName ? `net ${sharedSelection.netName}` : 'net unresolved'}</p>
                 </div>
               ) : (
-                <p className="text-[10px] leading-5 text-slate-500">Select a footprint, trace, or via. The Inspector edits that object without changing workspaces.</p>
+                <p className="text-[10px] leading-5 text-slate-500">Select a footprint, trace, or via. Pads are visible inside a selected footprint so you can cross-probe without guessing tiny canvas targets.</p>
               )}
             </div>
           ) : (
@@ -384,7 +512,10 @@ export const EngineeringBoardWorkbench: React.FC = () => {
                 type="button"
                 onClick={() => {
                   if (result.linkedObjectType === 'component') selectComponent(result.linkedObjectId);
-                  if (result.linkedObjectType === 'net') setActiveNet(result.linkedObjectId);
+                  if (result.linkedObjectType === 'net') {
+                    select({ entity: 'net', id: result.linkedObjectId, label: result.linkedObjectId, boardId: activeBoard.id, netName: result.linkedObjectId });
+                    setViewState((previous) => ({ ...previous, selectedNetName: result.linkedObjectId }));
+                  }
                 }}
                 className="border-l-2 border-amber-500 bg-amber-50 px-2 py-1.5 text-left"
               >
@@ -399,7 +530,7 @@ export const EngineeringBoardWorkbench: React.FC = () => {
 
       <EngineeringStatusBar
         left={viewState.isRouting ? `Routing ${viewState.selectedNetName || 'net'} · click to fix segments · finish on matching anchor · Esc cancels` : viewState.activeTool === 'route' ? 'Route: click a pad/via/trace endpoint to begin. Empty-space starts are rejected.' : 'Select and move footprints directly. Drag unplaced components from the browser.'}
-        center={`${viewState.activeLayerId} · ${configuredRouteWidth ? `configured width ${routeWidthMm.toFixed(2)} mm` : 'no explicit trace-width rule; new routes remain draft evidence'}`}
+        center={selectedPad ? `${selectedComponent?.referenceDesignator}.${selectedPad.name} · ${selectedPadAssignment?.netName || 'unassigned'}` : selectedTrace ? `Trace · ${selectedTrace.netName || 'unassigned'}` : selectedVia ? `Via · ${sharedSelection?.netName || 'net unresolved'}` : `${viewState.activeLayerId} · ${configuredRouteWidth ? `configured width ${routeWidthMm.toFixed(2)} mm` : 'no explicit trace-width rule; new routes remain draft evidence'}`}
         right={`${viewState.mouseXMm.toFixed(2)}, ${viewState.mouseYMm.toFixed(2)} mm`}
       />
     </section>

--- a/src/components/schematic/EngineeringSchematicWorkbench.tsx
+++ b/src/components/schematic/EngineeringSchematicWorkbench.tsx
@@ -53,12 +53,12 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
     activeBoardId,
     activeComponentId,
     activeNetName,
-    setActiveComponent,
-    setActiveNet,
+    selected: sharedSelection,
+    select,
     beginHandoff,
   } = useStudioContextStore();
 
-  const boardId = activeBoardId || store.activeBoardId || boards[0]?.id || '';
+  const boardId = activeBoardId || store.activeBoardId || '';
   const board = boards.find((candidate) => candidate.id === boardId);
   const contextualComponents = useMemo(
     () => boardComponents.filter((component) => !boardId || component.boardId === boardId),
@@ -88,12 +88,76 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
 
   const selectedComponent = boardComponents.find((component) => component.id === viewState.selectedComponentId) || null;
   const selectedWire = schematicWires.find((wire) => wire.id === viewState.selectedWireId) || null;
+  const selectedPin = sharedSelection?.entity === 'component-pin' && selectedComponent
+    ? (selectedComponent.pins || []).find((pin) => pin.id === sharedSelection.id) || null
+    : null;
 
   const updateView = useCallback((patch: Partial<SchematicUIState>) => {
     setViewState((previous) => ({ ...previous, ...patch }));
-    if (patch.selectedComponentId !== undefined) setActiveComponent(patch.selectedComponentId);
-    if (patch.selectedNetName !== undefined) setActiveNet(patch.selectedNetName);
-  }, [setActiveComponent, setActiveNet]);
+
+    if (patch.selectedWireId) {
+      const wire = schematicWires.find((candidate) => candidate.id === patch.selectedWireId);
+      select({
+        entity: 'wire',
+        id: patch.selectedWireId,
+        label: wire?.netName || patch.selectedWireId,
+        boardId: boardId || null,
+        netName: wire?.netName || null,
+      });
+      setInspectorOpen(true);
+      return;
+    }
+
+    if (patch.selectedComponentId) {
+      const component = boardComponents.find((candidate) => candidate.id === patch.selectedComponentId);
+      select({
+        entity: 'component-instance',
+        id: patch.selectedComponentId,
+        label: component?.referenceDesignator || patch.selectedComponentId,
+        boardId: component?.boardId || boardId || null,
+        componentId: patch.selectedComponentId,
+        netName: patch.selectedNetName !== undefined ? patch.selectedNetName : undefined,
+      });
+      setInspectorOpen(true);
+      return;
+    }
+
+    if (patch.selectedNetName) {
+      select({
+        entity: 'net',
+        id: patch.selectedNetName,
+        label: patch.selectedNetName,
+        boardId: boardId || null,
+        netName: patch.selectedNetName,
+      });
+      return;
+    }
+
+    if (patch.selectedComponentId === null || patch.selectedWireId === null || patch.selectedNetName === null) {
+      select(null);
+    }
+  }, [boardComponents, boardId, schematicWires, select]);
+
+  const selectPin = useCallback((componentId: string, pinId: string) => {
+    const component = boardComponents.find((candidate) => candidate.id === componentId);
+    const pin = component?.pins?.find((candidate) => candidate.id === pinId);
+    if (!component || !pin) return;
+    setViewState((previous) => ({
+      ...previous,
+      selectedComponentId: component.id,
+      selectedWireId: null,
+      selectedNetName: pin.netName || null,
+    }));
+    select({
+      entity: 'component-pin',
+      id: pin.id,
+      label: `${component.referenceDesignator}.${pin.pinNumber} ${pin.pinName}`,
+      boardId: component.boardId,
+      componentId: component.id,
+      netName: pin.netName || null,
+    });
+    setInspectorOpen(true);
+  }, [boardComponents, select]);
 
   const armPlacement = useCallback((componentId: string) => {
     updateView({
@@ -263,7 +327,7 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
 
         <EngineeringInspector
           open={inspectorOpen}
-          subtitle={selectedComponent ? selectedComponent.referenceDesignator : selectedWire ? selectedWire.netName : 'Select a symbol or wire'}
+          subtitle={selectedPin ? `${selectedComponent?.referenceDesignator}.${selectedPin.pinNumber}` : selectedComponent ? selectedComponent.referenceDesignator : selectedWire ? selectedWire.netName : 'Select a symbol or wire'}
           onClose={() => setInspectorOpen(false)}
           widthClassName="w-[300px]"
         >
@@ -286,17 +350,36 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
                   ].map(([label, value]) => <div key={label} className="bg-white p-2"><p className="text-slate-400">{label}</p><p className="mt-0.5 truncate font-semibold text-slate-800">{value}</p></div>)}
                 </div>
                 <div>
-                  <p className="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Pins</p>
+                  <p className="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Pins · select to cross-probe</p>
                   <div className="max-h-48 overflow-y-auto border-y border-slate-200">
-                    {(selectedComponent.pins || []).map((pin) => <div key={pin.id} className="grid grid-cols-[2.5rem_minmax(0,1fr)_5rem] gap-2 border-b border-slate-100 px-1 py-1.5 text-[9px] last:border-b-0"><span className="font-mono text-slate-500">{pin.pinNumber}</span><span className="truncate font-semibold text-slate-800">{pin.pinName}</span><span className="truncate text-right text-slate-400">{pin.netName || 'unconnected'}</span></div>)}
+                    {(selectedComponent.pins || []).map((pin) => {
+                      const active = selectedPin?.id === pin.id;
+                      return (
+                        <button
+                          key={pin.id}
+                          type="button"
+                          onClick={() => selectPin(selectedComponent.id, pin.id)}
+                          className={`grid w-full grid-cols-[2.5rem_minmax(0,1fr)_5rem] gap-2 border-b border-slate-100 px-1 py-1.5 text-left text-[9px] last:border-b-0 ${active ? 'bg-indigo-50' : 'hover:bg-slate-50'}`}
+                        >
+                          <span className={`font-mono ${active ? 'font-bold text-indigo-700' : 'text-slate-500'}`}>{pin.pinNumber}</span>
+                          <span className="truncate font-semibold text-slate-800">{pin.pinName}</span>
+                          <span className={`truncate text-right ${pin.netName ? 'text-slate-600' : 'text-slate-400'}`}>{pin.netName || 'unconnected'}</span>
+                        </button>
+                      );
+                    })}
                   </div>
+                  {selectedPin && (
+                    <div className="mt-2 border-l-2 border-indigo-500 bg-indigo-50 px-2 py-1.5 text-[9px] leading-4 text-indigo-900">
+                      <strong>{selectedPin.pinName}</strong> · pin {selectedPin.pinNumber} · {selectedPin.netName ? `net ${selectedPin.netName}` : 'no net assigned'}
+                    </div>
+                  )}
                 </div>
                 <button type="button" onClick={() => unplaceComponentFromSchematic(selectedComponent.id)} className="h-8 w-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-700 hover:bg-slate-100">Remove symbol from sheet</button>
               </div>
             ) : selectedWire ? (
-              <div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Net</p><p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedWire.netName}</p><p className="mt-2 text-[10px] leading-5 text-slate-500">{selectedWire.status || 'Connected'} · {selectedWire.points.length} route points</p></div>
+              <div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Wire / net</p><p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedWire.netName}</p><p className="mt-2 text-[10px] leading-5 text-slate-500">{selectedWire.status || 'Connected'} · {selectedWire.points.length} route points · shared wire {selectedWire.id}</p></div>
             ) : (
-              <p className="text-[10px] leading-5 text-slate-500">Select a symbol or wire. The Inspector describes engineering data; it does not navigate away from the sheet.</p>
+              <p className="text-[10px] leading-5 text-slate-500">Select a symbol or wire. Pins are visible inside a selected component so you can cross-probe without hunting for tiny canvas targets.</p>
             )}
           </div>
         </EngineeringInspector>
@@ -321,7 +404,7 @@ export const EngineeringSchematicWorkbench: React.FC = () => {
 
       <EngineeringStatusBar
         left={placementOverlay ? 'Placement: click a grid point to place the armed symbol · Esc cancels' : viewState.activeTool === 'wire' ? 'Wire: click a real pin to start · click corners · finish on another pin · Esc cancels' : viewState.activeTool === 'pan' ? 'Pan: drag the sheet · switch back to Select when finished' : 'Select: click or drag symbols · W wire · R rotate · Delete removes from this sheet'}
-        center={viewState.selectedNetName ? `Net ${viewState.selectedNetName}` : selectedComponent ? `${selectedComponent.referenceDesignator} selected` : 'No selection'}
+        center={selectedPin ? `${selectedComponent?.referenceDesignator}.${selectedPin.pinNumber} · ${selectedPin.netName || 'unconnected'}` : viewState.selectedNetName ? `Net ${viewState.selectedNetName}` : selectedComponent ? `${selectedComponent.referenceDesignator} selected` : selectedWire ? `Wire ${selectedWire.netName}` : 'No selection'}
         right={`${Math.round(viewState.zoom * 100)}%`}
       />
     </section>

--- a/src/store/studioContextStore.ts
+++ b/src/store/studioContextStore.ts
@@ -4,9 +4,12 @@ export type StudioContextEntity =
   | 'board'
   | 'component-definition'
   | 'component-instance'
+  | 'component-pin'
+  | 'pcb-pad'
   | 'net'
   | 'wire'
   | 'trace'
+  | 'via'
   | 'mechanical-object'
   | 'validation-item';
 
@@ -16,6 +19,10 @@ export interface StudioSelection {
   entity: StudioContextEntity;
   id: string;
   label?: string;
+  /** Parent context only. These IDs continue to point at existing project truth. */
+  boardId?: string | null;
+  componentId?: string | null;
+  netName?: string | null;
 }
 
 interface StudioContextState {
@@ -49,7 +56,7 @@ export const useStudioContextStore = create<StudioContextState>((set) => ({
 
   setActiveBoard: (activeBoardId) => set({
     activeBoardId,
-    selected: activeBoardId ? { entity: 'board', id: activeBoardId } : null,
+    selected: activeBoardId ? { entity: 'board', id: activeBoardId, boardId: activeBoardId } : null,
   }),
   setActiveComponentDefinition: (activeComponentDefinitionId) => set({
     activeComponentDefinitionId,
@@ -60,14 +67,19 @@ export const useStudioContextStore = create<StudioContextState>((set) => ({
   setActiveComponent: (activeComponentId) => set({
     activeComponentId,
     selected: activeComponentId
-      ? { entity: 'component-instance', id: activeComponentId }
+      ? { entity: 'component-instance', id: activeComponentId, componentId: activeComponentId }
       : null,
   }),
   setActiveNet: (activeNetName) => set({
     activeNetName,
-    selected: activeNetName ? { entity: 'net', id: activeNetName, label: activeNetName } : null,
+    selected: activeNetName ? { entity: 'net', id: activeNetName, label: activeNetName, netName: activeNetName } : null,
   }),
-  select: (selected) => set({ selected }),
+  select: (selected) => set((state) => ({
+    selected,
+    activeBoardId: selected?.boardId !== undefined ? selected.boardId : state.activeBoardId,
+    activeComponentId: selected?.componentId !== undefined ? selected.componentId : state.activeComponentId,
+    activeNetName: selected?.netName !== undefined ? selected.netName : state.activeNetName,
+  })),
   beginHandoff: (originView, returnView = originView) => set({ originView, returnView }),
   requestMechanicalMode: (requestedMechanicalMode) => set({ requestedMechanicalMode }),
   clearContext: () => set({


### PR DESCRIPTION
Parent: #96 / #66
Execution spec: `docs/development/STUDIO_UX_CONVERGENCE_EXECUTION_PLAN.md`

## What this slice changes

### Shared context
- extends the existing `StudioSelection` reference with optional parent `boardId`, `componentId`, and `netName` context;
- adds representation kinds for real existing component pins, PCB pads, and vias;
- selecting a representation updates shared parent context without creating or persisting duplicate engineering records.

### Schematic
- removes the remaining first-board fallback from the live workbench;
- wire selection publishes the real wire ID + net while preserving parent component context;
- selected component pins are visible as compact clickable Inspector rows for explicit cross-probing;
- a selected pin carries its real component, board and net (or explicit unresolved net) into shared context;
- Inspector/status bar show the immediate pin/wire representation instead of adding another navigation layer.

### PCB
- removes the remaining first-board fallback from the live workbench;
- trace and via selection publish their real representation IDs and net/board context;
- selected footprint pads are visible as compact clickable Inspector rows;
- pad cross-probing uses the existing project pad-net assignment when available and does not manufacture a net;
- DRC net navigation now uses the same shared selection model.

### Tests
- updates the prior Electronics identity truth contract for parent-aware selection;
- adds `electronicsCrossProbe.test.ts` to protect representation selection semantics, editor integration, no first-board fallback, and separation from canonical project storage.

## Non-goals
- no second selection store;
- no new Electronics navigation layer;
- no persisted UI selection in project data;
- no new pad project records or routing semantics.

## Completion gate
Do not merge until exact-head lint, typecheck, full tests, production build, and deployment-status inspection complete. External Vercel quota failure remains separate from code correctness.