### PR TITLE
U3.3: Make component representation switching visual and predictable

### DIFF
--- a/src/__tests__/electronicsRepresentations.test.ts
+++ b/src/__tests__/electronicsRepresentations.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import type { BoardComponent, BoardItem, BoardOutline, BOMItem } from '../types';
+import { deriveElectronicsRepresentationStatuses } from '../components/electronics/ElectronicsRepresentationStrip';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+function component(overrides: Partial<BoardComponent> = {}): BoardComponent {
+  return {
+    id: 'component-u1',
+    boardId: 'board-main',
+    referenceDesignator: 'U1',
+    componentName: 'Controller',
+    componentType: 'MCU',
+    value: 'MCU',
+    packageName: '',
+    footprint: '',
+    partNumber: '',
+    placementCriticality: 'High',
+    notes: '',
+    ...overrides,
+  };
+}
+
+const board: BoardItem = {
+  id: 'board-main',
+  name: 'Main PCB',
+  boardType: 'Main PCB',
+};
+
+const outline: BoardOutline = {
+  id: 'outline-main',
+  boardId: 'board-main',
+  width: 40,
+  height: 25,
+  units: 'mm',
+};
+
+describe('Electronics visual representation switching', () => {
+  it('shows incomplete authoring surfaces but blocks 3D when evidence is unresolved', () => {
+    const statuses = deriveElectronicsRepresentationStatuses(component(), [], [board], []);
+
+    expect(statuses).toEqual([
+      expect.objectContaining({ id: 'schematic', state: 'incomplete', stateLabel: 'Unplaced', enabled: true }),
+      expect.objectContaining({ id: 'pcb', state: 'blocked', stateLabel: 'No footprint', enabled: true }),
+      expect.objectContaining({ id: 'bom', state: 'incomplete', stateLabel: 'Unlinked', enabled: true }),
+      expect.objectContaining({ id: '3d', state: 'blocked', stateLabel: 'Unresolved', enabled: false }),
+    ]);
+  });
+
+  it('marks each representation ready only from explicit canonical evidence', () => {
+    const readyComponent = component({
+      footprint: 'QFN-32',
+      schematic: { placed: true, x: 120, y: 80 },
+      pcb: {
+        placed: true,
+        xMm: 10,
+        yMm: 12,
+        side: 'Top',
+        locked: false,
+        placementStatus: 'Placed',
+      },
+      packageDimensions: { widthMm: 5, heightMm: 5, heightZMm: 0.9 },
+      bomItemId: 'bom-u1',
+    });
+    const bom: BOMItem[] = [{
+      id: 'bom-u1',
+      componentId: readyComponent.id,
+      blockName: 'Controller',
+      candidateComponent: 'MCU',
+      stage: 'Prototype',
+      status: 'Sourced',
+    }];
+
+    const statuses = deriveElectronicsRepresentationStatuses(readyComponent, bom, [board], [outline]);
+    expect(statuses.every((status) => status.state === 'ready')).toBe(true);
+    expect(statuses.find((status) => status.id === '3d')?.enabled).toBe(true);
+  });
+
+  it('does not treat a board or package alone as sufficient 3D evidence', () => {
+    const incomplete = component({
+      footprint: 'QFN-32',
+      placementX: 0,
+      placementY: 0,
+      packageDimensions: { widthMm: 5, heightMm: 5, heightZMm: 0 },
+    });
+
+    const threeD = deriveElectronicsRepresentationStatuses(incomplete, [], [board], [outline])
+      .find((status) => status.id === '3d');
+    expect(threeD).toMatchObject({ state: 'blocked', enabled: false, stateLabel: 'Unresolved' });
+  });
+
+  it('uses one predictable representation strip rather than another navigation layer', () => {
+    const strip = source('../components/electronics/ElectronicsRepresentationStrip.tsx');
+    const shell = source('../components/editor/EngineeringEditorShell.tsx');
+
+    expect(strip).toContain("label: 'Symbol'");
+    expect(strip).toContain("label: 'PCB'");
+    expect(strip).toContain("label: 'BOM'");
+    expect(strip).toContain("label: '3D'");
+    expect(strip).toContain("setActiveView('schematic-editor')");
+    expect(strip).toContain("setActiveView('board-designer')");
+    expect(strip).toContain("setActiveView('bom')");
+    expect(strip).toContain("requestMechanicalMode('webgl-3d')");
+    expect(strip).toContain("setActiveView('mechanical-studio')");
+    expect(strip).not.toContain('window.location');
+    expect(strip).not.toContain('Dialog');
+
+    expect(shell).toContain("'schematic-editor': 'schematic'");
+    expect(shell).toContain("'board-designer': 'pcb'");
+    expect(shell).toContain('<ElectronicsRepresentationStrip');
+  });
+
+  it('keeps the same canonical component selected before changing representation', () => {
+    const strip = source('../components/electronics/ElectronicsRepresentationStrip.tsx');
+
+    expect(strip).toContain("entity: 'component-instance'");
+    expect(strip).toContain('componentId: component.id');
+    expect(strip).toContain('boardId: component.boardId');
+    expect(strip).toContain('setActiveBoard(component.boardId)');
+    expect(strip).toContain('if (!status?.enabled || representation === current) return;');
+  });
+});

