### PR TITLE
U5.2: Converge Mechanical representations inside one workbench

### DIFF
--- a/src/__tests__/electronicsIdentityTruth.test.ts
+++ b/src/__tests__/electronicsIdentityTruth.test.ts
@@ -37,8 +37,9 @@ describe('Electronics canonical identity and representation truth', () => {
     expect(library).not.toContain("setSelectedBoardId(boards[0]?.id ?? '')");
 
     expect(adapters).not.toContain('previousIds');
-    expect(adapters).not.toContain('useEffect');
     expect(adapters).not.toContain('useProjectStore');
+    expect(adapters).not.toContain('placeComponentOnSchematic');
+    expect(adapters).toContain('if (requestedMode) requestMechanicalMode(null);');
   });
 
   it('never invents a selected BOM component and stores canonical BOM linkage', () => {

--- a/src/__tests__/mechanicalRepresentations.test.ts
+++ b/src/__tests__/mechanicalRepresentations.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('U5.2 Mechanical representation convergence', () => {
+  it('stores representation choice as Mechanical UI state, not project engineering state', () => {
+    const uiStore = source('../store/mechanicalWorkspaceUiStore.ts');
+    const projectStore = source('../store/projectStore.ts');
+
+    expect(uiStore).toContain("export type MechanicalRepresentation = 'layout' | 'review-3d' | 'assembly'");
+    expect(uiStore).toContain("representation: 'layout'");
+    expect(uiStore).toContain('setRepresentation');
+    expect(projectStore).not.toContain('mechanicalRepresentation');
+    expect(projectStore).not.toContain('review-3d');
+  });
+
+  it('maps legacy Mechanical requests into the contextual representation state and clears the handoff', () => {
+    const adapter = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
+
+    expect(adapter).toContain('mechanicalRepresentationForLegacyMode');
+    expect(adapter).toContain("mode === 'assembly'");
+    expect(adapter).toContain("mode === 'webgl-3d' || mode === '3d-preview'");
+    expect(adapter).toContain("return 'review-3d'");
+    expect(adapter).toContain('if (requestedMode) requestMechanicalMode(null)');
+    expect(adapter).toContain('<MechanicalRepresentationTabs />');
+    expect(adapter).toContain('<Mechanical3DReview />');
+    expect(adapter).toContain('<EngineeringMechanicalWorkbench initialMode="assembly" />');
+    expect(adapter).toContain('<EngineeringMechanicalWorkbench initialMode="canvas" />');
+  });
+
+  it('makes 2D, 3D Review, and Assembly explicit contextual tabs instead of global destinations', () => {
+    const tabs = source('../components/mechanical/MechanicalRepresentationTabs.tsx');
+    const navigation = source('../lib/navigationRegistry.ts');
+
+    expect(tabs).toContain('aria-label="Mechanical representations"');
+    expect(tabs).toContain("label: '2D Layout'");
+    expect(tabs).toContain("label: '3D Review'");
+    expect(tabs).toContain("detail: 'Visualization'");
+    expect(tabs).toContain("label: 'Assembly'");
+    expect(tabs).toContain('3D review never grants CAD or validation authority.');
+    expect(navigation).not.toContain("label: '3D Review'");
+  });
+
+  it('keeps the Project Drawer and representation state coherent without creating another Mechanical browser', () => {
+    const drawer = source('../components/mechanical/MechanicalProjectDrawer.tsx');
+    const workbench = source('../components/mechanical/EngineeringMechanicalWorkbench.tsx');
+
+    expect(drawer).toContain("if (section === 'assembly') setRepresentation('assembly')");
+    expect(drawer).toContain("else if (representation === 'assembly') setRepresentation('layout')");
+    expect(drawer).toContain('data-workbench="mechanical"');
+    expect(workbench).not.toContain('Design browser');
+  });
+
+  it('classifies 3D as review visualization while retaining canonical selection context', () => {
+    const review = source('../components/mechanical/Mechanical3DReview.tsx');
+    const renderer = source('../components/mechanical/UnifiedBoard3DView.tsx');
+
+    expect(review).toContain('title="3D Review"');
+    expect(review).toContain('Visualization only');
+    expect(review).toContain('3D Review is not CAD and never grants validation authority.');
+    expect(review).toContain('const selected = useStudioContextStore((state) => state.selected)');
+    expect(review).toContain('Selection · ${selectedLabel}');
+    expect(review).toContain('[&>section>header]:hidden');
+
+    expect(renderer).toContain('Hardware Studio will not substitute the first board.');
+    expect(renderer).toContain('No 50 × 30 mm preview envelope or other guessed outline will be created.');
+    expect(renderer).toContain('not STEP/B-Rep geometry and not manufacturing clearance evidence.');
+  });
+});

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -82,7 +82,7 @@ describe('golden-path regression guards', () => {
     expect(existsSync(new URL('../components/PCBConstraints.tsx', import.meta.url))).toBe(false);
   });
 
-  it('adapts editors to selected canonical context without mutating the schematic on open', () => {
+  it('adapts editors to selected canonical context without mutating Electronics on open', () => {
     const adapters = source('../components/studio/UnifiedWorkbenchAdapters.tsx');
     const library = source('../components/component-library/ComponentLibraryWorkbench.tsx');
     const schematic = source('../components/schematic/EngineeringSchematicWorkbench.tsx');
@@ -91,9 +91,9 @@ describe('golden-path regression guards', () => {
     expect(appShell).not.toContain('placeComponentOnSchematic');
     expect(adapters).toContain('<EngineeringSchematicWorkbench />');
     expect(adapters).toContain('<EngineeringBoardWorkbench />');
-    expect(adapters).not.toContain('useEffect');
     expect(adapters).not.toContain('previousIds');
     expect(adapters).not.toContain('useProjectStore');
+    expect(adapters).toContain('if (requestedMode) requestMechanicalMode(null);');
     expect(library).toContain('setActiveComponentDefinition(selectedComponent.libraryId)');
     expect(library).toContain('setContextBoard(effectiveBoard.id)');
     expect(library).toContain('setActiveComponent(component.id)');

--- a/src/components/mechanical/Mechanical3DReview.tsx
+++ b/src/components/mechanical/Mechanical3DReview.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React from 'react';
+import { BadgeCheck, CircuitBoard } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import { useStudioContextStore } from '../../store/studioContextStore';
+import { EngineeringEditorBar, EngineeringStatusBar } from '../editor/EngineeringEditorShell';
+import { UnifiedBoard3DView } from './UnifiedBoard3DView';
+
+export const Mechanical3DReview: React.FC = () => {
+  const boards = useProjectStore((state) => state.boards || []);
+  const projectActiveBoardId = useProjectStore((state) => state.activeBoardId);
+  const contextBoardId = useStudioContextStore((state) => state.activeBoardId);
+  const selected = useStudioContextStore((state) => state.selected);
+  const boardId = contextBoardId || projectActiveBoardId || null;
+  const board = boards.find((candidate) => candidate.id === boardId);
+  const selectedLabel = selected?.label || selected?.id || 'No canonical selection';
+
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden" aria-label="Mechanical 3D review representation">
+      <EngineeringEditorBar
+        domain="Mechanical"
+        title="3D Review"
+        meta={`${board?.name || 'Board context unresolved'} · evidence-backed visualization only`}
+        actions={(
+          <div className="inline-flex h-8 items-center gap-1.5 border border-sky-200 bg-sky-50 px-2.5 text-[9px] font-semibold text-sky-800" title="Three.js renders explicit recorded dimensions only. This is not a CAD kernel or verification evidence.">
+            <BadgeCheck className="h-3.5 w-3.5" aria-hidden="true" /> Visualization only
+          </div>
+        )}
+      />
+      <div className="min-h-0 flex-1 overflow-hidden [&>section>header]:hidden">
+        <UnifiedBoard3DView />
+      </div>
+      <EngineeringStatusBar
+        left="3D Review is not CAD and never grants validation authority."
+        center={`Selection · ${selectedLabel}`}
+        right={board ? <span className="inline-flex items-center gap-1"><CircuitBoard className="h-3 w-3" aria-hidden="true" /> {board.name}</span> : 'board unresolved'}
+      />
+    </section>
+  );
+};

--- a/src/components/mechanical/MechanicalProjectDrawer.tsx
+++ b/src/components/mechanical/MechanicalProjectDrawer.tsx
@@ -20,12 +20,20 @@ export const MechanicalProjectDrawer: React.FC = () => {
   const selected = useStudioContextStore((state) => state.selected);
   const select = useStudioContextStore((state) => state.select);
   const drawerSection = useMechanicalWorkspaceUiStore((state) => state.drawerSection);
+  const representation = useMechanicalWorkspaceUiStore((state) => state.representation);
   const setDrawerSection = useMechanicalWorkspaceUiStore((state) => state.setDrawerSection);
+  const setRepresentation = useMechanicalWorkspaceUiStore((state) => state.setRepresentation);
   const setInspectorOpen = useMechanicalWorkspaceUiStore((state) => state.setInspectorOpen);
 
   const selectObject = (id: string, label: string, boardId?: string) => {
     select({ entity: 'mechanical-object', id, label, boardId: boardId || null });
     setInspectorOpen(true);
+  };
+
+  const openSection = (section: MechanicalDrawerSection) => {
+    setDrawerSection(section);
+    if (section === 'assembly') setRepresentation('assembly');
+    else if (representation === 'assembly') setRepresentation('layout');
   };
 
   return (
@@ -45,7 +53,7 @@ export const MechanicalProjectDrawer: React.FC = () => {
           <button
             key={id}
             type="button"
-            onClick={() => setDrawerSection(id)}
+            onClick={() => openSection(id)}
             aria-pressed={drawerSection === id}
             className={`flex min-h-11 flex-col items-center justify-center gap-1 border-r border-[#d8d1c5] text-[8px] font-semibold last:border-r-0 ${drawerSection === id ? 'bg-[#fbfaf6] text-slate-950' : 'text-slate-500 hover:bg-[#ece6dc]'}`}
           >

--- a/src/components/mechanical/MechanicalRepresentationTabs.tsx
+++ b/src/components/mechanical/MechanicalRepresentationTabs.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import { Boxes, Layers3, Ruler } from 'lucide-react';
+import {
+  useMechanicalWorkspaceUiStore,
+  type MechanicalRepresentation,
+} from '../../store/mechanicalWorkspaceUiStore';
+
+const representations: Array<{
+  id: MechanicalRepresentation;
+  label: string;
+  detail: string;
+  icon: React.ComponentType<{ className?: string }>;
+}> = [
+  { id: 'layout', label: '2D Layout', detail: 'Authoring', icon: Ruler },
+  { id: 'review-3d', label: '3D Review', detail: 'Visualization', icon: Layers3 },
+  { id: 'assembly', label: 'Assembly', detail: 'Physical stack', icon: Boxes },
+];
+
+export const MechanicalRepresentationTabs: React.FC = () => {
+  const representation = useMechanicalWorkspaceUiStore((state) => state.representation);
+  const setRepresentation = useMechanicalWorkspaceUiStore((state) => state.setRepresentation);
+
+  return (
+    <div
+      className="flex h-9 shrink-0 items-stretch border-b border-[#cfc9bd] bg-[#efeae1]"
+      role="tablist"
+      aria-label="Mechanical representations"
+      data-mechanical-representation-tabs
+    >
+      <div className="flex shrink-0 items-center border-r border-[#d7d0c4] px-3 text-[8px] font-semibold uppercase tracking-[0.13em] text-slate-400">
+        Representation
+      </div>
+      {representations.map(({ id, label, detail, icon: Icon }) => {
+        const active = representation === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => setRepresentation(id)}
+            className={`relative flex min-w-[118px] items-center gap-2 border-r border-[#d7d0c4] px-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400/70 ${active ? 'bg-[#fbfaf6] text-slate-950' : 'text-slate-500 hover:bg-[#e7e1d7] hover:text-slate-900'}`}
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span className="min-w-0">
+              <span className="block text-[10px] font-semibold">{label}</span>
+              <span className="block text-[8px] text-slate-400">{detail}</span>
+            </span>
+            {active && <span className="absolute inset-x-0 bottom-0 h-0.5 bg-slate-950" aria-hidden="true" />}
+          </button>
+        );
+      })}
+      <div className="min-w-0 flex-1" />
+      <div className="flex shrink-0 items-center px-3 text-[8px] text-slate-400">
+        3D review never grants CAD or validation authority.
+      </div>
+    </div>
+  );
+};

--- a/src/components/mechanical/MechanicalRepresentationTabs.tsx
+++ b/src/components/mechanical/MechanicalRepresentationTabs.tsx
@@ -20,7 +20,15 @@ const representations: Array<{
 
 export const MechanicalRepresentationTabs: React.FC = () => {
   const representation = useMechanicalWorkspaceUiStore((state) => state.representation);
+  const drawerSection = useMechanicalWorkspaceUiStore((state) => state.drawerSection);
   const setRepresentation = useMechanicalWorkspaceUiStore((state) => state.setRepresentation);
+  const setDrawerSection = useMechanicalWorkspaceUiStore((state) => state.setDrawerSection);
+
+  const openRepresentation = (next: MechanicalRepresentation) => {
+    setRepresentation(next);
+    if (next === 'assembly') setDrawerSection('assembly');
+    else if (next === 'layout' && drawerSection === 'assembly') setDrawerSection('features');
+  };
 
   return (
     <div
@@ -40,7 +48,7 @@ export const MechanicalRepresentationTabs: React.FC = () => {
             type="button"
             role="tab"
             aria-selected={active}
-            onClick={() => setRepresentation(id)}
+            onClick={() => openRepresentation(id)}
             className={`relative flex min-w-[118px] items-center gap-2 border-r border-[#d7d0c4] px-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400/70 ${active ? 'bg-[#fbfaf6] text-slate-950' : 'text-slate-500 hover:bg-[#e7e1d7] hover:text-slate-900'}`}
           >
             <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -10,8 +10,8 @@ import { ComponentLibraryWorkbench } from '../component-library/ComponentLibrary
 import { EngineeringBoardWorkbench } from '../board/EngineeringBoardWorkbench';
 import { EngineeringSchematicWorkbench } from '../schematic/EngineeringSchematicWorkbench';
 import { EngineeringMechanicalWorkbench } from '../mechanical/EngineeringMechanicalWorkbench';
+import { Mechanical3DReview } from '../mechanical/Mechanical3DReview';
 import { MechanicalRepresentationTabs } from '../mechanical/MechanicalRepresentationTabs';
-import { UnifiedBoard3DView } from '../mechanical/UnifiedBoard3DView';
 
 export const UnifiedComponentLibraryWorkbench: React.FC = () => <ComponentLibraryWorkbench />;
 
@@ -41,7 +41,7 @@ export const UnifiedMechanicalWorkbench: React.FC<{ defaultMode: MechanicalWorkb
     <section className="flex h-full min-h-0 flex-col overflow-hidden" data-workbench="mechanical" data-mechanical-representation={representation}>
       <MechanicalRepresentationTabs />
       <div className="min-h-0 flex-1 overflow-hidden">
-        {representation === 'review-3d' && <UnifiedBoard3DView />}
+        {representation === 'review-3d' && <Mechanical3DReview />}
         {representation === 'assembly' && <EngineeringMechanicalWorkbench initialMode="assembly" />}
         {representation === 'layout' && <EngineeringMechanicalWorkbench initialMode="canvas" />}
       </div>

--- a/src/components/studio/UnifiedWorkbenchAdapters.tsx
+++ b/src/components/studio/UnifiedWorkbenchAdapters.tsx
@@ -1,11 +1,16 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useStudioContextStore, type MechanicalWorkbenchMode } from '../../store/studioContextStore';
+import {
+  useMechanicalWorkspaceUiStore,
+  type MechanicalRepresentation,
+} from '../../store/mechanicalWorkspaceUiStore';
 import { ComponentLibraryWorkbench } from '../component-library/ComponentLibraryWorkbench';
 import { EngineeringBoardWorkbench } from '../board/EngineeringBoardWorkbench';
 import { EngineeringSchematicWorkbench } from '../schematic/EngineeringSchematicWorkbench';
 import { EngineeringMechanicalWorkbench } from '../mechanical/EngineeringMechanicalWorkbench';
+import { MechanicalRepresentationTabs } from '../mechanical/MechanicalRepresentationTabs';
 import { UnifiedBoard3DView } from '../mechanical/UnifiedBoard3DView';
 
 export const UnifiedComponentLibraryWorkbench: React.FC = () => <ComponentLibraryWorkbench />;
@@ -14,13 +19,32 @@ export const UnifiedSchematicWorkbench: React.FC = () => <EngineeringSchematicWo
 
 export const UnifiedBoardDesignerWorkbench: React.FC = () => <EngineeringBoardWorkbench />;
 
+export function mechanicalRepresentationForLegacyMode(mode: MechanicalWorkbenchMode): MechanicalRepresentation {
+  if (mode === 'assembly') return 'assembly';
+  if (mode === 'webgl-3d' || mode === '3d-preview') return 'review-3d';
+  return 'layout';
+}
+
 export const UnifiedMechanicalWorkbench: React.FC<{ defaultMode: MechanicalWorkbenchMode }> = ({ defaultMode }) => {
   const requestedMode = useStudioContextStore((state) => state.requestedMechanicalMode);
-  const resolvedMode = requestedMode || defaultMode;
+  const requestMechanicalMode = useStudioContextStore((state) => state.requestMechanicalMode);
+  const representation = useMechanicalWorkspaceUiStore((state) => state.representation);
+  const setRepresentation = useMechanicalWorkspaceUiStore((state) => state.setRepresentation);
 
-  if (resolvedMode === 'webgl-3d' || resolvedMode === '3d-preview') {
-    return <UnifiedBoard3DView />;
-  }
+  useEffect(() => {
+    const incomingMode = requestedMode || defaultMode;
+    setRepresentation(mechanicalRepresentationForLegacyMode(incomingMode));
+    if (requestedMode) requestMechanicalMode(null);
+  }, [defaultMode, requestMechanicalMode, requestedMode, setRepresentation]);
 
-  return <EngineeringMechanicalWorkbench key={resolvedMode} initialMode={resolvedMode} />;
+  return (
+    <section className="flex h-full min-h-0 flex-col overflow-hidden" data-workbench="mechanical" data-mechanical-representation={representation}>
+      <MechanicalRepresentationTabs />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {representation === 'review-3d' && <UnifiedBoard3DView />}
+        {representation === 'assembly' && <EngineeringMechanicalWorkbench initialMode="assembly" />}
+        {representation === 'layout' && <EngineeringMechanicalWorkbench initialMode="canvas" />}
+      </div>
+    </section>
+  );
 };

--- a/src/store/mechanicalWorkspaceUiStore.ts
+++ b/src/store/mechanicalWorkspaceUiStore.ts
@@ -1,13 +1,16 @@
 import { create } from 'zustand';
 
 export type MechanicalDrawerSection = 'features' | 'dimensions' | 'assembly';
+export type MechanicalRepresentation = 'layout' | 'review-3d' | 'assembly';
 
 interface MechanicalWorkspaceUiState {
   drawerSection: MechanicalDrawerSection;
+  representation: MechanicalRepresentation;
   inspectorOpen: boolean;
   problemsOpen: boolean;
   panMode: boolean;
   setDrawerSection: (drawerSection: MechanicalDrawerSection) => void;
+  setRepresentation: (representation: MechanicalRepresentation) => void;
   setInspectorOpen: (inspectorOpen: boolean) => void;
   setProblemsOpen: (problemsOpen: boolean) => void;
   setPanMode: (panMode: boolean) => void;
@@ -15,10 +18,12 @@ interface MechanicalWorkspaceUiState {
 
 export const useMechanicalWorkspaceUiStore = create<MechanicalWorkspaceUiState>((set) => ({
   drawerSection: 'features',
+  representation: 'layout',
   inspectorOpen: false,
   problemsOpen: false,
   panMode: false,
   setDrawerSection: (drawerSection) => set({ drawerSection }),
+  setRepresentation: (representation) => set({ representation }),
   setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
   setProblemsOpen: (problemsOpen) => set({ problemsOpen }),
   setPanMode: (panMode) => set({ panMode }),


### PR DESCRIPTION
Closes #109
Parent: #16 / #17 / #43 / #46
Execution ledger: `docs/development/STUDIO_PHASE_EXECUTION_STATUS.md`
Mechanical notes: `docs/development/U5_MECHANICAL_CONVERGENCE_NOTES.md`

## Replaces
- legacy Mechanical mode switching that made 2D, Assembly, and 3D feel like separate applications;
- standalone 3D application-like chrome inside the Mechanical surface.

## Canonical context
- Mechanical representation choice lives only in `mechanicalWorkspaceUiStore`;
- project geometry remains in canonical project state;
- shared `studioContextStore` selection survives representation switching;
- legacy `requestedMechanicalMode` is treated only as a compatibility handoff and cleared after translation.

## User job
A user can move predictably among **2D Layout**, **3D Review**, and **Assembly** while remaining inside the same Mechanical workbench and retaining the same engineering context.

## Progressive disclosure
- representation switch is contextual to Mechanical, not global navigation;
- 3D review uses explicit visualization-only language and does not claim CAD/verification authority;
- unresolved physical/package/placement geometry remains unresolved.

## Truth constraints
- no board/outline/package/placement/mechanical dimensions are invented for 3D rendering;
- 3D is explicitly `Review / Visualization only`;
- no CAD-kernel, B-Rep, interference, or validation authority is claimed;
- #16/#17 remain open.

## Proof
Adds bounded regression coverage for UI-only representation state, legacy compatibility mapping, selection preservation, shared Mechanical shell ownership, and 3D truthfulness wording.

## Completion gate
Do not merge until the exact PR head passes lint, typecheck, full tests, production build, and deployment-status inspection. Vercel build-rate limiting, if present, is recorded separately from code correctness.