--- a/src/components/editor/EngineeringEditorShell.tsx
+++ b/src/components/editor/EngineeringEditorShell.tsx
@@ -2,6 +2,12 @@
 
 import React from 'react';
 import { X } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+import {
+  ElectronicsRepresentationStrip,
+  type ElectronicsRepresentation,
+} from '../electronics/ElectronicsRepresentationStrip';
 
 interface EngineeringEditorBarProps {
   domain: string;
@@ -99,9 +105,16 @@ interface EngineeringInspectorProps {
   children: React.ReactNode;
 }
 
+const inspectorRepresentationByView: Readonly<Record<string, ElectronicsRepresentation | undefined>> = {
+  'schematic-editor': 'schematic',
+  'board-designer': 'pcb',
+};
+
 /**
  * Shared right-side selection surface. The workbench owns whether it is open and
- * what the current canonical selection means; the Inspector owns only framing.
+ * what the current canonical selection means; the Inspector owns framing plus a
+ * compact cross-representation header when the immediate Electronics selection
+ * is attached to a canonical component.
  */
 export const EngineeringInspector: React.FC<EngineeringInspectorProps> = ({
   open,
@@ -110,6 +123,12 @@ export const EngineeringInspector: React.FC<EngineeringInspectorProps> = ({
   widthClassName = 'w-[320px]',
   children,
 }) => {
+  const activeView = useProjectStore((state) => state.activeView);
+  const sharedSelection = useStudioContextStore((state) => state.selected);
+  const currentRepresentation = inspectorRepresentationByView[activeView];
+  const contextualComponentId = sharedSelection?.componentId
+    ?? (sharedSelection?.entity === 'component-instance' ? sharedSelection.id : null);
+
   if (!open) return null;
   return (
     <EngineeringDock
@@ -120,6 +139,12 @@ export const EngineeringInspector: React.FC<EngineeringInspectorProps> = ({
       widthClassName={widthClassName}
       chromeId="inspector"
     >
+      {currentRepresentation && contextualComponentId && (
+        <ElectronicsRepresentationStrip
+          componentId={contextualComponentId}
+          current={currentRepresentation}
+        />
+      )}
       {children}
     </EngineeringDock>
   );

--- a/src/components/electronics/ElectronicsRepresentationStrip.tsx
+++ b/src/components/electronics/ElectronicsRepresentationStrip.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import React from 'react';
+import {
+  Box,
+  Boxes,
+  CircuitBoard,
+  FileSpreadsheet,
+  Workflow,
+  type LucideIcon,
+} from 'lucide-react';
+import type { BOMItem, BoardComponent, BoardItem, BoardOutline } from '../../types';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+
+export type ElectronicsRepresentation = 'schematic' | 'pcb' | 'bom' | '3d';
+export type ElectronicsRepresentationState = 'ready' | 'incomplete' | 'blocked';
+
+interface ElectronicsRepresentationStatus {
+  id: ElectronicsRepresentation;
+  label: string;
+  state: ElectronicsRepresentationState;
+  stateLabel: string;
+  enabled: boolean;
+}
+
+interface ElectronicsRepresentationStripProps {
+  componentId: string;
+  current: ElectronicsRepresentation;
+}
+
+const EMPTY_COMPONENTS: BoardComponent[] = [];
+const EMPTY_BOM: BOMItem[] = [];
+const EMPTY_BOARDS: BoardItem[] = [];
+const EMPTY_OUTLINES: BoardOutline[] = [];
+
+const iconByRepresentation: Record<ElectronicsRepresentation, LucideIcon> = {
+  schematic: Workflow,
+  pcb: CircuitBoard,
+  bom: FileSpreadsheet,
+  '3d': Box,
+};
+
+function hasExplicitOutline(outline: BoardOutline | undefined): boolean {
+  if (!outline) return false;
+  if (outline.points && outline.points.length >= 3) return true;
+  return Boolean(
+    outline.width != null
+    && outline.height != null
+    && outline.width > 0
+    && outline.height > 0,
+  );
+}
+
+function hasPositivePackageDimensions(component: BoardComponent): boolean {
+  const dimensions = component.packageDimensions;
+  return Boolean(
+    dimensions
+    && dimensions.widthMm > 0
+    && dimensions.heightMm > 0
+    && dimensions.heightZMm > 0,
+  );
+}
+
+function hasExplicitPcbPlacement(component: BoardComponent): boolean {
+  const x = component.pcb?.xMm ?? component.placementX;
+  const y = component.pcb?.yMm ?? component.placementY;
+  return x != null && y != null;
+}
+
+export function deriveElectronicsRepresentationStatuses(
+  component: BoardComponent,
+  bom: readonly BOMItem[],
+  boards: readonly BoardItem[],
+  boardOutlines: readonly BoardOutline[],
+): ElectronicsRepresentationStatus[] {
+  const schematicPlaced = component.schematic?.placed === true;
+  const hasFootprint = Boolean(component.footprint?.trim());
+  const pcbPlaced = hasExplicitPcbPlacement(component);
+  const bomLinked = bom.some((item) => item.componentId === component.id || item.id === component.bomItemId);
+  const boardExists = boards.some((board) => board.id === component.boardId);
+  const outlineExists = hasExplicitOutline(boardOutlines.find((outline) => outline.boardId === component.boardId));
+  const packageReady = hasPositivePackageDimensions(component);
+  const threeDReady = boardExists && outlineExists && pcbPlaced && packageReady;
+
+  return [
+    {
+      id: 'schematic',
+      label: 'Symbol',
+      state: schematicPlaced ? 'ready' : 'incomplete',
+      stateLabel: schematicPlaced ? 'Placed' : 'Unplaced',
+      enabled: true,
+    },
+    {
+      id: 'pcb',
+      label: 'PCB',
+      state: !hasFootprint ? 'blocked' : pcbPlaced ? 'ready' : 'incomplete',
+      stateLabel: !hasFootprint ? 'No footprint' : pcbPlaced ? 'Placed' : 'Unplaced',
+      enabled: true,
+    },
+    {
+      id: 'bom',
+      label: 'BOM',
+      state: bomLinked ? 'ready' : 'incomplete',
+      stateLabel: bomLinked ? 'Linked' : 'Unlinked',
+      enabled: true,
+    },
+    {
+      id: '3d',
+      label: '3D',
+      state: threeDReady ? 'ready' : 'blocked',
+      stateLabel: threeDReady ? 'Ready' : 'Unresolved',
+      enabled: threeDReady,
+    },
+  ];
+}
+
+const stateDotClass: Record<ElectronicsRepresentationState, string> = {
+  ready: 'bg-emerald-500',
+  incomplete: 'bg-amber-400',
+  blocked: 'bg-slate-300',
+};
+
+export const ElectronicsRepresentationStrip: React.FC<ElectronicsRepresentationStripProps> = ({ componentId, current }) => {
+  const boardComponents = useProjectStore((state) => state.boardComponents ?? EMPTY_COMPONENTS);
+  const bom = useProjectStore((state) => state.bom ?? EMPTY_BOM);
+  const boards = useProjectStore((state) => state.boards ?? EMPTY_BOARDS);
+  const boardOutlines = useProjectStore((state) => state.boardOutlines ?? EMPTY_OUTLINES);
+  const setActiveBoard = useProjectStore((state) => state.setActiveBoard);
+  const setActiveView = useProjectStore((state) => state.setActiveView);
+  const select = useStudioContextStore((state) => state.select);
+  const beginHandoff = useStudioContextStore((state) => state.beginHandoff);
+  const requestMechanicalMode = useStudioContextStore((state) => state.requestMechanicalMode);
+
+  const component = boardComponents.find((candidate) => candidate.id === componentId);
+  if (!component) return null;
+
+  const statuses = deriveElectronicsRepresentationStatuses(component, bom, boards, boardOutlines);
+
+  const openRepresentation = (representation: ElectronicsRepresentation) => {
+    const status = statuses.find((candidate) => candidate.id === representation);
+    if (!status?.enabled || representation === current) return;
+
+    select({
+      entity: 'component-instance',
+      id: component.id,
+      label: component.referenceDesignator,
+      boardId: component.boardId,
+      componentId: component.id,
+    });
+    setActiveBoard(component.boardId);
+    beginHandoff(current === 'schematic' ? 'schematic-editor' : current === 'pcb' ? 'board-designer' : current === 'bom' ? 'bom' : 'mechanical-studio');
+
+    if (representation === 'schematic') setActiveView('schematic-editor');
+    if (representation === 'pcb') setActiveView('board-designer');
+    if (representation === 'bom') setActiveView('bom');
+    if (representation === '3d') {
+      requestMechanicalMode('webgl-3d');
+      setActiveView('mechanical-studio');
+    }
+  };
+
+  return (
+    <section className="border-y border-slate-200 bg-slate-50/70 px-2 py-2" aria-label={`${component.referenceDesignator} representations`}>
+      <div className="mb-1.5 flex items-center gap-1.5 px-1">
+        <Boxes className="h-3 w-3 text-slate-400" aria-hidden="true" />
+        <span className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-400">Same component</span>
+      </div>
+      <div className="grid grid-cols-4 gap-1">
+        {statuses.map((status) => {
+          const Icon = iconByRepresentation[status.id];
+          const active = status.id === current;
+          return (
+            <button
+              key={status.id}
+              type="button"
+              disabled={!status.enabled || active}
+              aria-current={active ? 'page' : undefined}
+              onClick={() => openRepresentation(status.id)}
+              title={active ? `${status.label} is open` : status.enabled ? `Open ${status.label} for ${component.referenceDesignator}` : `${status.label}: ${status.stateLabel}`}
+              className={`min-w-0 border px-1.5 py-2 text-center transition focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400/70 ${
+                active
+                  ? 'border-slate-950 bg-slate-950 text-white'
+                  : status.enabled
+                    ? 'border-slate-200 bg-white text-slate-700 hover:border-slate-400 hover:bg-slate-100'
+                    : 'cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400'
+              }`}
+            >
+              <Icon className="mx-auto h-3.5 w-3.5" aria-hidden="true" />
+              <span className="mt-1 block truncate text-[9px] font-semibold">{status.label}</span>
+              <span className={`mx-auto mt-1 block h-1.5 w-1.5 rounded-full ${active ? 'bg-white' : stateDotClass[status.state]}`} aria-hidden="true" />
+              <span className={`mt-0.5 block truncate text-[7px] ${active ? 'text-white/65' : 'text-slate-400'}`}>{active ? 'Open' : status.stateLabel}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+};


### PR DESCRIPTION
Parent: #98 / #66
Execution spec: `docs/development/STUDIO_UX_CONVERGENCE_EXECUTION_PLAN.md`

## User-facing change
A selected canonical component now gets one compact visual representation strip inside the live Schematic/PCB Inspector grammar:

`Symbol | PCB | BOM | 3D`

Each cell shows short state feedback with an icon + state dot instead of another paragraph/navigation layer. The current representation is visibly active and the destination is explicit before click.

## Truth rules
- Schematic derives placed/unplaced only from canonical schematic state.
- PCB derives footprint/placement state from the canonical component.
- BOM is linked only through `componentId` or the existing `bomItemId` compatibility link.
- 3D is enabled only when the component has a real board, explicit board outline, explicit PCB placement, and positive package dimensions.
- Unresolved 3D stays disabled; no preview assumptions are created.

## Predictable navigation
- Symbol → Schematic
- PCB → PCB
- BOM → BOM
- 3D → connected Mechanical 3D mode

Before switching, the same canonical component + board context are reasserted in the shared selection context. No dialog and no new global/workbench navigation is introduced.

## Integration
The shared Inspector renders the strip only when the immediate shared selection is attached to a component and the active surface is Schematic or PCB. Unrelated net/wire selections do not receive misleading component representation chrome.

## Tests
Adds `electronicsRepresentations.test.ts` covering incomplete/ready state derivation, strict 3D eligibility, predictable destinations, selection persistence, and the absence of modal/hash navigation.

## Completion gate
Do not merge until exact-head lint, typecheck, full tests, production build, and deployment-status inspection complete. Vercel Hobby build-rate limiting remains an external deployment constraint.