### PR TITLE
U7.1: Converge Validation on explicit Define Execute Review

### DIFF
--- a/src/__tests__/editorInteractionBaseline.test.ts
+++ b/src/__tests__/editorInteractionBaseline.test.ts
@@ -84,6 +84,7 @@ describe('editor-first interaction model', () => {
     }
     expect(shellNavigation).toContain('<PcbProjectDrawer />');
     expect(shellNavigation).toContain('<MechanicalProjectDrawer />');
+    expect(shellNavigation).toContain('<ValidationProjectDrawer />');
 
     expect(schematic).toContain('<SchematicCanvas');
     expect(pcb).toContain('<BoardCanvas');
@@ -97,8 +98,11 @@ describe('editor-first interaction model', () => {
     expect(mechanical).not.toContain('Design browser');
     expect(mechanicalCanvas).toContain('mechanicalDimensions');
 
-    expect(validation).toContain('testListOpen');
-    expect(unifiedValidation).toContain('runPanelOpen');
+    expect(validation).toContain('useValidationWorkspaceUiStore');
+    expect(validation).not.toContain('testListOpen');
+    expect(unifiedValidation).toContain('<EngineeringInspector');
+    expect(unifiedValidation).toContain('<EngineeringBottomDock');
+    expect(unifiedValidation).not.toContain('runPanelOpen');
     expect(firmwareSource).toContain('Firmware source editor');
   });
 });

--- a/src/__tests__/studioUnification.test.ts
+++ b/src/__tests__/studioUnification.test.ts
@@ -125,11 +125,12 @@ describe('golden-path regression guards', () => {
     expect(bom).not.toContain('|| contextualComponents[0]');
   });
 
-  it('links validation to the selected component and its actual net IDs', () => {
+  it('links validation to the selected component and its actual pin net IDs', () => {
     const validation = source('../components/studio/UnifiedValidationWorkbench.tsx');
     expect(validation).toContain('activeComponentId');
-    expect(validation).toContain('activeNetName');
-    expect(validation).toContain('linkedNetIds');
+    expect(validation).toContain('.map((pin) => pin.netId)');
+    expect(validation).toContain('selectedNetIds');
+    expect(validation).toContain('linkedNetIds: selectedNetIds');
   });
 
   it('keeps board checks in the PCB bottom dock and routes findings to shared object context', () => {

--- a/src/__tests__/validationConvergence.test.ts
+++ b/src/__tests__/validationConvergence.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { useValidationWorkspaceUiStore } from '../store/validationWorkspaceUiStore';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('U7 Validation convergence', () => {
+  beforeEach(() => {
+    useValidationWorkspaceUiStore.setState({
+      view: 'define',
+      drawerSection: 'tests',
+      selectedTestId: null,
+      selectedRunId: null,
+      inspectorOpen: true,
+      bottomDockOpen: false,
+    });
+  });
+
+  it('keeps Validation selection and panel state UI-only', () => {
+    const ui = useValidationWorkspaceUiStore.getState();
+    ui.setSelectedTestId('test-1');
+    ui.setSelectedRunId('run-2');
+    ui.setView('review');
+    ui.setDrawerSection('runs');
+    ui.setBottomDockOpen(true);
+
+    expect(useValidationWorkspaceUiStore.getState()).toMatchObject({
+      selectedTestId: 'test-1',
+      selectedRunId: 'run-2',
+      view: 'review',
+      drawerSection: 'runs',
+      bottomDockOpen: true,
+    });
+
+    const uiSource = source('../store/validationWorkspaceUiStore.ts');
+    expect(uiSource).not.toContain('useProjectStore');
+    expect(uiSource).not.toContain('validationTests:');
+    expect(uiSource).not.toContain('validationRuns:');
+  });
+
+  it('uses one shell-owned Validation Project Drawer', () => {
+    const navigation = source('../components/StudioWorkbenchNavigation.tsx');
+    const drawer = source('../components/validation/ValidationProjectDrawer.tsx');
+
+    expect(navigation).toContain("activeWorkbench.id === 'validation'");
+    expect(navigation).toContain('<ValidationProjectDrawer />');
+    expect(drawer).toContain("{ id: 'tests', label: 'Tests'");
+    expect(drawer).toContain("{ id: 'coverage', label: 'Coverage'");
+    expect(drawer).toContain("{ id: 'factory-qa', label: 'Factory'");
+    expect(drawer).toContain("{ id: 'runs', label: 'Runs'");
+    expect(drawer).toContain('setSelectedTestId(testId)');
+    expect(drawer).toContain('setSelectedRunId(runId)');
+  });
+
+  it('never chooses the first test or run implicitly', () => {
+    const definition = source('../components/validation/ValidationStudio.tsx');
+    const workbench = source('../components/studio/UnifiedValidationWorkbench.tsx');
+
+    expect(definition).not.toContain('visibleTests[0]');
+    expect(definition).not.toContain('useState<string | null>(null)');
+    expect(definition).not.toContain('testListOpen');
+    expect(workbench).not.toContain('linkedTests[0]');
+    expect(workbench).not.toContain('validationTests[0]');
+    expect(workbench).not.toContain('runHistory[0]');
+    expect(workbench).toContain('selectedTestId ? tests.find');
+    expect(workbench).toContain('selectedRunId ? runs.find');
+  });
+
+  it('separates Define specification from Execute observations and Review history', () => {
+    const definition = source('../components/validation/ValidationStudio.tsx');
+    const workbench = source('../components/studio/UnifiedValidationWorkbench.tsx');
+
+    expect(definition).toContain('Expected values/tolerances belong to Define. Actual readings belong to Execute.');
+    expect(definition).not.toContain('value={measurement.actualValue');
+    expect(definition).not.toContain('Mark step');
+    expect(definition).toContain('Definition references');
+    expect(definition).toContain('not validation run evidence');
+
+    expect(workbench).toContain("label=\"Define\"");
+    expect(workbench).toContain("label=\"Execute\"");
+    expect(workbench).toContain("label=\"Review\"");
+    expect(workbench).toContain('ValidationExecuteSurface');
+    expect(workbench).toContain('ValidationReviewSurface');
+    expect(workbench).not.toContain('runPanelOpen');
+  });
+
+  it('uses the shared Inspector and bottom dock for selection and run output', () => {
+    const workbench = source('../components/studio/UnifiedValidationWorkbench.tsx');
+
+    expect(workbench).toContain('<EngineeringEditorBar');
+    expect(workbench).toContain('<EngineeringInspector');
+    expect(workbench).toContain('<EngineeringBottomDock');
+    expect(workbench).toContain('title="Validation run output"');
+    expect(workbench).toContain('<EngineeringStatusBar');
+  });
+
+  it('preserves the existing bounded execution authority instead of broadening automation', () => {
+    const runner = source('../lib/validationRunner.ts');
+    const workbench = source('../components/studio/UnifiedValidationWorkbench.tsx');
+
+    expect(runner).toContain("export type ValidationExecutionMode = 'drc-auto' | 'firmware-state-auto' | 'mechanical-screen' | 'manual'");
+    expect(runner).toContain('approximate AABB collision screen');
+    expect(runner).toContain('Hardware Studio does not currently run a thermal solver');
+    expect(runner).toContain('Prior history remains immutable');
+    expect(workbench).toContain('Durable hashed evidence, exact version/DUT/equipment binding and reviewed immutability remain #19.');
+  });
+
+  it('keeps the old Validation component files only as the one controlled definition surface', () => {
+    expect(existsSync(new URL('../components/validation/ValidationStudio.tsx', import.meta.url))).toBe(true);
+    const definition = source('../components/validation/ValidationStudio.tsx');
+    expect(definition).toContain('useValidationWorkspaceUiStore');
+    expect(definition).not.toContain('EditorDockButton');
+  });
+});

--- a/src/__tests__/validationConvergence.test.ts
+++ b/src/__tests__/validationConvergence.test.ts
@@ -101,7 +101,8 @@ describe('U7 Validation convergence', () => {
     const workbench = source('../components/studio/UnifiedValidationWorkbench.tsx');
 
     expect(runner).toContain("export type ValidationExecutionMode = 'drc-auto' | 'firmware-state-auto' | 'mechanical-screen' | 'manual'");
-    expect(runner).toContain('approximate AABB collision screen');
+    expect(runner).toContain('Approximate AABB collision screen completed');
+    expect(runner).toContain('not CAD-kernel or physical clearance verification');
     expect(runner).toContain('Hardware Studio does not currently run a thermal solver');
     expect(runner).toContain('Prior history remains immutable');
     expect(workbench).toContain('Durable hashed evidence, exact version/DUT/equipment binding and reviewed immutability remain #19.');

--- a/src/__tests__/validationExecutionModeUx.test.ts
+++ b/src/__tests__/validationExecutionModeUx.test.ts
@@ -22,7 +22,7 @@ describe('validation execution mode UX contract', () => {
     expect(workbench).toContain('Run approximate screen');
     expect(workbench).toContain('exact CAD/physical evidence');
     expect(workbench).toContain('reviewer identity');
-    expect(workbench).toContain('No thermal solver is implemented in Hardware Studio yet');
+    expect(workbench).toContain('No internal thermal solver exists');
     expect(workbench).toContain('external simulation/lab evidence');
   });
 });

--- a/src/__tests__/validationFeedbackBaseline.test.ts
+++ b/src/__tests__/validationFeedbackBaseline.test.ts
@@ -11,11 +11,12 @@ describe('validation destructive-action baseline', () => {
   it('routes full test deletion through the shared feedback decision system', () => {
     expect(source).toContain("import { useFeedback } from '../feedback/FeedbackProvider';");
     expect(source).toContain('const feedback = useFeedback();');
+    expect(source).toContain('const deleteTest = async () =>');
     expect(source).toContain('const confirmed = await feedback.confirm({');
     expect(source).toContain("variant: 'destructive'");
     expect(source).toContain('if (!confirmed) return;');
     expect(source).toContain("store.executeProjectCommand('DEL_TEST'");
-    expect(source).toContain('onClick={handleDeleteTest}');
+    expect(source).toContain('onClick={() => void deleteTest()}');
   });
 
   it('does not use browser-native blocking dialogs in Validation Studio', () => {

--- a/src/components/StudioWorkbenchNavigation.tsx
+++ b/src/components/StudioWorkbenchNavigation.tsx
@@ -37,6 +37,7 @@ import { useProjectStore } from '../store/projectStore';
 import { PcbProjectDrawer } from './board/PcbProjectDrawer';
 import { MechanicalProjectDrawer } from './mechanical/MechanicalProjectDrawer';
 import { FirmwareProjectDrawer } from './firmware/FirmwareProjectDrawer';
+import { ValidationProjectDrawer } from './validation/ValidationProjectDrawer';
 
 interface StudioWorkbenchTabsProps {
   drawerOpen: boolean;
@@ -93,7 +94,7 @@ export const StudioWorkbenchTabs: React.FC<StudioWorkbenchTabsProps> = ({ drawer
   const setActiveView = useProjectStore((state) => state.setActiveView);
   const activeWorkbench = getWorkbenchForView(activeView);
   const contextualItems = getContextualNavigationItemsForView(activeView);
-  const hasDrawer = contextualItems.length > 0 || ['pcb', 'mechanical', 'firmware'].includes(activeWorkbench?.id || '');
+  const hasDrawer = contextualItems.length > 0 || ['pcb', 'mechanical', 'firmware', 'validation'].includes(activeWorkbench?.id || '');
 
   return (
     <div className="flex h-10 shrink-0 items-stretch border-b border-[#cfc9bd] bg-[#f4f0e7]" data-studio-shell="workbench-tabs">
@@ -159,6 +160,7 @@ export const StudioProjectDrawer: React.FC<StudioProjectDrawerProps> = ({ open }
   if (activeWorkbench.id === 'pcb') return <PcbProjectDrawer />;
   if (activeWorkbench.id === 'mechanical') return <MechanicalProjectDrawer />;
   if (activeWorkbench.id === 'firmware') return <FirmwareProjectDrawer />;
+  if (activeWorkbench.id === 'validation') return <ValidationProjectDrawer />;
   if (contextualItems.length === 0) return null;
 
   return (

--- a/src/components/studio/UnifiedValidationWorkbench.tsx
+++ b/src/components/studio/UnifiedValidationWorkbench.tsx
@@ -1,31 +1,47 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import {
+  AlertTriangle,
   CheckCircle2,
+  ClipboardList,
   FileCheck2,
   History,
   Link2,
+  PanelRight,
   Play,
   Plus,
-  RotateCcw,
   TestTube2,
-  X,
+  XCircle,
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore } from '../../store/studioContextStore';
+import {
+  useValidationWorkspaceUiStore,
+  type ValidationWorkspaceView,
+} from '../../store/validationWorkspaceUiStore';
+import type { ValidationRun, ValidationTest } from '../../types';
 import {
   getValidationExecutionMode,
   getValidationRunHistory,
   runValidationTest,
 } from '../../lib/validationRunner';
-import { useFeedback } from '../feedback/FeedbackProvider';
 import { ValidationStudio } from '../validation/ValidationStudio';
+import { useFeedback } from '../feedback/FeedbackProvider';
 import { EditorDockButton } from '../editor/EditorDockButton';
+import {
+  EditorToolButton,
+  EngineeringBottomDock,
+  EngineeringEditorBar,
+  EngineeringInspector,
+  EngineeringStatusBar,
+} from '../editor/EngineeringEditorShell';
 
 interface UnifiedValidationWorkbenchProps {
   initialMode: 'tests' | 'coverage' | 'factory-qa';
 }
+
+const EMPTY_RUNS: ValidationRun[] = [];
 
 function runStatusToTestStatus(status: string): string {
   if (status === 'Pass' || status === 'Passed') return 'Passed';
@@ -33,64 +49,231 @@ function runStatusToTestStatus(status: string): string {
   return 'In Progress';
 }
 
-export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProps> = ({ initialMode }) => {
-  const store = useProjectStore();
-  const feedback = useFeedback();
-  const {
-    boardComponents = [],
-    validationTests = [],
-    validationRuns = [],
-    addValidationTest,
-    executeProjectCommand,
-    updateProjectState,
-    updateValidationTest,
-  } = store;
-  const { activeBoardId, activeComponentId, activeNetName } = useStudioContextStore();
+function statusTone(status: string): string {
+  if (status === 'Pass' || status === 'Passed') return 'text-emerald-700';
+  if (status === 'Fail' || status === 'Failed') return 'text-rose-700';
+  return 'text-amber-700';
+}
 
-  const [runPanelOpen, setRunPanelOpen] = useState(false);
-  const [selectedRunTestId, setSelectedRunTestId] = useState('');
+function executionAuthority(test: ValidationTest | null): string {
+  if (!test) return 'Select a test explicitly before execution.';
+  const mode = getValidationExecutionMode(test.category, test.name || test.testName);
+  if (mode === 'drc-auto') return 'Local DRC rules may produce an automated verdict for this run.';
+  if (mode === 'firmware-state-auto') return 'Local state-machine structural validation may produce an automated verdict; compilation/runtime are not verified.';
+  if (mode === 'mechanical-screen') return 'Local Mechanical execution is an approximate AABB collision screen; a clean screen cannot auto-pass exact clearance.';
+  if ((test.category || '').trim().toLowerCase() === 'thermal') return 'No internal thermal solver exists; a verdict requires external evidence and reviewer identity.';
+  return 'This is a manual/physical validation path; an explicit engineer verdict is required.';
+}
+
+const EmptySelection: React.FC<{ title: string; detail: string }> = ({ title, detail }) => (
+  <div className="grid h-full min-h-0 place-items-center bg-white p-8 text-center">
+    <div className="max-w-sm">
+      <TestTube2 className="mx-auto h-8 w-8 text-slate-300" aria-hidden="true" />
+      <h2 className="mt-3 text-sm font-semibold text-slate-800">{title}</h2>
+      <p className="mt-1 text-xs leading-5 text-slate-500">{detail}</p>
+    </div>
+  </div>
+);
+
+const ValidationExecuteSurface: React.FC<{
+  test: ValidationTest | null;
+  onRunRecorded: (run: ValidationRun) => void;
+}> = ({ test, onRunRecorded }) => {
+  const feedback = useFeedback();
+  const validationRuns = useProjectStore((state) => state.validationRuns ?? EMPTY_RUNS);
+  const updateProjectState = useProjectStore((state) => state.updateProjectState);
+  const updateValidationTest = useProjectStore((state) => state.updateValidationTest);
   const [measurement, setMeasurement] = useState('');
   const [evidenceLink, setEvidenceLink] = useState('');
   const [operator, setOperator] = useState('');
   const [manualVerdict, setManualVerdict] = useState<'' | 'Pass' | 'Fail' | 'Inconclusive'>('');
 
-  const selectedComponent = activeComponentId
-    ? boardComponents.find((component) => component.id === activeComponentId)
-    : undefined;
-  const selectedNetIds = Array.from(new Set(
-    (selectedComponent?.pins || [])
-      .map((pin) => pin.netId)
-      .filter((netId): netId is string => Boolean(netId)),
-  ));
-  const linkedTests = selectedComponent
-    ? validationTests.filter((test) => (test.linkedComponentIds || []).includes(selectedComponent.id))
-    : [];
-  const runTest = validationTests.find((test) => test.id === selectedRunTestId)
-    || linkedTests[0]
-    || validationTests[0];
-  const runHistory = runTest ? getValidationRunHistory({ ...store, validationRuns }, runTest.id) : [];
-  const latestRun = runHistory[0];
-  const executionMode = getValidationExecutionMode(runTest?.category, runTest?.name || runTest?.testName);
+  if (!test) {
+    return <EmptySelection title="Select a test to execute" detail="Execution never falls back to the first or linked test. Choose the exact definition in the Validation Project Drawer." />;
+  }
+
+  const project = useProjectStore.getState();
+  const runHistory = getValidationRunHistory({ ...project, validationRuns }, test.id);
+  const executionMode = getValidationExecutionMode(test.category, test.name || test.testName);
   const automatedRun = executionMode === 'drc-auto' || executionMode === 'firmware-state-auto';
   const mechanicalScreenRun = executionMode === 'mechanical-screen';
-  const thermalReview = (runTest?.category || '').trim().toLowerCase() === 'thermal';
+  const thermalReview = (test.category || '').trim().toLowerCase() === 'thermal';
   const evidenceBackedReview = mechanicalScreenRun || thermalReview;
 
-  const contextualComponentCount = useMemo(
-    () => boardComponents.filter((component) => !activeBoardId || component.boardId === activeBoardId).length,
-    [activeBoardId, boardComponents],
-  );
-
-  const createLinkedTest = () => {
-    if (!selectedComponent) {
+  const recordRun = () => {
+    if (!automatedRun && !mechanicalScreenRun && !manualVerdict) {
+      feedback.notify({ tone: 'warning', title: 'Engineer verdict required', detail: 'Choose Pass, Fail, or Inconclusive after reviewing the procedure and evidence.' });
+      return;
+    }
+    if (evidenceBackedReview && manualVerdict && (!evidenceLink.trim() || !operator.trim())) {
       feedback.notify({
         tone: 'warning',
-        title: 'Select a component first',
-        detail: 'Choose a canonical component in Electronics or PCB before creating component-linked validation evidence.',
+        title: 'Evidence and reviewer required',
+        detail: mechanicalScreenRun
+          ? 'A Mechanical verdict requires an exact CAD/physical evidence reference plus reviewer identity; the approximate local screen alone cannot verify clearance.'
+          : 'A Thermal verdict requires external simulation/lab evidence plus reviewer identity because Hardware Studio does not run a thermal solver.',
       });
       return;
     }
-    executeProjectCommand('ADD_COMPONENT_TEST', `Create validation test for ${selectedComponent.referenceDesignator}`, () =>
+
+    const current = useProjectStore.getState();
+    const { run, updatedRuns } = runValidationTest(current, test.id, {
+      measuredValue: measurement.trim() || undefined,
+      evidenceLink: evidenceLink.trim() || undefined,
+      runBy: operator.trim() || undefined,
+      manualVerdict: automatedRun ? undefined : manualVerdict || undefined,
+    });
+    updateProjectState({ validationRuns: updatedRuns });
+    updateValidationTest(test.id, { status: runStatusToTestStatus(run.status) });
+    onRunRecorded(run);
+    setMeasurement('');
+    setEvidenceLink('');
+    setManualVerdict('');
+    feedback.notify({
+      tone: run.status === 'Fail' || run.status === 'Failed' ? 'error' : run.status === 'Pass' || run.status === 'Passed' ? 'success' : 'warning',
+      title: `${run.testName || test.name} · run #${run.runNumber || 1}`,
+      detail: runHistory.length > 0 ? `${run.status}. Retest appended; prior run history remains present.` : `${run.status}. First run record captured.`,
+    });
+  };
+
+  const actionLabel = executionMode === 'drc-auto'
+    ? 'Run local DRC validation'
+    : executionMode === 'firmware-state-auto'
+      ? 'Run structural state check'
+      : mechanicalScreenRun && !manualVerdict
+        ? 'Run approximate screen'
+        : runHistory.length > 0
+          ? 'Record retest'
+          : 'Record run';
+
+  return (
+    <main className="h-full min-h-0 overflow-y-auto bg-white" aria-label={`Execute ${test.name}`}>
+      <div className="mx-auto max-w-5xl p-5">
+        <div className="border-b border-slate-300 pb-4">
+          <div className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-400">Execute · explicit test</div>
+          <h2 className="mt-1 text-lg font-semibold text-slate-950">{test.name}</h2>
+          <p className="mt-1 text-[10px] leading-5 text-slate-500">{executionAuthority(test)}</p>
+        </div>
+
+        <section className="border-b border-slate-200 py-5">
+          <h3 className="text-xs font-semibold text-slate-900">Procedure snapshot</h3>
+          <p className="mt-1 text-[10px] text-slate-500">The current runner snapshots this procedure into the run. Per-step execution state/recovery remains #19.</p>
+          <ol className="mt-3 divide-y divide-slate-100 border-y border-slate-200">
+            {test.steps.map((step, index) => <li key={`${step.stepNumber}-${index}`} className="grid gap-2 px-2 py-2.5 text-[10px] sm:grid-cols-[2rem_minmax(0,1fr)_minmax(0,1fr)]"><span className="font-mono text-slate-400">{index + 1}</span><span className="text-slate-800">{step.instruction || 'Instruction unresolved'}</span><span className="text-slate-500">{step.expectedResult || 'Expected result unresolved'}</span></li>)}
+            {test.steps.length === 0 && <li className="py-5 text-center text-[10px] text-amber-700">No procedure steps are defined.</li>}
+          </ol>
+        </section>
+
+        <section className="border-b border-slate-200 py-5">
+          <h3 className="text-xs font-semibold text-slate-900">Measurement definitions</h3>
+          <p className="mt-1 text-[10px] text-slate-500">Expected/tolerance schema is read-only during this run. The current local runner records one observation summary; typed per-measurement execution belongs to #19.</p>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {test.measurements.map((item) => <div key={item.id} className="border border-slate-200 bg-[#fbfaf6] p-2.5 text-[9px]"><div className="font-semibold text-slate-800">{item.name || 'Unnamed measurement'} <span className="font-normal text-slate-400">· {item.type}</span></div><div className="mt-1 font-mono text-slate-500">expected {item.expectedValue == null ? 'unresolved' : String(item.expectedValue)}{item.unit ? ` ${item.unit}` : ''}{item.tolerancePlus != null || item.toleranceMinus != null ? ` · +${item.tolerancePlus ?? '?'} / -${item.toleranceMinus ?? '?'}` : ''}</div></div>)}
+            {test.measurements.length === 0 && <p className="text-[10px] text-slate-400">No measurement schema defined.</p>}
+          </div>
+        </section>
+
+        <section className="py-5">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div>
+              <label className="block text-[10px] font-semibold text-slate-600">Observed measurement / behavior<textarea value={measurement} onChange={(event) => setMeasurement(event.target.value)} placeholder="Record what was actually measured or observed" className="mt-1 min-h-28 w-full resize-y border border-slate-300 p-2.5 text-xs font-normal leading-5 outline-none focus:border-slate-500" /></label>
+              {!automatedRun && <label className="mt-3 block text-[10px] font-semibold text-slate-600">Engineer verdict{mechanicalScreenRun ? ' · optional for screen-only run' : ''}<select value={manualVerdict} onChange={(event) => setManualVerdict(event.target.value as typeof manualVerdict)} className="mt-1 h-9 w-full border border-slate-300 bg-white px-2.5 text-xs font-normal"><option value="">Choose verdict…</option><option value="Pass">Pass</option><option value="Fail">Fail</option><option value="Inconclusive">Inconclusive</option></select></label>}
+            </div>
+            <div>
+              <label className="block text-[10px] font-semibold text-slate-600">Evidence reference{evidenceBackedReview && manualVerdict ? ' · required' : ''}<input value={evidenceLink} onChange={(event) => setEvidenceLink(event.target.value)} placeholder="File, URL, log, image, CAD review or lab reference" className="mt-1 h-9 w-full border border-slate-300 bg-white px-2.5 text-xs font-normal" /></label>
+              <label className="mt-3 block text-[10px] font-semibold text-slate-600">Operator / reviewer{evidenceBackedReview && manualVerdict ? ' · required' : ''}<input value={operator} onChange={(event) => setOperator(event.target.value)} placeholder="Name or role" className="mt-1 h-9 w-full border border-slate-300 bg-white px-2.5 text-xs font-normal" /></label>
+              <div className="mt-3 border-l-2 border-amber-400 bg-amber-50 px-3 py-2 text-[9px] leading-4 text-amber-900">Run evidence is stored in the current project record. Durable hashed evidence, exact version/DUT/equipment binding and reviewed immutability remain #19.</div>
+            </div>
+          </div>
+          <button type="button" onClick={recordRun} className="mt-4 inline-flex h-9 items-center gap-2 bg-slate-950 px-3 text-xs font-semibold text-white"><Play className="h-4 w-4" /> {actionLabel}</button>
+        </section>
+      </div>
+    </main>
+  );
+};
+
+const ValidationReviewSurface: React.FC<{
+  test: ValidationTest | null;
+  selectedRunId: string | null;
+  onSelectRun: (runId: string) => void;
+}> = ({ test, selectedRunId, onSelectRun }) => {
+  const project = useProjectStore();
+  if (!test) return <EmptySelection title="Select a test to review" detail="Review never chooses the newest or first test implicitly. Select the exact test or a run from the Project Drawer." />;
+
+  const history = getValidationRunHistory(project, test.id);
+  const selectedRun = selectedRunId ? history.find((run) => run.id === selectedRunId) ?? null : null;
+
+  return (
+    <main className="flex h-full min-h-0 overflow-hidden bg-white" aria-label={`Review ${test.name}`}>
+      <section className="w-[min(340px,42%)] shrink-0 overflow-y-auto border-r border-slate-200 bg-[#fbfaf6]">
+        <div className="border-b border-slate-200 p-3"><div className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-400">Review · append-only history</div><h2 className="mt-1 text-[12px] font-semibold text-slate-900">{test.name}</h2><p className="mt-1 text-[9px] leading-4 text-slate-500">Select a run explicitly. Historical snapshots are displayed read-only.</p></div>
+        <div className="p-1.5">
+          {history.map((run) => {
+            const active = selectedRunId === run.id;
+            return <button key={run.id} type="button" onClick={() => onSelectRun(run.id)} aria-pressed={active} className={`mb-1 w-full border px-2.5 py-2 text-left ${active ? 'border-slate-950 bg-slate-950 text-white' : 'border-slate-200 bg-white hover:border-slate-400'}`}><div className="flex items-center gap-2"><span className={`h-2 w-2 rounded-full ${run.status === 'Pass' || run.status === 'Passed' ? 'bg-emerald-500' : run.status === 'Fail' || run.status === 'Failed' ? 'bg-rose-500' : 'bg-amber-500'}`} /><span className="text-[10px] font-semibold">Run #{run.runNumber || 1}</span><span className={`ml-auto text-[9px] font-semibold ${active ? 'text-white/70' : statusTone(run.status)}`}>{run.status}</span></div><div className={`mt-1 truncate text-[8px] ${active ? 'text-white/55' : 'text-slate-400'}`}>{run.timestamp || 'time unresolved'} · {run.runBy || 'actor unresolved'}</div></button>;
+          })}
+          {history.length === 0 && <p className="p-3 text-[10px] leading-4 text-slate-400">No runs exist for this test. Define the test, then execute it explicitly.</p>}
+        </div>
+      </section>
+
+      <section className="min-w-0 flex-1 overflow-y-auto p-5">
+        {selectedRun ? (
+          <div className="mx-auto max-w-3xl">
+            <div className="flex items-start justify-between gap-3 border-b border-slate-300 pb-4"><div><div className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-400">Frozen run snapshot</div><h3 className="mt-1 text-lg font-semibold text-slate-950">Run #{selectedRun.runNumber || 1}</h3><p className="mt-1 text-[10px] text-slate-500">{selectedRun.timestamp || 'Timestamp unresolved'} · {selectedRun.runBy || 'Actor unresolved'}</p></div><span className={`text-sm font-semibold ${statusTone(selectedRun.status)}`}>{selectedRun.status}</span></div>
+            <dl className="grid gap-3 border-b border-slate-200 py-4 sm:grid-cols-2"><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Observed value</dt><dd className="mt-1 text-xs text-slate-800">{selectedRun.measuredValue == null ? 'Not recorded' : String(selectedRun.measuredValue)}</dd></div><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Environment</dt><dd className="mt-1 text-xs text-slate-800">{selectedRun.environment || 'Not recorded'}</dd></div><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Pass criteria snapshot</dt><dd className="mt-1 text-xs leading-5 text-slate-800">{selectedRun.passCriteria || 'Not recorded'}</dd></div><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Evidence reference</dt><dd className="mt-1 break-all text-xs text-slate-800">{selectedRun.evidenceLink || 'Not recorded'}</dd></div></dl>
+            <section className="py-4"><h4 className="text-xs font-semibold text-slate-900">Captured procedure snapshot</h4><div className="mt-2 divide-y divide-slate-100 border-y border-slate-200">{(selectedRun.stepResults || []).map((step, index) => <div key={`${step.stepNumber}-${index}`} className="grid gap-2 px-2 py-2 text-[10px] sm:grid-cols-[2rem_minmax(0,1fr)_minmax(0,1fr)]"><span className="font-mono text-slate-400">{index + 1}</span><span>{step.instruction}</span><span className="text-slate-500">{step.expectedResult}</span></div>)}{(selectedRun.stepResults || []).length === 0 && <p className="py-4 text-center text-[10px] text-slate-400">No procedure snapshot recorded.</p>}</div></section>
+            <section className="border-t border-slate-200 py-4"><h4 className="text-xs font-semibold text-slate-900">Evidence snapshot</h4><div className="mt-2 space-y-1">{(selectedRun.evidence || []).map((item, index) => <div key={`${String((item as { id?: string }).id || 'evidence')}-${index}`} className="border border-slate-200 px-2.5 py-2 text-[10px] text-slate-600">{typeof item === 'object' && item ? String((item as { value?: unknown }).value ?? JSON.stringify(item)) : String(item)}</div>)}{(selectedRun.evidence || []).length === 0 && <p className="text-[10px] text-slate-400">No frozen evidence items recorded.</p>}</div></section>
+          </div>
+        ) : <EmptySelection title="Select a run" detail="Run history is visible at left, but Review does not silently select the latest run. Choose the exact snapshot you want to inspect." />}
+      </section>
+    </main>
+  );
+};
+
+export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProps> = ({ initialMode }) => {
+  const tests = useProjectStore((state) => state.validationTests ?? []);
+  const runs = useProjectStore((state) => state.validationRuns ?? EMPTY_RUNS);
+  const boardComponents = useProjectStore((state) => state.boardComponents ?? []);
+  const setActiveView = useProjectStore((state) => state.setActiveView);
+  const addValidationTest = useProjectStore((state) => state.addValidationTest);
+  const executeProjectCommand = useProjectStore((state) => state.executeProjectCommand);
+  const activeComponentId = useStudioContextStore((state) => state.activeComponentId);
+
+  const view = useValidationWorkspaceUiStore((state) => state.view);
+  const selectedTestId = useValidationWorkspaceUiStore((state) => state.selectedTestId);
+  const selectedRunId = useValidationWorkspaceUiStore((state) => state.selectedRunId);
+  const inspectorOpen = useValidationWorkspaceUiStore((state) => state.inspectorOpen);
+  const bottomDockOpen = useValidationWorkspaceUiStore((state) => state.bottomDockOpen);
+  const setView = useValidationWorkspaceUiStore((state) => state.setView);
+  const setDrawerSection = useValidationWorkspaceUiStore((state) => state.setDrawerSection);
+  const setSelectedTestId = useValidationWorkspaceUiStore((state) => state.setSelectedTestId);
+  const setSelectedRunId = useValidationWorkspaceUiStore((state) => state.setSelectedRunId);
+  const setInspectorOpen = useValidationWorkspaceUiStore((state) => state.setInspectorOpen);
+  const setBottomDockOpen = useValidationWorkspaceUiStore((state) => state.setBottomDockOpen);
+
+  const selectedTest = selectedTestId ? tests.find((test) => test.id === selectedTestId) ?? null : null;
+  const selectedRun = selectedRunId ? runs.find((run) => run.id === selectedRunId) ?? null : null;
+  const selectedComponent = activeComponentId ? boardComponents.find((component) => component.id === activeComponentId) ?? null : null;
+
+  const effectiveView: ValidationWorkspaceView = initialMode === 'coverage'
+    ? 'coverage'
+    : initialMode === 'factory-qa'
+      ? 'factory-qa'
+      : view === 'coverage' || view === 'factory-qa'
+        ? 'define'
+        : view;
+
+  const switchJob = (nextView: 'define' | 'execute' | 'review') => {
+    setView(nextView);
+    setActiveView('validation-studio');
+    setDrawerSection(nextView === 'review' ? 'runs' : 'tests');
+  };
+
+  const createLinkedTest = () => {
+    if (!selectedComponent) return;
+    const beforeIds = new Set((useProjectStore.getState().validationTests ?? []).map((test) => test.id));
+    const selectedNetIds = Array.from(new Set((selectedComponent.pins || []).map((pin) => pin.netId).filter((netId): netId is string => Boolean(netId))));
+    executeProjectCommand('ADD_COMPONENT_TEST', `Create validation test for ${selectedComponent.referenceDesignator}`, () => {
       addValidationTest({
         name: `${selectedComponent.referenceDesignator} ${selectedComponent.componentName} validation`,
         stage: 'EVT',
@@ -100,167 +283,66 @@ export const UnifiedValidationWorkbench: React.FC<UnifiedValidationWorkbenchProp
         linkedComponentIds: [selectedComponent.id],
         linkedNetIds: selectedNetIds,
         linkedFirmwareModuleIds: [],
-        steps: [
-          {
-            stepNumber: 1,
-            instruction: `Inspect ${selectedComponent.referenceDesignator}, its footprint, orientation, and connected nets before applying power.`,
-            expectedResult: 'The physical and electrical implementation matches the reviewed component definition and schematic intent.',
-            completed: false,
-          },
-        ],
+        steps: [{ stepNumber: 1, instruction: `Inspect ${selectedComponent.referenceDesignator}, its footprint, orientation and connected nets before applying power.`, expectedResult: 'Physical/electrical implementation matches reviewed intent.', completed: false }],
         measurements: [],
-        passCriteria: [
-          `${selectedComponent.referenceDesignator} is correctly placed and electrically connected for the intended test.`,
-        ],
+        passCriteria: [`${selectedComponent.referenceDesignator} is correctly placed and electrically connected for the intended validation.`],
         status: 'Not Started',
         evidence: [],
-      })
-    );
-    feedback.notify({ tone: 'success', title: 'Linked test created', detail: `Validation now references ${selectedComponent.referenceDesignator} by canonical component ID.` });
+      });
+    });
+    const created = (useProjectStore.getState().validationTests ?? []).find((test) => !beforeIds.has(test.id));
+    if (created) {
+      setSelectedTestId(created.id);
+      switchJob('define');
+      setInspectorOpen(true);
+    }
   };
 
-  const recordRun = () => {
-    if (!runTest) {
-      feedback.notify({ tone: 'warning', title: 'No validation test selected', detail: 'Create or select a validation test before recording evidence.' });
-      return;
-    }
-
-    if (!automatedRun && !mechanicalScreenRun && !manualVerdict) {
-      feedback.notify({
-        tone: 'warning',
-        title: 'Engineer verdict required',
-        detail: 'This validation type is not fully automated. Choose Pass, Fail, or Inconclusive after reviewing the procedure and evidence.',
-      });
-      return;
-    }
-
-    if (evidenceBackedReview && manualVerdict && (!evidenceLink.trim() || !operator.trim())) {
-      feedback.notify({
-        tone: 'warning',
-        title: 'Evidence and reviewer required',
-        detail: mechanicalScreenRun
-          ? 'A reviewed Mechanical verdict requires an exact CAD/physical evidence reference and reviewer identity. You can run the approximate screen without a verdict first.'
-          : 'A Thermal verdict requires external simulation/lab evidence and reviewer identity because Hardware Studio does not run a thermal solver yet.',
-      });
-      return;
-    }
-
-    const previousRunCount = runHistory.length;
-    const { run, updatedRuns } = runValidationTest(store, runTest.id, {
-      measuredValue: measurement.trim() || undefined,
-      evidenceLink: evidenceLink.trim() || undefined,
-      runBy: operator.trim() || undefined,
-      manualVerdict: automatedRun ? undefined : manualVerdict || undefined,
-    });
-    updateProjectState({ validationRuns: updatedRuns });
-    updateValidationTest(runTest.id, { status: runStatusToTestStatus(run.status) });
-    feedback.notify({
-      tone: run.status === 'Fail' || run.status === 'Failed' ? 'error' : run.status === 'Pass' || run.status === 'Passed' ? 'success' : 'warning',
-      title: `${run.testName || runTest.name} · run #${run.runNumber || 1}`,
-      detail: previousRunCount > 0
-        ? `${run.status}. Retest recorded without replacing the previous run.`
-        : `${run.status}. First immutable run record captured.`,
-    });
-    setMeasurement('');
-    setEvidenceLink('');
-    setManualVerdict('');
+  const onRunRecorded = (run: ValidationRun) => {
+    setSelectedRunId(run.id);
+    setBottomDockOpen(true);
   };
 
-  const measurementPlaceholder = automatedRun
-    ? 'Optional reading or observation'
-    : mechanicalScreenRun
-      ? 'Optional observation; the local screen uses recorded explicit geometry'
-      : thermalReview
-        ? 'Record measured temperature, simulation result, or lab observation'
-        : 'Record the observed result';
+  const onSelectRun = (runId: string) => {
+    setSelectedRunId(runId);
+    setBottomDockOpen(true);
+  };
 
-  const runActionLabel = mechanicalScreenRun && !manualVerdict
-    ? 'Run approximate screen'
-    : runHistory.length > 0
-      ? 'Record retest'
-      : 'Record run';
+  const title = effectiveView === 'coverage' ? 'Coverage' : effectiveView === 'factory-qa' ? 'Factory QA' : effectiveView === 'define' ? 'Define' : effectiveView === 'execute' ? 'Execute' : 'Review';
+  const history = selectedTest ? getValidationRunHistory({ ...useProjectStore.getState(), validationRuns: runs }, selectedTest.id) : EMPTY_RUNS;
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-50" aria-label="Context-aware validation workbench">
-      <header className="flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-slate-300 bg-white px-3 py-1.5">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <TestTube2 className="h-4 w-4 shrink-0 text-slate-500" aria-hidden="true" />
-          <div className="min-w-0">
-            <p className="truncate text-[11px] font-semibold text-slate-900">
-              {initialMode === 'tests' ? 'Validation tests' : initialMode === 'coverage' ? 'Requirement coverage' : 'Factory QA'}
-            </p>
-            <p className="truncate text-[9px] text-slate-500">
-              {selectedComponent
-                ? `${selectedComponent.referenceDesignator} · ${selectedComponent.componentName} · ${linkedTests.length} linked tests · ${selectedNetIds.length} nets`
-                : `${validationTests.length} tests · ${validationRuns.length} immutable runs · ${contextualComponentCount} components in current board context`}
-              {activeNetName ? ` · active net ${activeNetName}` : ''}
-            </p>
-          </div>
-        </div>
+    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-[#ebe8df]" aria-label="Validation workbench">
+      <EngineeringEditorBar
+        domain="Validation"
+        title={title}
+        meta={selectedTest ? `${selectedTest.name} · ${history.length} run${history.length === 1 ? '' : 's'}` : `${tests.length} test definitions · explicit selection required`}
+        tools={<><EditorToolButton label="Define" active={effectiveView === 'define'} onClick={() => switchJob('define')}><ClipboardList className="h-4 w-4" /></EditorToolButton><EditorToolButton label="Execute" active={effectiveView === 'execute'} onClick={() => switchJob('execute')}><Play className="h-4 w-4" /></EditorToolButton><EditorToolButton label="Review" active={effectiveView === 'review'} onClick={() => switchJob('review')}><History className="h-4 w-4" /></EditorToolButton></>}
+        docks={<><EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} count={selectedTest || selectedRun ? 1 : 0} onClick={() => setInspectorOpen(!inspectorOpen)} />{selectedRun && <EditorDockButton label="Run output" icon={FileCheck2} active={bottomDockOpen} count={selectedRun.logs.length} onClick={() => setBottomDockOpen(!bottomDockOpen)} />}</>}
+        actions={selectedComponent ? <button type="button" onClick={createLinkedTest} className="inline-flex h-8 items-center gap-1.5 border border-slate-300 bg-white px-2.5 text-[9px] font-semibold text-slate-700 hover:border-slate-500"><Plus className="h-3.5 w-3.5" /> Test {selectedComponent.referenceDesignator}</button> : undefined}
+      />
 
-        <div className="ml-auto flex items-center gap-1.5">
-          {initialMode === 'tests' && (
-            <button type="button" onClick={createLinkedTest} className="inline-flex min-h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-400">
-              <Plus className="h-3.5 w-3.5" /> Linked test
-            </button>
-          )}
-          <EditorDockButton label="Run evidence" icon={FileCheck2} active={runPanelOpen} count={runHistory.length} onClick={() => setRunPanelOpen((value) => !value)} />
-        </div>
-      </header>
+      <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
+        {effectiveView === 'coverage' ? <ValidationStudio initialMode="coverage" /> : effectiveView === 'factory-qa' ? <ValidationStudio initialMode="factory-qa" /> : effectiveView === 'define' ? <ValidationStudio initialMode="tests" /> : effectiveView === 'execute' ? <ValidationExecuteSurface key={selectedTest?.id ?? 'no-test'} test={selectedTest} onRunRecorded={onRunRecorded} /> : <ValidationReviewSurface test={selectedTest} selectedRunId={selectedRunId} onSelectRun={onSelectRun} />}
 
-      <div className="relative min-h-0 flex-1 overflow-hidden">
-        <ValidationStudio initialMode={initialMode} />
+        <EngineeringInspector open={inspectorOpen} onClose={() => setInspectorOpen(false)} subtitle={selectedRun ? 'Selected immutable run snapshot' : selectedTest ? 'Selected test definition' : 'No validation selection'}>
+          {selectedRun ? (
+            <div className="space-y-3 p-3 text-[10px]"><div><div className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Run</div><div className="mt-1 font-semibold text-slate-900">#{selectedRun.runNumber || 1} · {selectedRun.status}</div></div><dl className="space-y-2 text-slate-600"><div><dt className="text-[8px] uppercase text-slate-400">Test</dt><dd>{selectedRun.testName || selectedRun.testId}</dd></div><div><dt className="text-[8px] uppercase text-slate-400">Timestamp</dt><dd>{selectedRun.timestamp || 'Unresolved'}</dd></div><div><dt className="text-[8px] uppercase text-slate-400">Actor</dt><dd>{selectedRun.runBy || 'Unresolved'}</dd></div><div><dt className="text-[8px] uppercase text-slate-400">Evidence</dt><dd className="break-all">{selectedRun.evidenceLink || 'No external reference'}</dd></div><div><dt className="text-[8px] uppercase text-slate-400">Environment</dt><dd>{selectedRun.environment || 'Unresolved'}</dd></div></dl><div className="border-l-2 border-amber-400 pl-2 text-[9px] leading-4 text-slate-500">Displayed read-only. #19 remains responsible for reviewed immutable evidence/provenance policy.</div></div>
+          ) : selectedTest ? (
+            <div className="space-y-3 p-3 text-[10px]"><div><div className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Definition</div><div className="mt-1 font-semibold text-slate-900">{selectedTest.name}</div><div className="mt-0.5 text-slate-500">{selectedTest.stage || 'stage unresolved'} · {selectedTest.category || 'category unresolved'}</div></div><dl className="grid grid-cols-2 gap-2 text-slate-600"><div><dt className="text-[8px] uppercase text-slate-400">Requirements</dt><dd className="font-mono">{selectedTest.linkedRequirementIds.length}</dd></div><div><dt className="text-[8px] uppercase text-slate-400">Components</dt><dd className="font-mono">{selectedTest.linkedComponentIds?.length || 0}</dd></div><div><dt className="text-[8px] uppercase text-slate-400">Procedure</dt><dd className="font-mono">{selectedTest.steps.length}</dd></div><div><dt className="text-[8px] uppercase text-slate-400">Runs</dt><dd className="font-mono">{history.length}</dd></div></dl><div className="border-t border-slate-200 pt-2 text-[9px] leading-4 text-slate-500">{executionAuthority(selectedTest)}</div></div>
+          ) : <div className="p-3 text-[10px] leading-5 text-slate-500">Select a test or run explicitly in the Validation Project Drawer. Opening the workbench does not choose one for you.</div>}
+        </EngineeringInspector>
 
-        {runPanelOpen && (
-          <aside className="absolute bottom-3 right-3 top-3 z-40 flex w-[min(360px,calc(100%-1.5rem))] flex-col overflow-hidden rounded-lg border border-slate-300 bg-white shadow-xl" aria-label="Validation run evidence">
-            <div className="flex items-start justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-2.5">
-              <div><p className="text-[11px] font-semibold text-slate-900">Record run evidence</p><p className="mt-0.5 text-[9px] leading-4 text-slate-500">Runs are append-only. A screen, measurement, or visual review never implies Pass unless that validation mode can actually support the verdict.</p></div>
-              <button type="button" onClick={() => setRunPanelOpen(false)} className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-slate-500 hover:bg-slate-200" aria-label="Close run evidence"><X className="h-3.5 w-3.5" /></button>
-            </div>
-
-            <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
-              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Test</span><select value={runTest?.id || ''} onChange={(event) => setSelectedRunTestId(event.target.value)} className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-800 outline-none focus:border-slate-500">{validationTests.length === 0 && <option value="">No validation tests</option>}{validationTests.map((test) => <option key={test.id} value={test.id}>{test.name} · {test.category || 'Manual'}</option>)}</select></label>
-
-              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Measurement / observation</span><textarea value={measurement} onChange={(event) => setMeasurement(event.target.value)} placeholder={measurementPlaceholder} className="mt-1 min-h-20 w-full resize-y rounded-md border border-slate-300 bg-white p-2.5 text-[10px] leading-5 outline-none focus:border-slate-500" /></label>
-
-              {executionMode === 'drc-auto' && (
-                <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2.5 text-[10px] font-semibold leading-4 text-emerald-800">The implemented local DRC rules derive this verdict from recorded PCB state.</div>
-              )}
-              {executionMode === 'firmware-state-auto' && (
-                <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2.5 text-[10px] font-semibold leading-4 text-emerald-800">The local state-machine validator checks structural reachability only. It does not verify compilation, timing, hardware behavior, or runtime correctness.</div>
-              )}
-              {mechanicalScreenRun && (
-                <div className="rounded-md border border-amber-200 bg-amber-50 p-2.5 text-[10px] font-semibold leading-4 text-amber-900">Mechanical first runs an approximate AABB collision screen. A detected collision can fail the run; a clean screen stays Needs Review unless an engineer records a verdict with exact CAD/physical evidence and reviewer identity.</div>
-              )}
-              {thermalReview && (
-                <div className="rounded-md border border-amber-200 bg-amber-50 p-2.5 text-[10px] font-semibold leading-4 text-amber-900">No thermal solver is implemented in Hardware Studio yet. Thermal verdicts require external simulation/lab evidence plus reviewer identity.</div>
-              )}
-
-              {!automatedRun && (
-                <label className="block"><span className="text-[9px] font-semibold text-slate-500">Engineer verdict{mechanicalScreenRun ? ' (optional for screen-only run)' : ''}</span><select value={manualVerdict} onChange={(event) => setManualVerdict(event.target.value as typeof manualVerdict)} className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold outline-none focus:border-slate-500"><option value="">Choose verdict…</option><option value="Pass">Pass</option><option value="Fail">Fail</option><option value="Inconclusive">Inconclusive</option></select></label>
-              )}
-
-              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Evidence reference{evidenceBackedReview && manualVerdict ? ' · required' : ''}</span><input value={evidenceLink} onChange={(event) => setEvidenceLink(event.target.value)} placeholder="File, URL, log, image, CAD review, simulation, or lab reference" className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] outline-none focus:border-slate-500" /></label>
-              <label className="block"><span className="text-[9px] font-semibold text-slate-500">Operator / reviewer{evidenceBackedReview && manualVerdict ? ' · required' : ''}</span><input value={operator} onChange={(event) => setOperator(event.target.value)} placeholder="Name or role" className="mt-1 h-9 w-full rounded-md border border-slate-300 bg-white px-2.5 text-[10px] outline-none focus:border-slate-500" /></label>
-
-              <div className="rounded-md border border-slate-200 bg-slate-50 p-2.5">
-                <div className="flex items-center gap-1.5 text-[10px] font-semibold text-slate-700"><History className="h-3.5 w-3.5" /> Run history</div>
-                {latestRun ? <p className="mt-1 text-[9px] leading-4 text-slate-500"><strong className="text-slate-700">Latest:</strong> run #{latestRun.runNumber || 1} · {latestRun.status} · {latestRun.timestamp || 'time not recorded'} · {Math.max(0, runHistory.length - 1)} prior preserved</p> : <p className="mt-1 text-[9px] leading-4 text-slate-500">No immutable run evidence yet.</p>}
-              </div>
-
-              {selectedComponent && linkedTests.length > 0 && <div className="flex items-start gap-2 rounded-md border border-emerald-200 bg-emerald-50 p-2.5 text-[9px] leading-4 text-emerald-900"><CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" /><span><strong>Linked:</strong> {linkedTests.map((test) => `${test.name} (${test.status})`).join(' · ')}</span></div>}
-              {selectedComponent && linkedTests.length === 0 && <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-2.5 text-[9px] leading-4 text-amber-900"><Link2 className="mt-0.5 h-3.5 w-3.5 shrink-0" /><span>This selected component has no linked validation definition yet.</span></div>}
-            </div>
-
-            <div className="border-t border-slate-200 bg-slate-50 p-3">
-              <button type="button" onClick={recordRun} disabled={!runTest} className="inline-flex min-h-9 w-full items-center justify-center gap-1.5 rounded-md bg-slate-950 px-3 text-[10px] font-semibold text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-40">
-                {runHistory.length > 0 ? <RotateCcw className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
-                {runActionLabel}
-              </button>
-            </div>
-          </aside>
-        )}
+        <EngineeringBottomDock open={bottomDockOpen && Boolean(selectedRun)} title="Validation run output" subtitle={selectedRun ? `${selectedRun.testName || selectedRun.testId} · run #${selectedRun.runNumber || 1} · ${selectedRun.status}` : undefined} onClose={() => setBottomDockOpen(false)} heightClassName="h-[220px]">
+          {selectedRun && <div className="h-full overflow-auto bg-[#1b1a18] p-3 font-mono text-[9px] leading-5 text-[#d7d2c8]">{selectedRun.logs.map((line, index) => <div key={`${index}-${line}`}><span className="mr-2 text-[#777168]">{String(index + 1).padStart(2, '0')}</span>{line}</div>)}</div>}
+        </EngineeringBottomDock>
       </div>
+
+      <EngineeringStatusBar
+        left={<span>{title} · {selectedTest ? selectedTest.name : 'no test selected'}</span>}
+        center={<span>{effectiveView === 'execute' ? executionAuthority(selectedTest) : effectiveView === 'review' ? 'Run history is read-only; selection is explicit.' : effectiveView === 'define' ? 'Definition schema only; execution evidence is separate.' : 'Traceability context; passing evidence still required.'}</span>}
+        right={<span>{tests.length} tests · {runs.length} runs</span>}
+      />
     </section>
   );
 };

--- a/src/components/studio/UnifiedValidationWorkbench.tsx
+++ b/src/components/studio/UnifiedValidationWorkbench.tsx
@@ -2,17 +2,13 @@
 
 import React, { useState } from 'react';
 import {
-  AlertTriangle,
-  CheckCircle2,
   ClipboardList,
   FileCheck2,
   History,
-  Link2,
   PanelRight,
   Play,
   Plus,
   TestTube2,
-  XCircle,
 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
 import { useStudioContextStore } from '../../store/studioContextStore';
@@ -41,7 +37,24 @@ interface UnifiedValidationWorkbenchProps {
   initialMode: 'tests' | 'coverage' | 'factory-qa';
 }
 
+interface ValidationRunStepSnapshot {
+  stepNumber?: number;
+  instruction: string;
+  expectedResult: string;
+  completed?: boolean;
+}
+
 const EMPTY_RUNS: ValidationRun[] = [];
+
+function isValidationRunStepSnapshot(value: unknown): value is ValidationRunStepSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.instruction === 'string' && typeof candidate.expectedResult === 'string';
+}
+
+function getValidationRunStepSnapshots(run: ValidationRun): ValidationRunStepSnapshot[] {
+  return (run.stepResults || []).filter(isValidationRunStepSnapshot);
+}
 
 function runStatusToTestStatus(status: string): string {
   if (status === 'Pass' || status === 'Passed') return 'Passed';
@@ -202,6 +215,8 @@ const ValidationReviewSurface: React.FC<{
 
   const history = getValidationRunHistory(project, test.id);
   const selectedRun = selectedRunId ? history.find((run) => run.id === selectedRunId) ?? null : null;
+  const stepSnapshots = selectedRun ? getValidationRunStepSnapshots(selectedRun) : [];
+  const unresolvedStepSnapshots = selectedRun ? (selectedRun.stepResults || []).length - stepSnapshots.length : 0;
 
   return (
     <main className="flex h-full min-h-0 overflow-hidden bg-white" aria-label={`Review ${test.name}`}>
@@ -221,8 +236,8 @@ const ValidationReviewSurface: React.FC<{
           <div className="mx-auto max-w-3xl">
             <div className="flex items-start justify-between gap-3 border-b border-slate-300 pb-4"><div><div className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-400">Frozen run snapshot</div><h3 className="mt-1 text-lg font-semibold text-slate-950">Run #{selectedRun.runNumber || 1}</h3><p className="mt-1 text-[10px] text-slate-500">{selectedRun.timestamp || 'Timestamp unresolved'} · {selectedRun.runBy || 'Actor unresolved'}</p></div><span className={`text-sm font-semibold ${statusTone(selectedRun.status)}`}>{selectedRun.status}</span></div>
             <dl className="grid gap-3 border-b border-slate-200 py-4 sm:grid-cols-2"><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Observed value</dt><dd className="mt-1 text-xs text-slate-800">{selectedRun.measuredValue == null ? 'Not recorded' : String(selectedRun.measuredValue)}</dd></div><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Environment</dt><dd className="mt-1 text-xs text-slate-800">{selectedRun.environment || 'Not recorded'}</dd></div><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Pass criteria snapshot</dt><dd className="mt-1 text-xs leading-5 text-slate-800">{selectedRun.passCriteria || 'Not recorded'}</dd></div><div><dt className="text-[8px] uppercase tracking-[0.1em] text-slate-400">Evidence reference</dt><dd className="mt-1 break-all text-xs text-slate-800">{selectedRun.evidenceLink || 'Not recorded'}</dd></div></dl>
-            <section className="py-4"><h4 className="text-xs font-semibold text-slate-900">Captured procedure snapshot</h4><div className="mt-2 divide-y divide-slate-100 border-y border-slate-200">{(selectedRun.stepResults || []).map((step, index) => <div key={`${step.stepNumber}-${index}`} className="grid gap-2 px-2 py-2 text-[10px] sm:grid-cols-[2rem_minmax(0,1fr)_minmax(0,1fr)]"><span className="font-mono text-slate-400">{index + 1}</span><span>{step.instruction}</span><span className="text-slate-500">{step.expectedResult}</span></div>)}{(selectedRun.stepResults || []).length === 0 && <p className="py-4 text-center text-[10px] text-slate-400">No procedure snapshot recorded.</p>}</div></section>
-            <section className="border-t border-slate-200 py-4"><h4 className="text-xs font-semibold text-slate-900">Evidence snapshot</h4><div className="mt-2 space-y-1">{(selectedRun.evidence || []).map((item, index) => <div key={`${String((item as { id?: string }).id || 'evidence')}-${index}`} className="border border-slate-200 px-2.5 py-2 text-[10px] text-slate-600">{typeof item === 'object' && item ? String((item as { value?: unknown }).value ?? JSON.stringify(item)) : String(item)}</div>)}{(selectedRun.evidence || []).length === 0 && <p className="text-[10px] text-slate-400">No frozen evidence items recorded.</p>}</div></section>
+            <section className="py-4"><h4 className="text-xs font-semibold text-slate-900">Captured procedure snapshot</h4><div className="mt-2 divide-y divide-slate-100 border-y border-slate-200">{stepSnapshots.map((step, index) => <div key={`${step.stepNumber ?? index + 1}-${index}`} className="grid gap-2 px-2 py-2 text-[10px] sm:grid-cols-[2rem_minmax(0,1fr)_minmax(0,1fr)]"><span className="font-mono text-slate-400">{index + 1}</span><span>{step.instruction}</span><span className="text-slate-500">{step.expectedResult}</span></div>)}{stepSnapshots.length === 0 && <p className="py-4 text-center text-[10px] text-slate-400">No readable procedure snapshot recorded.</p>}{unresolvedStepSnapshots > 0 && <p className="border-t border-amber-200 bg-amber-50 px-2 py-2 text-[9px] leading-4 text-amber-900">{unresolvedStepSnapshots} legacy step snapshot{unresolvedStepSnapshots === 1 ? '' : 's'} could not be interpreted as the current procedure shape and remain unresolved.</p>}</div></section>
+            <section className="border-t border-slate-200 py-4"><h4 className="text-xs font-semibold text-slate-900">Evidence snapshot</h4><div className="mt-2 space-y-1">{(selectedRun.evidence || []).map((item, index) => <div key={`${typeof item === 'object' && item && 'id' in item ? String((item as { id?: unknown }).id) : 'evidence'}-${index}`} className="border border-slate-200 px-2.5 py-2 text-[10px] text-slate-600">{typeof item === 'object' && item ? String('value' in item ? (item as { value?: unknown }).value ?? JSON.stringify(item) : JSON.stringify(item)) : String(item)}</div>)}{(selectedRun.evidence || []).length === 0 && <p className="text-[10px] text-slate-400">No frozen evidence items recorded.</p>}</div></section>
           </div>
         ) : <EmptySelection title="Select a run" detail="Run history is visible at left, but Review does not silently select the latest run. Choose the exact snapshot you want to inspect." />}
       </section>

--- a/src/components/validation/ValidationProjectDrawer.tsx
+++ b/src/components/validation/ValidationProjectDrawer.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import React from 'react';
+import { ClipboardCheck, Factory, History, Plus, TestTube2 } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import {
+  useValidationWorkspaceUiStore,
+  type ValidationDrawerSection,
+  type ValidationWorkspaceView,
+} from '../../store/validationWorkspaceUiStore';
+
+const sections: Array<{
+  id: ValidationDrawerSection;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}> = [
+  { id: 'tests', label: 'Tests', icon: TestTube2 },
+  { id: 'coverage', label: 'Coverage', icon: ClipboardCheck },
+  { id: 'factory-qa', label: 'Factory', icon: Factory },
+  { id: 'runs', label: 'Runs', icon: History },
+];
+
+function statusClass(status: string): string {
+  if (status === 'Pass' || status === 'Passed') return 'text-emerald-600';
+  if (status === 'Fail' || status === 'Failed') return 'text-rose-600';
+  return 'text-amber-600';
+}
+
+export const ValidationProjectDrawer: React.FC = () => {
+  const tests = useProjectStore((state) => state.validationTests ?? []);
+  const runs = useProjectStore((state) => state.validationRuns ?? []);
+  const requirements = useProjectStore((state) => state.requirements ?? []);
+  const activeView = useProjectStore((state) => state.activeView);
+  const setActiveView = useProjectStore((state) => state.setActiveView);
+  const executeProjectCommand = useProjectStore((state) => state.executeProjectCommand);
+  const addValidationTest = useProjectStore((state) => state.addValidationTest);
+
+  const drawerSection = useValidationWorkspaceUiStore((state) => state.drawerSection);
+  const selectedTestId = useValidationWorkspaceUiStore((state) => state.selectedTestId);
+  const selectedRunId = useValidationWorkspaceUiStore((state) => state.selectedRunId);
+  const setDrawerSection = useValidationWorkspaceUiStore((state) => state.setDrawerSection);
+  const setSelectedTestId = useValidationWorkspaceUiStore((state) => state.setSelectedTestId);
+  const setSelectedRunId = useValidationWorkspaceUiStore((state) => state.setSelectedRunId);
+  const setView = useValidationWorkspaceUiStore((state) => state.setView);
+  const setInspectorOpen = useValidationWorkspaceUiStore((state) => state.setInspectorOpen);
+  const setBottomDockOpen = useValidationWorkspaceUiStore((state) => state.setBottomDockOpen);
+
+  const factoryTests = tests.filter((test) => test.stage === 'Factory QA');
+  const orderedRuns = runs.slice().sort((a, b) => Date.parse(b.timestamp || '') - Date.parse(a.timestamp || ''));
+
+  const moveTo = (view: ValidationWorkspaceView, route = 'validation-studio') => {
+    setView(view);
+    setActiveView(route);
+  };
+
+  const openSection = (section: ValidationDrawerSection) => {
+    setDrawerSection(section);
+    if (section === 'coverage') {
+      moveTo('coverage', 'requirement-coverage');
+      return;
+    }
+    if (section === 'factory-qa') {
+      moveTo('factory-qa', 'factory-qa');
+      return;
+    }
+    if (section === 'runs') {
+      moveTo('review');
+      return;
+    }
+    moveTo('define');
+  };
+
+  const selectTest = (testId: string, view: ValidationWorkspaceView = 'define', route = 'validation-studio') => {
+    setSelectedTestId(testId);
+    setView(view);
+    setActiveView(route);
+    setInspectorOpen(true);
+  };
+
+  const selectRun = (runId: string, testId: string) => {
+    setSelectedTestId(testId);
+    setSelectedRunId(runId);
+    setView('review');
+    setDrawerSection('runs');
+    setActiveView('validation-studio');
+    setInspectorOpen(true);
+    setBottomDockOpen(true);
+  };
+
+  const addTest = (factory: boolean) => {
+    const beforeIds = new Set((useProjectStore.getState().validationTests ?? []).map((test) => test.id));
+    executeProjectCommand(factory ? 'ADD_QA' : 'ADD_TEST', factory ? 'Add Factory QA test' : 'Add validation test', () => {
+      addValidationTest({
+        name: factory ? `Factory QA ${factoryTests.length + 1}` : `Test ${tests.length + 1}`,
+        stage: factory ? 'Factory QA' : 'EVT',
+        category: factory ? 'Manufacturing' : 'Requirement',
+        linkedRequirementIds: [],
+        linkedArchitectureNodeIds: [],
+        linkedComponentIds: [],
+        linkedNetIds: [],
+        linkedFirmwareModuleIds: [],
+        steps: [],
+        measurements: [],
+        passCriteria: [],
+        status: 'Not Started',
+        evidence: [],
+      });
+    });
+    const created = (useProjectStore.getState().validationTests ?? []).find((test) => !beforeIds.has(test.id));
+    if (created) selectTest(created.id, 'define', factory ? 'factory-qa' : 'validation-studio');
+  };
+
+  const routeSection: ValidationDrawerSection = activeView === 'requirement-coverage'
+    ? 'coverage'
+    : activeView === 'factory-qa'
+      ? 'factory-qa'
+      : drawerSection;
+
+  return (
+    <aside
+      className="z-20 flex h-full w-[224px] shrink-0 flex-col overflow-hidden border-r border-[#cfc9bd] bg-[#f7f3eb]"
+      aria-label="Validation project drawer"
+      data-studio-shell="project-drawer"
+      data-workbench="validation"
+    >
+      <div className="shrink-0 border-b border-[#d8d1c5] px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <TestTube2 className="h-3.5 w-3.5 text-slate-500" aria-hidden="true" />
+          <div>
+            <div className="text-[8px] font-semibold uppercase tracking-[0.13em] text-slate-400">Validation</div>
+            <h2 className="mt-0.5 text-[12px] font-semibold text-slate-950">Verification structure</h2>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid shrink-0 grid-cols-4 border-b border-[#d8d1c5] bg-[#f1ece3]">
+        {sections.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => openSection(id)}
+            aria-pressed={routeSection === id}
+            className={`flex min-h-11 flex-col items-center justify-center gap-1 border-r border-[#d8d1c5] text-[8px] font-semibold last:border-r-0 ${routeSection === id ? 'bg-[#fbfaf6] text-slate-950' : 'text-slate-500 hover:bg-[#ece6dc]'}`}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+        {routeSection === 'tests' && (
+          <div className="space-y-0.5">
+            <button type="button" onClick={() => addTest(false)} className="mb-1.5 flex h-8 w-full items-center justify-center gap-1.5 border border-dashed border-slate-300 bg-[#fbfaf6] text-[9px] font-semibold text-slate-600 hover:border-slate-500 hover:text-slate-950">
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" /> Add test
+            </button>
+            {tests.map((test) => {
+              const active = selectedTestId === test.id;
+              const runCount = runs.filter((run) => run.testId === test.id).length;
+              return (
+                <button key={test.id} type="button" onClick={() => selectTest(test.id)} aria-pressed={active} className={`flex min-h-10 w-full items-center gap-2 px-2 text-left ${active ? 'bg-slate-950 text-white' : 'text-slate-700 hover:bg-[#ece6dc]'}`}>
+                  <TestTube2 className={`h-3.5 w-3.5 shrink-0 ${active ? 'text-white/60' : 'text-slate-400'}`} aria-hidden="true" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[9px] font-semibold">{test.name}</span>
+                    <span className={`mt-0.5 block truncate text-[8px] ${active ? 'text-white/55' : 'text-slate-400'}`}>{test.stage} · {test.category} · {runCount} run{runCount === 1 ? '' : 's'}</span>
+                  </span>
+                </button>
+              );
+            })}
+            {tests.length === 0 && <p className="p-3 text-[9px] leading-4 text-slate-400">No validation tests yet. Creating a definition does not create execution evidence.</p>}
+          </div>
+        )}
+
+        {routeSection === 'coverage' && (
+          <div className="space-y-2 p-2">
+            <p className="text-[9px] leading-4 text-slate-500">Coverage is traceability across {requirements.length} requirement{requirements.length === 1 ? '' : 's'} and {tests.length} test definition{tests.length === 1 ? '' : 's'}.</p>
+            <p className="border-l-2 border-amber-400 pl-2 text-[9px] leading-4 text-slate-600">A linked test is not a passing run. Coverage remains evidence-driven.</p>
+          </div>
+        )}
+
+        {routeSection === 'factory-qa' && (
+          <div className="space-y-0.5">
+            <button type="button" onClick={() => addTest(true)} className="mb-1.5 flex h-8 w-full items-center justify-center gap-1.5 border border-dashed border-slate-300 bg-[#fbfaf6] text-[9px] font-semibold text-slate-600 hover:border-slate-500 hover:text-slate-950">
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" /> Add Factory QA test
+            </button>
+            {factoryTests.map((test) => {
+              const active = selectedTestId === test.id;
+              return (
+                <button key={test.id} type="button" onClick={() => selectTest(test.id, 'factory-qa', 'factory-qa')} aria-pressed={active} className={`flex min-h-10 w-full items-center gap-2 px-2 text-left ${active ? 'bg-slate-950 text-white' : 'text-slate-700 hover:bg-[#ece6dc]'}`}>
+                  <Factory className={`h-3.5 w-3.5 shrink-0 ${active ? 'text-white/60' : 'text-slate-400'}`} aria-hidden="true" />
+                  <span className="min-w-0 flex-1"><span className="block truncate text-[9px] font-semibold">{test.name}</span><span className={`mt-0.5 block truncate text-[8px] ${active ? 'text-white/55' : 'text-slate-400'}`}>{test.category} · {test.status}</span></span>
+                </button>
+              );
+            })}
+            {factoryTests.length === 0 && <p className="p-3 text-[9px] leading-4 text-slate-400">No Factory QA definitions yet.</p>}
+          </div>
+        )}
+
+        {routeSection === 'runs' && (
+          <div className="space-y-0.5">
+            {orderedRuns.map((run) => {
+              const active = selectedRunId === run.id;
+              return (
+                <button key={run.id} type="button" onClick={() => selectRun(run.id, run.testId)} aria-pressed={active} className={`flex min-h-11 w-full items-center gap-2 px-2 text-left ${active ? 'bg-slate-950 text-white' : 'text-slate-700 hover:bg-[#ece6dc]'}`}>
+                  <History className={`h-3.5 w-3.5 shrink-0 ${active ? 'text-white/60' : statusClass(run.status)}`} aria-hidden="true" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[9px] font-semibold">{run.testName || run.testId}</span>
+                    <span className={`mt-0.5 block truncate text-[8px] ${active ? 'text-white/55' : 'text-slate-400'}`}>run #{run.runNumber || 1} · {run.status} · {run.timestamp ? new Date(run.timestamp).toLocaleString() : 'time unresolved'}</span>
+                  </span>
+                </button>
+              );
+            })}
+            {orderedRuns.length === 0 && <p className="p-3 text-[9px] leading-4 text-slate-400">No recorded validation runs. Define a test, then execute it explicitly.</p>}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+};

--- a/src/components/validation/ValidationStudio.tsx
+++ b/src/components/validation/ValidationStudio.tsx
@@ -1,22 +1,12 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React from 'react';
+import { ClipboardCheck, Link2, Plus, Ruler, TestTube2, Trash2 } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
+import { useValidationWorkspaceUiStore } from '../../store/validationWorkspaceUiStore';
 import type { ValidationEvidence, ValidationMeasurement, ValidationTest, ValidationTestStep } from '../../types';
-import { evaluateValidationMeasurement, calculateTestStatus } from '../../lib/validation/measurementEvaluation';
 import { calculateRequirementCoverage } from '../../lib/validation/validationCoverage';
-import {
-  AlertCircle,
-  CheckCircle2,
-  ClipboardCheck,
-  HelpCircle,
-  ListChecks,
-  Plus,
-  Trash2,
-  XCircle,
-} from 'lucide-react';
 import { useFeedback } from '../feedback/FeedbackProvider';
-import { EditorDockButton } from '../editor/EditorDockButton';
 
 interface ValidationStudioProps {
   initialMode?: string;
@@ -24,8 +14,8 @@ interface ValidationStudioProps {
 
 type ValidationMode = 'tests' | 'coverage' | 'factory-qa';
 
-const inputClass = 'h-8 w-full rounded-md border border-slate-300 bg-white px-2 text-[10px] text-slate-800 outline-none focus:border-slate-500';
-const textAreaClass = 'w-full resize-y rounded-md border border-slate-300 bg-white p-2.5 text-[10px] leading-5 text-slate-800 outline-none focus:border-slate-500';
+const inputClass = 'h-8 w-full border border-slate-300 bg-white px-2 text-[10px] text-slate-800 outline-none focus:border-slate-500';
+const textAreaClass = 'w-full resize-y border border-slate-300 bg-white p-2.5 text-[10px] leading-5 text-slate-800 outline-none focus:border-slate-500';
 
 function normalizeMode(initialMode?: string): ValidationMode {
   if (initialMode === 'coverage' || initialMode === 'factory-qa') return initialMode;
@@ -33,50 +23,43 @@ function normalizeMode(initialMode?: string): ValidationMode {
 }
 
 function statusTone(status: string): string {
-  switch (status) {
-    case 'Passed':
-    case 'Pass':
-    case 'Covered':
-      return 'text-emerald-700';
-    case 'Failed':
-    case 'Fail':
-      return 'text-rose-700';
-    case 'In Progress':
-    case 'Partially Covered':
-      return 'text-amber-700';
-    case 'Needs Review':
-      return 'text-violet-700';
-    default:
-      return 'text-slate-500';
-  }
+  if (status === 'Covered') return 'text-emerald-700';
+  if (status === 'Partially Covered') return 'text-amber-700';
+  return 'text-slate-500';
 }
 
-function StatusIcon({ status }: { status: string }) {
-  if (status === 'Passed' || status === 'Pass' || status === 'Covered') return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" />;
-  if (status === 'Failed' || status === 'Fail') return <XCircle className="h-3.5 w-3.5 text-rose-600" aria-hidden="true" />;
-  if (status === 'In Progress' || status === 'Partially Covered') return <AlertCircle className="h-3.5 w-3.5 text-amber-600" aria-hidden="true" />;
-  return <HelpCircle className="h-3.5 w-3.5 text-slate-400" aria-hidden="true" />;
+function nextScopedId(prefix: string, ownerId: string, existingIds: string[]): string {
+  let sequence = 1;
+  let candidate = `${prefix}_${ownerId}_${sequence}`;
+  while (existingIds.includes(candidate)) {
+    sequence += 1;
+    candidate = `${prefix}_${ownerId}_${sequence}`;
+  }
+  return candidate;
 }
 
 export const ValidationStudio: React.FC<ValidationStudioProps> = ({ initialMode }) => {
   const store = useProjectStore();
   const feedback = useFeedback();
   const mode = normalizeMode(initialMode);
-  const [selectedTestId, setSelectedTestId] = useState<string | null>(null);
-  const [testListOpen, setTestListOpen] = useState(false);
+  const selectedTestId = useValidationWorkspaceUiStore((state) => state.selectedTestId);
+  const setSelectedTestId = useValidationWorkspaceUiStore((state) => state.setSelectedTestId);
+  const setInspectorOpen = useValidationWorkspaceUiStore((state) => state.setInspectorOpen);
 
-  const validationTests = store.validationTests || [];
-  const requirements = store.requirements || [];
-  const visibleTests = useMemo(
-    () => mode === 'factory-qa' ? validationTests.filter((test) => test.stage === 'Factory QA') : validationTests,
-    [mode, validationTests],
-  );
-  const selectedTest = visibleTests.find((test) => test.id === selectedTestId) || visibleTests[0] || null;
+  const validationTests = store.validationTests ?? [];
+  const requirements = store.requirements ?? [];
+  const visibleTests = mode === 'factory-qa'
+    ? validationTests.filter((test) => test.stage === 'Factory QA')
+    : validationTests;
+  const selectedTest = selectedTestId
+    ? visibleTests.find((test) => test.id === selectedTestId) ?? null
+    : null;
 
-  const handleAddTest = () => {
+  const addTest = () => {
     const factory = mode === 'factory-qa';
-    store.executeProjectCommand(factory ? 'ADD_QA' : 'ADD_TEST', factory ? 'Add Factory QA test' : 'Add validation test', () =>
-      store.addValidationTest({
+    const beforeIds = new Set((useProjectStore.getState().validationTests ?? []).map((test) => test.id));
+    store.executeProjectCommand(factory ? 'ADD_QA' : 'ADD_TEST', factory ? 'Add Factory QA test' : 'Add validation test', () => {
+      useProjectStore.getState().addValidationTest({
         name: factory ? `Factory QA ${visibleTests.length + 1}` : `Test ${validationTests.length + 1}`,
         stage: factory ? 'Factory QA' : 'EVT',
         category: factory ? 'Manufacturing' : 'Requirement',
@@ -90,12 +73,16 @@ export const ValidationStudio: React.FC<ValidationStudioProps> = ({ initialMode 
         passCriteria: [],
         status: 'Not Started',
         evidence: [],
-      })
-    );
-    setTestListOpen(true);
+      });
+    });
+    const created = (useProjectStore.getState().validationTests ?? []).find((test) => !beforeIds.has(test.id));
+    if (created) {
+      setSelectedTestId(created.id);
+      setInspectorOpen(true);
+    }
   };
 
-  const handleAddStep = () => {
+  const addStep = () => {
     if (!selectedTest) return;
     const newStep: ValidationTestStep = {
       stepNumber: selectedTest.steps.length + 1,
@@ -103,55 +90,53 @@ export const ValidationStudio: React.FC<ValidationStudioProps> = ({ initialMode 
       expectedResult: '',
       completed: false,
     };
-    store.executeProjectCommand('ADD_STEP', 'Add test step', () =>
-      store.updateValidationTest(selectedTest.id, { steps: [...selectedTest.steps, newStep] })
-    );
+    store.executeProjectCommand('ADD_STEP', 'Add validation procedure step', () => {
+      store.updateValidationTest(selectedTest.id, { steps: [...selectedTest.steps, newStep] });
+    });
   };
 
-  const handleAddMeasurement = () => {
+  const addMeasurement = () => {
     if (!selectedTest) return;
-    const newMeasurement: ValidationMeasurement = {
-      id: `meas_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    const id = nextScopedId('meas', selectedTest.id, selectedTest.measurements.map((item) => item.id));
+    const measurement: ValidationMeasurement = {
+      id,
       name: '',
       type: 'Numeric',
       required: true,
       status: 'Untested',
     };
-    store.executeProjectCommand('ADD_MEAS', 'Add measurement', () =>
-      store.updateValidationTest(selectedTest.id, { measurements: [...selectedTest.measurements, newMeasurement] })
-    );
+    store.executeProjectCommand('ADD_MEAS', 'Add validation measurement definition', () => {
+      store.updateValidationTest(selectedTest.id, { measurements: [...selectedTest.measurements, measurement] });
+    });
   };
 
-  const handleAddEvidence = () => {
+  const addDefinitionReference = () => {
     if (!selectedTest) return;
-    const newEvidence: ValidationEvidence = {
-      id: `ev_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    const id = nextScopedId('ref', selectedTest.id, selectedTest.evidence.map((item) => item.id));
+    const reference: ValidationEvidence = {
+      id,
       type: 'Text',
       value: '',
       createdAt: new Date().toISOString(),
+      notes: 'Definition/reference metadata only — not validation run evidence.',
     };
-    store.executeProjectCommand('ADD_EVIDENCE', 'Add evidence', () =>
-      store.updateValidationTest(selectedTest.id, { evidence: [...selectedTest.evidence, newEvidence] })
-    );
+    store.executeProjectCommand('ADD_TEST_REFERENCE', 'Add validation definition reference', () => {
+      store.updateValidationTest(selectedTest.id, { evidence: [...selectedTest.evidence, reference] });
+    });
   };
 
-  const handleDeleteTest = async () => {
+  const deleteTest = async () => {
     if (!selectedTest) return;
     const confirmed = await feedback.confirm({
       title: `Delete ${selectedTest.name}?`,
-      description: 'This removes the validation test, including its steps, measurements, pass criteria, and attached evidence from the current project state. The deletion is not applied until you confirm.',
+      description: 'This removes the editable test definition from current project state. Historical validation runs remain separate records.',
       confirmLabel: 'Delete test',
       cancelLabel: 'Keep test',
       variant: 'destructive',
     });
     if (!confirmed) return;
-
-    const deletedName = selectedTest.name;
-    store.executeProjectCommand('DEL_TEST', `Delete validation test ${deletedName}`, () =>
-      store.deleteValidationTest(selectedTest.id)
-    );
+    store.executeProjectCommand('DEL_TEST', `Delete validation test ${selectedTest.name}`, () => store.deleteValidationTest(selectedTest.id));
     setSelectedTestId(null);
-    feedback.notify({ tone: 'success', title: 'Validation test deleted', detail: `${deletedName} was removed from the current project state.` });
   };
 
   const updateStep = (index: number, patch: Partial<ValidationTestStep>) => {
@@ -162,11 +147,11 @@ export const ValidationStudio: React.FC<ValidationStudioProps> = ({ initialMode 
 
   const updateMeasurement = (index: number, patch: Partial<ValidationMeasurement>) => {
     if (!selectedTest) return;
-    const measurements = selectedTest.measurements.map((measurement, itemIndex) => itemIndex === index ? { ...measurement, ...patch } : measurement);
+    const measurements = selectedTest.measurements.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item);
     store.updateValidationTest(selectedTest.id, { measurements });
   };
 
-  const updateEvidence = (index: number, patch: Partial<ValidationEvidence>) => {
+  const updateReference = (index: number, patch: Partial<ValidationEvidence>) => {
     if (!selectedTest) return;
     const evidence = selectedTest.evidence.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item);
     store.updateValidationTest(selectedTest.id, { evidence });
@@ -175,128 +160,106 @@ export const ValidationStudio: React.FC<ValidationStudioProps> = ({ initialMode 
   if (mode === 'coverage') {
     const coverage = calculateRequirementCoverage(requirements, validationTests);
     const covered = coverage.filter((entry) => entry.status === 'Covered').length;
-    const total = coverage.length;
-
     return (
       <section className="flex h-full min-h-0 flex-col overflow-hidden bg-white" aria-label="Requirement coverage workspace">
-        <header className="flex min-h-11 shrink-0 items-center gap-3 border-b border-slate-300 bg-white px-3">
-          <div className="min-w-0 flex-1"><p className="text-[11px] font-semibold text-slate-900">Requirement coverage</p><p className="mt-0.5 text-[9px] text-slate-500">Traceability evidence only—coverage does not replace a passing validation run.</p></div>
-          <span className="text-[10px] tabular-nums text-slate-500"><strong className="text-slate-900">{covered}/{total}</strong> covered · {total > 0 ? Math.round((covered / total) * 100) : 0}%</span>
-        </header>
+        <div className="flex min-h-10 shrink-0 items-center gap-3 border-b border-slate-300 bg-[#f8f6f0] px-3">
+          <ClipboardCheck className="h-4 w-4 text-slate-500" aria-hidden="true" />
+          <div className="min-w-0 flex-1"><p className="text-[10px] font-semibold text-slate-900">Requirement coverage</p><p className="text-[8px] text-slate-500">Traceability only. A linked definition is not a passing run.</p></div>
+          <span className="font-mono text-[9px] text-slate-500">{covered}/{coverage.length} covered</span>
+        </div>
         <div className="min-h-0 flex-1 overflow-auto">
           <table className="w-full min-w-[760px] border-collapse text-left text-[10px]">
-            <thead className="sticky top-0 z-10 bg-[#f5f1e8] text-slate-600">
-              <tr><th className="border-b border-slate-300 px-3 py-2 font-semibold">Requirement</th><th className="border-b border-slate-300 px-3 py-2 font-semibold">Priority</th><th className="border-b border-slate-300 px-3 py-2 font-semibold">Linked tests</th><th className="border-b border-slate-300 px-3 py-2 font-semibold">Passed</th><th className="border-b border-slate-300 px-3 py-2 font-semibold">Failed</th><th className="border-b border-slate-300 px-3 py-2 font-semibold">Coverage state</th></tr>
-            </thead>
+            <thead className="sticky top-0 z-10 bg-[#f5f1e8] text-slate-600"><tr><th className="border-b border-slate-300 px-3 py-2">Requirement</th><th className="border-b border-slate-300 px-3 py-2">Priority</th><th className="border-b border-slate-300 px-3 py-2">Linked tests</th><th className="border-b border-slate-300 px-3 py-2">Passed</th><th className="border-b border-slate-300 px-3 py-2">Failed</th><th className="border-b border-slate-300 px-3 py-2">State</th></tr></thead>
             <tbody className="divide-y divide-slate-100">
-              {coverage.map((entry) => <tr key={entry.requirementId} className="bg-white"><td className="px-3 py-2.5 font-medium text-slate-900">{entry.requirementTitle}</td><td className="px-3 py-2.5 text-slate-600">{entry.priority}</td><td className="px-3 py-2.5 tabular-nums text-slate-600">{entry.linkedTestIds.length}</td><td className="px-3 py-2.5 tabular-nums text-slate-600">{entry.passedTestIds.length}</td><td className="px-3 py-2.5 tabular-nums text-slate-600">{entry.failedTestIds.length}</td><td className={`px-3 py-2.5 font-semibold ${statusTone(entry.status)}`}>{entry.status}</td></tr>)}
+              {coverage.map((entry) => (
+                <tr key={entry.requirementId}><td className="px-3 py-2.5 font-medium text-slate-900">{entry.requirementTitle}</td><td className="px-3 py-2.5 text-slate-600">{entry.priority}</td><td className="px-3 py-2.5 font-mono text-slate-600">{entry.linkedTestIds.length}</td><td className="px-3 py-2.5 font-mono text-slate-600">{entry.passedTestIds.length}</td><td className="px-3 py-2.5 font-mono text-slate-600">{entry.failedTestIds.length}</td><td className={`px-3 py-2.5 font-semibold ${statusTone(entry.status)}`}>{entry.status}</td></tr>
+              ))}
             </tbody>
           </table>
-          {coverage.length === 0 && <div className="grid min-h-64 place-items-center p-8 text-center"><div><ClipboardCheck className="mx-auto h-7 w-7 text-slate-300" /><p className="mt-3 text-sm font-semibold text-slate-800">No requirements to evaluate</p><p className="mt-1 text-xs text-slate-500">Create measurable requirements and link validation tests to see coverage.</p></div></div>}
+          {coverage.length === 0 && <div className="grid min-h-64 place-items-center p-8 text-center"><div><ClipboardCheck className="mx-auto h-7 w-7 text-slate-300" /><p className="mt-3 text-sm font-semibold text-slate-800">No requirements to evaluate</p><p className="mt-1 text-xs text-slate-500">Create measurable requirements and link explicit test definitions.</p></div></div>}
         </div>
       </section>
     );
   }
 
-  const selectedStatus = selectedTest ? calculateTestStatus(selectedTest) : 'Not Started';
+  if (!selectedTest) {
+    return (
+      <section className="grid h-full min-h-0 place-items-center bg-white p-8 text-center" aria-label={mode === 'factory-qa' ? 'Factory QA definition workspace' : 'Validation definition workspace'}>
+        <div className="max-w-sm">
+          <TestTube2 className="mx-auto h-8 w-8 text-slate-300" aria-hidden="true" />
+          <h2 className="mt-3 text-sm font-semibold text-slate-800">Select a test definition</h2>
+          <p className="mt-1 text-xs leading-5 text-slate-500">Opening Validation never chooses a test for you. Select one in the Project Drawer or create a new definition explicitly.</p>
+          <button type="button" onClick={addTest} className="mt-3 inline-flex h-8 items-center gap-1.5 bg-slate-950 px-3 text-[10px] font-semibold text-white"><Plus className="h-3.5 w-3.5" /> {mode === 'factory-qa' ? 'Create Factory QA test' : 'Create test'}</button>
+        </div>
+      </section>
+    );
+  }
+
+  const runCount = (store.validationRuns ?? []).filter((run) => run.testId === selectedTest.id).length;
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-[#fbfaf6]" aria-label={mode === 'factory-qa' ? 'Factory QA test editor' : 'Validation test editor'}>
-      <header className="flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-slate-300 bg-white px-3 py-1.5">
-        <div className="min-w-0 flex-1"><p className="text-[11px] font-semibold text-slate-900">{mode === 'factory-qa' ? 'Factory QA tests' : 'Test definitions'}</p><p className="mt-0.5 truncate text-[9px] text-slate-500">{visibleTests.length} test{visibleTests.length === 1 ? '' : 's'} · select, author procedure, measurements, evidence, and pass criteria here; record runs separately.</p></div>
-        <EditorDockButton label="Tests" icon={ListChecks} active={testListOpen} count={visibleTests.length} onClick={() => setTestListOpen((value) => !value)} />
-        <button type="button" onClick={handleAddTest} className="inline-flex min-h-8 items-center gap-1.5 rounded-md bg-slate-950 px-2.5 text-[10px] font-semibold text-white hover:bg-slate-800"><Plus className="h-3.5 w-3.5" /> {mode === 'factory-qa' ? 'Add QA test' : 'Add test'}</button>
-      </header>
+    <main className="h-full min-h-0 overflow-y-auto bg-white" aria-label={`Define ${selectedTest.name}`}>
+      <div className="mx-auto max-w-5xl px-4 py-4 sm:px-6">
+        <div className="flex flex-col gap-3 border-b border-slate-300 pb-4 sm:flex-row sm:items-start">
+          <div className="min-w-0 flex-1">
+            <div className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-400">Definition · {runCount} recorded run{runCount === 1 ? '' : 's'}</div>
+            <label className="sr-only" htmlFor={`validation-name-${selectedTest.id}`}>Test name</label>
+            <input id={`validation-name-${selectedTest.id}`} value={selectedTest.name} onChange={(event) => store.updateValidationTest(selectedTest.id, { name: event.target.value })} className="mt-1 w-full border-0 bg-transparent p-0 text-xl font-semibold tracking-tight text-slate-950 outline-none" />
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <select value={selectedTest.stage ?? 'EVT'} onChange={(event) => store.updateValidationTest(selectedTest.id, { stage: event.target.value as ValidationTest['stage'] })} className="h-8 border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 outline-none"><option>EVT</option><option>DVT</option><option>PVT</option><option>Factory QA</option></select>
+              <select value={selectedTest.category ?? 'Requirement'} onChange={(event) => store.updateValidationTest(selectedTest.id, { category: event.target.value })} className="h-8 border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 outline-none">{['Requirement', 'Mechanical', 'Electrical', 'Power', 'RF', 'Firmware', 'Thermal', 'Environmental', 'Manufacturing', 'DRC'].map((category) => <option key={category}>{category}</option>)}</select>
+              <span className="text-[9px] font-medium text-slate-400">Latest aggregate status: {selectedTest.status ?? 'Not Started'}</span>
+            </div>
+          </div>
+          <button type="button" onClick={() => void deleteTest()} className="inline-flex h-8 items-center gap-1.5 px-2.5 text-[10px] font-semibold text-rose-700 hover:bg-rose-50"><Trash2 className="h-3.5 w-3.5" /> Delete</button>
+        </div>
 
-      <div className="relative min-h-0 flex-1 overflow-hidden">
-        {selectedTest ? (
-          <main className="h-full overflow-y-auto bg-white" aria-label={`Edit ${selectedTest.name}`}>
-            <div className="mx-auto max-w-5xl px-4 py-4 sm:px-6">
-              <div className="flex flex-col gap-3 border-b border-slate-300 pb-4 sm:flex-row sm:items-start">
-                <div className="min-w-0 flex-1">
-                  <label className="sr-only" htmlFor={`validation-name-${selectedTest.id}`}>Test name</label>
-                  <input id={`validation-name-${selectedTest.id}`} value={selectedTest.name} onChange={(event) => store.updateValidationTest(selectedTest.id, { name: event.target.value })} className="w-full border-0 bg-transparent p-0 text-xl font-semibold tracking-tight text-slate-950 outline-none" />
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <select value={selectedTest.stage} onChange={(event) => store.executeProjectCommand('UPDATE_STAGE', 'Change stage', () => store.updateValidationTest(selectedTest.id, { stage: event.target.value as ValidationTest['stage'] }))} className="h-8 rounded-md border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 outline-none focus:border-slate-500">{['EVT', 'DVT', 'PVT', 'Factory QA'].map((stage) => <option key={stage} value={stage}>{stage}</option>)}</select>
-                    <select value={selectedTest.category} onChange={(event) => store.updateValidationTest(selectedTest.id, { category: event.target.value as ValidationTest['category'] })} className="h-8 rounded-md border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 outline-none focus:border-slate-500">{['Requirement', 'Mechanical', 'Electrical', 'Power', 'RF', 'Firmware', 'Thermal', 'Environmental', 'Manufacturing'].map((category) => <option key={category} value={category}>{category}</option>)}</select>
-                    <span className={`inline-flex items-center gap-1 text-[10px] font-semibold ${statusTone(selectedStatus)}`}><StatusIcon status={selectedStatus} />{selectedStatus}</span>
-                  </div>
+        <section className="border-b border-slate-200 py-5" aria-labelledby="validation-links-title">
+          <div className="flex items-center gap-2"><Link2 className="h-4 w-4 text-slate-400" /><div><h2 id="validation-links-title" className="text-sm font-semibold text-slate-900">Requirement links</h2><p className="text-[10px] text-slate-500">Traceability links only. They do not make the requirement verified.</p></div></div>
+          <div className="mt-3 grid gap-1 sm:grid-cols-2">
+            {requirements.map((requirement) => {
+              const linked = selectedTest.linkedRequirementIds.includes(requirement.id);
+              return <label key={requirement.id} className="flex min-h-9 cursor-pointer items-center gap-2 border border-slate-200 px-2.5 text-[10px] hover:bg-slate-50"><input type="checkbox" checked={linked} onChange={() => store.updateValidationTest(selectedTest.id, { linkedRequirementIds: linked ? selectedTest.linkedRequirementIds.filter((id) => id !== requirement.id) : [...selectedTest.linkedRequirementIds, requirement.id] })} /><span className="min-w-0 flex-1 truncate">{requirement.title}</span><span className="text-[8px] text-slate-400">{requirement.priority}</span></label>;
+            })}
+            {requirements.length === 0 && <p className="text-[10px] text-slate-400">No product requirements exist yet.</p>}
+          </div>
+        </section>
+
+        <section className="border-b border-slate-200 py-5" aria-labelledby="validation-steps-title">
+          <div className="flex items-center justify-between gap-3"><div><h2 id="validation-steps-title" className="text-sm font-semibold text-slate-900">Procedure</h2><p className="text-[10px] text-slate-500">Define actions and expected outcomes. Completion is recorded during execution, not here.</p></div><button type="button" onClick={addStep} className="inline-flex h-8 items-center gap-1 border border-slate-300 px-2 text-[10px] font-semibold"><Plus className="h-3 w-3" /> Step</button></div>
+          <div className="mt-3 divide-y divide-slate-100 border-y border-slate-200">
+            {selectedTest.steps.map((step, index) => <div key={`${step.stepNumber}-${index}`} className="grid gap-2 px-2 py-2.5 md:grid-cols-[2rem_minmax(0,1fr)_minmax(0,1fr)_2rem]"><span className="grid h-8 place-items-center font-mono text-[10px] text-slate-400">{index + 1}</span><input value={step.instruction} onChange={(event) => updateStep(index, { instruction: event.target.value, completed: false })} placeholder="Operator action" className={inputClass} /><input value={step.expectedResult} onChange={(event) => updateStep(index, { expectedResult: event.target.value, completed: false })} placeholder="Expected result" className={inputClass} /><button type="button" onClick={() => store.updateValidationTest(selectedTest.id, { steps: selectedTest.steps.filter((_, itemIndex) => itemIndex !== index).map((item, itemIndex) => ({ ...item, stepNumber: itemIndex + 1 })) })} className="grid h-8 w-8 place-items-center text-rose-600 hover:bg-rose-50" aria-label={`Delete step ${index + 1}`}><Trash2 className="h-3.5 w-3.5" /></button></div>)}
+            {selectedTest.steps.length === 0 && <p className="py-5 text-center text-[10px] text-slate-400">No procedure steps defined.</p>}
+          </div>
+        </section>
+
+        <section className="border-b border-slate-200 py-5" aria-labelledby="validation-measurements-title">
+          <div className="flex items-center justify-between gap-3"><div className="flex items-center gap-2"><Ruler className="h-4 w-4 text-slate-400" /><div><h2 id="validation-measurements-title" className="text-sm font-semibold text-slate-900">Measurement schema</h2><p className="text-[10px] text-slate-500">Expected values/tolerances belong to Define. Actual readings belong to Execute.</p></div></div><button type="button" onClick={addMeasurement} className="inline-flex h-8 items-center gap-1 border border-slate-300 px-2 text-[10px] font-semibold"><Plus className="h-3 w-3" /> Measurement</button></div>
+          <div className="mt-3 space-y-2">
+            {selectedTest.measurements.map((measurement, index) => (
+              <div key={measurement.id} className="border border-slate-300 bg-[#fbfaf6] p-3">
+                <div className="flex flex-wrap items-center gap-2"><input value={measurement.name} onChange={(event) => updateMeasurement(index, { name: event.target.value, actualValue: undefined, status: 'Untested' })} placeholder="Measurement name" className="h-8 min-w-[180px] flex-1 border border-slate-300 bg-white px-2 text-[10px]" /><select value={measurement.type} onChange={(event) => updateMeasurement(index, { type: event.target.value as ValidationMeasurement['type'], actualValue: undefined, status: 'Untested' })} className="h-8 border border-slate-300 bg-white px-2 text-[10px]">{['Numeric', 'Boolean', 'Text', 'Visual Inspection'].map((type) => <option key={type}>{type}</option>)}</select><label className="inline-flex items-center gap-1 text-[9px] text-slate-600"><input type="checkbox" checked={measurement.required} onChange={(event) => updateMeasurement(index, { required: event.target.checked })} /> Required</label><button type="button" onClick={() => store.updateValidationTest(selectedTest.id, { measurements: selectedTest.measurements.filter((item) => item.id !== measurement.id) })} className="grid h-8 w-8 place-items-center text-rose-600 hover:bg-rose-50"><Trash2 className="h-3.5 w-3.5" /></button></div>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                  {measurement.type === 'Numeric' && <><label className="text-[9px] text-slate-500">Expected<input type="number" value={typeof measurement.expectedValue === 'number' ? measurement.expectedValue : ''} onChange={(event) => updateMeasurement(index, { expectedValue: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className={`${inputClass} mt-1`} /></label><label className="text-[9px] text-slate-500">Unit<input value={measurement.unit ?? ''} onChange={(event) => updateMeasurement(index, { unit: event.target.value })} className={`${inputClass} mt-1`} /></label><label className="text-[9px] text-slate-500">Tolerance +<input type="number" value={measurement.tolerancePlus ?? ''} onChange={(event) => updateMeasurement(index, { tolerancePlus: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className={`${inputClass} mt-1`} /></label><label className="text-[9px] text-slate-500">Tolerance -<input type="number" value={measurement.toleranceMinus ?? ''} onChange={(event) => updateMeasurement(index, { toleranceMinus: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className={`${inputClass} mt-1`} /></label></>}
+                  {measurement.type === 'Boolean' && <label className="text-[9px] text-slate-500">Expected<select value={typeof measurement.expectedValue === 'boolean' ? String(measurement.expectedValue) : ''} onChange={(event) => updateMeasurement(index, { expectedValue: event.target.value === '' ? undefined : event.target.value === 'true' })} className={`${inputClass} mt-1`}><option value="">—</option><option value="true">True</option><option value="false">False</option></select></label>}
+                  {measurement.type === 'Text' && <label className="text-[9px] text-slate-500 sm:col-span-2">Expected<input value={typeof measurement.expectedValue === 'string' ? measurement.expectedValue : ''} onChange={(event) => updateMeasurement(index, { expectedValue: event.target.value })} className={`${inputClass} mt-1`} /></label>}
                 </div>
-                <button type="button" onClick={handleDeleteTest} className="inline-flex min-h-8 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-[10px] font-semibold text-rose-700 hover:bg-rose-50"><Trash2 className="h-3.5 w-3.5" /> Delete</button>
               </div>
+            ))}
+            {selectedTest.measurements.length === 0 && <p className="border border-dashed border-slate-300 py-5 text-center text-[10px] text-slate-400">No measurement schema defined.</p>}
+          </div>
+        </section>
 
-              <section className="border-b border-slate-200 py-5" aria-labelledby="validation-steps-title">
-                <div className="flex items-center justify-between gap-3"><div><h2 id="validation-steps-title" className="text-sm font-semibold text-slate-900">Procedure</h2><p className="mt-0.5 text-[10px] text-slate-500">Author explicit actions and expected outcomes. Checking steps alone is not run evidence.</p></div><button type="button" onClick={handleAddStep} className="inline-flex min-h-8 items-center gap-1 rounded-md border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 hover:bg-slate-100"><Plus className="h-3 w-3" /> Step</button></div>
-                <div className="mt-3 divide-y divide-slate-100 border-y border-slate-200">
-                  {selectedTest.steps.map((step, index) => (
-                    <div key={`${step.stepNumber}-${index}`} className="grid gap-2 px-2 py-2.5 md:grid-cols-[2rem_minmax(0,1fr)_minmax(0,1fr)_2rem] md:items-start">
-                      <label className="grid h-8 place-items-center"><input type="checkbox" checked={step.completed} onChange={(event) => store.executeProjectCommand('TOGGLE_STEP', 'Toggle step', () => updateStep(index, { completed: event.target.checked }))} aria-label={`Mark step ${index + 1} complete`} /></label>
-                      <div><label className="text-[9px] font-medium text-slate-500" htmlFor={`step-instruction-${index}`}>Instruction {index + 1}</label><input id={`step-instruction-${index}`} value={step.instruction} onChange={(event) => updateStep(index, { instruction: event.target.value })} placeholder="What should the operator do?" className={`${inputClass} mt-1`} /></div>
-                      <div><label className="text-[9px] font-medium text-slate-500" htmlFor={`step-expected-${index}`}>Expected result</label><input id={`step-expected-${index}`} value={step.expectedResult} onChange={(event) => updateStep(index, { expectedResult: event.target.value })} placeholder="What evidence indicates success?" className={`${inputClass} mt-1`} /></div>
-                      <button type="button" onClick={() => store.updateValidationTest(selectedTest.id, { steps: selectedTest.steps.filter((_, itemIndex) => itemIndex !== index) })} className="grid h-8 w-8 place-items-center rounded-md text-rose-600 hover:bg-rose-50" aria-label={`Delete step ${index + 1}`}><Trash2 className="h-3.5 w-3.5" /></button>
-                    </div>
-                  ))}
-                  {selectedTest.steps.length === 0 && <p className="py-5 text-center text-[10px] text-slate-400">No procedure steps recorded.</p>}
-                </div>
-              </section>
+        <section className="border-b border-slate-200 py-5" aria-labelledby="validation-reference-title">
+          <div className="flex items-center justify-between gap-3"><div><h2 id="validation-reference-title" className="text-sm font-semibold text-slate-900">Definition references</h2><p className="text-[10px] text-slate-500">Procedure/specification references only. These are editable and are not immutable run evidence.</p></div><button type="button" onClick={addDefinitionReference} className="inline-flex h-8 items-center gap-1 border border-slate-300 px-2 text-[10px] font-semibold"><Plus className="h-3 w-3" /> Reference</button></div>
+          <div className="mt-3 divide-y divide-slate-100 border-y border-slate-200">
+            {selectedTest.evidence.map((reference, index) => <div key={reference.id} className="flex flex-wrap items-center gap-2 px-2 py-2"><select value={reference.type} onChange={(event) => updateReference(index, { type: event.target.value as ValidationEvidence['type'] })} className="h-8 border border-slate-300 bg-white px-2 text-[10px]">{['Text', 'URL', 'Photo Reference', 'File Reference'].map((type) => <option key={type}>{type}</option>)}</select><input value={reference.value} onChange={(event) => updateReference(index, { value: event.target.value, notes: 'Definition/reference metadata only — not validation run evidence.' })} placeholder="Procedure, standard, fixture or reference" className="h-8 min-w-[220px] flex-1 border border-slate-300 bg-white px-2 text-[10px]" /><button type="button" onClick={() => store.updateValidationTest(selectedTest.id, { evidence: selectedTest.evidence.filter((item) => item.id !== reference.id) })} className="grid h-8 w-8 place-items-center text-rose-600 hover:bg-rose-50"><Trash2 className="h-3.5 w-3.5" /></button></div>)}
+            {selectedTest.evidence.length === 0 && <p className="py-5 text-center text-[10px] text-slate-400">No definition references attached.</p>}
+          </div>
+        </section>
 
-              <section className="border-b border-slate-200 py-5" aria-labelledby="validation-measurements-title">
-                <div className="flex items-center justify-between gap-3"><div><h2 id="validation-measurements-title" className="text-sm font-semibold text-slate-900">Measurements</h2><p className="mt-0.5 text-[10px] text-slate-500">Define expected values and tolerances; actual readings remain evidence inputs.</p></div><button type="button" onClick={handleAddMeasurement} className="inline-flex min-h-8 items-center gap-1 rounded-md border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 hover:bg-slate-100"><Plus className="h-3 w-3" /> Measurement</button></div>
-                <div className="mt-3 space-y-2">
-                  {selectedTest.measurements.map((measurement, index) => {
-                    const evaluation = evaluateValidationMeasurement(measurement);
-                    return (
-                      <div key={measurement.id} className="rounded-md border border-slate-300 bg-[#fbfaf6] p-3">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <input value={measurement.name} onChange={(event) => updateMeasurement(index, { name: event.target.value })} placeholder="Measurement name" className="h-8 min-w-[180px] flex-1 rounded-md border border-slate-300 bg-white px-2 text-[10px] outline-none focus:border-slate-500" />
-                          <select value={measurement.type} onChange={(event) => updateMeasurement(index, { type: event.target.value as ValidationMeasurement['type'] })} className="h-8 rounded-md border border-slate-300 bg-white px-2 text-[10px] text-slate-700 outline-none focus:border-slate-500">{['Numeric', 'Boolean', 'Text', 'Visual Inspection'].map((type) => <option key={type} value={type}>{type}</option>)}</select>
-                          <span className={`inline-flex items-center gap-1 text-[9px] font-semibold ${statusTone(evaluation)}`}><StatusIcon status={evaluation} />{evaluation}</span>
-                          <label className="inline-flex items-center gap-1 text-[9px] text-slate-600"><input type="checkbox" checked={measurement.required} onChange={(event) => updateMeasurement(index, { required: event.target.checked })} /> Required</label>
-                          <button type="button" onClick={() => store.updateValidationTest(selectedTest.id, { measurements: selectedTest.measurements.filter((item) => item.id !== measurement.id) })} className="grid h-8 w-8 place-items-center rounded-md text-rose-600 hover:bg-rose-50" aria-label={`Delete ${measurement.name || 'measurement'}`}><Trash2 className="h-3.5 w-3.5" /></button>
-                        </div>
-
-                        <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-                          {measurement.type === 'Numeric' && <><label className="text-[9px] font-medium text-slate-500">Expected<input type="number" value={typeof measurement.expectedValue === 'number' ? measurement.expectedValue : ''} onChange={(event) => updateMeasurement(index, { expectedValue: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className={`${inputClass} mt-1`} /></label><label className="text-[9px] font-medium text-slate-500">Tolerance +<input type="number" value={measurement.tolerancePlus ?? ''} onChange={(event) => updateMeasurement(index, { tolerancePlus: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className={`${inputClass} mt-1`} /></label><label className="text-[9px] font-medium text-slate-500">Tolerance -<input type="number" value={measurement.toleranceMinus ?? ''} onChange={(event) => updateMeasurement(index, { toleranceMinus: event.target.value ? Number.parseFloat(event.target.value) : undefined })} className={`${inputClass} mt-1`} /></label></>}
-                          {measurement.type === 'Boolean' && <label className="text-[9px] font-medium text-slate-500">Expected<select value={typeof measurement.expectedValue === 'boolean' ? String(measurement.expectedValue) : ''} onChange={(event) => updateMeasurement(index, { expectedValue: event.target.value === '' ? undefined : event.target.value === 'true' })} className={`${inputClass} mt-1`}><option value="">—</option><option value="true">True</option><option value="false">False</option></select></label>}
-                          {measurement.type === 'Text' && <label className="text-[9px] font-medium text-slate-500 sm:col-span-2">Expected<input value={typeof measurement.expectedValue === 'string' ? measurement.expectedValue : ''} onChange={(event) => updateMeasurement(index, { expectedValue: event.target.value })} className={`${inputClass} mt-1`} /></label>}
-                          <label className="text-[9px] font-medium text-slate-500">Actual{measurement.type === 'Boolean' ? <select value={typeof measurement.actualValue === 'boolean' ? String(measurement.actualValue) : ''} onChange={(event) => updateMeasurement(index, { actualValue: event.target.value === '' ? undefined : event.target.value === 'true' })} className={`${inputClass} mt-1`}><option value="">—</option><option value="true">True</option><option value="false">False</option></select> : <input value={measurement.actualValue != null ? String(measurement.actualValue) : ''} onChange={(event) => updateMeasurement(index, { actualValue: measurement.type === 'Numeric' ? (event.target.value ? Number.parseFloat(event.target.value) : undefined) : event.target.value })} className={`${inputClass} mt-1`} />}</label>
-                        </div>
-                      </div>
-                    );
-                  })}
-                  {selectedTest.measurements.length === 0 && <p className="rounded-md border border-dashed border-slate-300 py-5 text-center text-[10px] text-slate-400">No measurements defined.</p>}
-                </div>
-              </section>
-
-              <section className="border-b border-slate-200 py-5" aria-labelledby="validation-evidence-title">
-                <div className="flex items-center justify-between gap-3"><div><h2 id="validation-evidence-title" className="text-sm font-semibold text-slate-900">Evidence references</h2><p className="mt-0.5 text-[10px] text-slate-500">Attach descriptions or references; run history remains a separate immutable record.</p></div><button type="button" onClick={handleAddEvidence} className="inline-flex min-h-8 items-center gap-1 rounded-md border border-slate-300 bg-white px-2 text-[10px] font-semibold text-slate-700 hover:bg-slate-100"><Plus className="h-3 w-3" /> Evidence</button></div>
-                <div className="mt-3 divide-y divide-slate-100 border-y border-slate-200">
-                  {selectedTest.evidence.map((evidence, index) => <div key={evidence.id} className="flex flex-wrap items-center gap-2 px-2 py-2"><select value={evidence.type} onChange={(event) => updateEvidence(index, { type: event.target.value as ValidationEvidence['type'] })} className="h-8 rounded-md border border-slate-300 bg-white px-2 text-[10px] outline-none focus:border-slate-500">{['Text', 'URL', 'Measurement', 'Photo Reference', 'File Reference'].map((type) => <option key={type} value={type}>{type}</option>)}</select><input value={evidence.value} onChange={(event) => updateEvidence(index, { value: event.target.value })} placeholder="Value / description / reference" className="h-8 min-w-[220px] flex-1 rounded-md border border-slate-300 bg-white px-2 text-[10px] outline-none focus:border-slate-500" /><button type="button" onClick={() => store.updateValidationTest(selectedTest.id, { evidence: selectedTest.evidence.filter((item) => item.id !== evidence.id) })} className="grid h-8 w-8 place-items-center rounded-md text-rose-600 hover:bg-rose-50" aria-label="Delete evidence"><Trash2 className="h-3.5 w-3.5" /></button></div>)}
-                  {selectedTest.evidence.length === 0 && <p className="py-5 text-center text-[10px] text-slate-400">No evidence references attached.</p>}
-                </div>
-              </section>
-
-              <section className="py-5" aria-labelledby="validation-pass-title"><h2 id="validation-pass-title" className="text-sm font-semibold text-slate-900">Pass criteria</h2><p className="mt-0.5 text-[10px] text-slate-500">One explicit criterion per line.</p><textarea value={selectedTest.passCriteria.join('\n')} onChange={(event) => store.updateValidationTest(selectedTest.id, { passCriteria: event.target.value.split('\n').map((criterion) => criterion.trim()).filter(Boolean) })} placeholder="Acceptance criterion" className={`${textAreaClass} mt-3 min-h-28`} /></section>
-            </div>
-          </main>
-        ) : (
-          <div className="grid h-full place-items-center bg-white p-8 text-center"><div className="max-w-sm"><ListChecks className="mx-auto h-7 w-7 text-slate-300" /><p className="mt-3 text-sm font-semibold text-slate-800">No {mode === 'factory-qa' ? 'Factory QA ' : ''}test selected</p><p className="mt-1 text-xs leading-5 text-slate-500">Create a test or open the Tests dock. Defining a test does not count as execution evidence.</p><button type="button" onClick={handleAddTest} className="mt-3 inline-flex min-h-8 items-center gap-1.5 rounded-md bg-slate-950 px-3 text-[10px] font-semibold text-white"><Plus className="h-3.5 w-3.5" /> Create test</button></div></div>
-        )}
-
-        {testListOpen && (
-          <aside className="absolute bottom-3 left-3 top-3 z-30 flex w-[260px] flex-col overflow-hidden rounded-lg border border-slate-300 bg-white shadow-xl" aria-label="Validation test list">
-            <div className="border-b border-slate-200 bg-slate-50 px-3 py-2.5"><p className="text-[10px] font-semibold text-slate-700">{mode === 'factory-qa' ? 'Factory QA tests' : 'Validation tests'}</p><p className="mt-0.5 text-[9px] text-slate-400">Selecting a test edits it here; it does not navigate away.</p></div>
-            <div className="min-h-0 flex-1 space-y-1 overflow-y-auto p-1.5">
-              {visibleTests.map((test) => {
-                const testStatus = calculateTestStatus(test);
-                const selected = selectedTest?.id === test.id;
-                return <button key={test.id} type="button" onClick={() => setSelectedTestId(test.id)} aria-pressed={selected} className={`flex min-h-11 w-full items-center gap-2 rounded-md border px-2 text-left ${selected ? 'border-slate-950 bg-slate-100' : 'border-transparent hover:border-slate-200 hover:bg-slate-50'}`}><StatusIcon status={testStatus} /><span className="min-w-0 flex-1"><span className="block truncate text-[10px] font-semibold text-slate-800">{test.name}</span><span className="mt-0.5 block truncate text-[9px] text-slate-400">{test.stage} · {test.category}</span></span><span className={`text-[8px] font-semibold ${statusTone(testStatus)}`}>{testStatus}</span></button>;
-              })}
-              {visibleTests.length === 0 && <p className="px-3 py-8 text-center text-[10px] leading-4 text-slate-400">No tests in this workspace yet.</p>}
-            </div>
-          </aside>
-        )}
+        <section className="py-5" aria-labelledby="validation-pass-title"><h2 id="validation-pass-title" className="text-sm font-semibold text-slate-900">Pass criteria</h2><p className="mt-0.5 text-[10px] text-slate-500">Explicit criteria define what a reviewer/run evaluates; they do not mark the test Passed.</p><textarea value={selectedTest.passCriteria.join('\n')} onChange={(event) => store.updateValidationTest(selectedTest.id, { passCriteria: event.target.value.split('\n').map((criterion) => criterion.trim()).filter(Boolean) })} placeholder="One acceptance criterion per line" className={`${textAreaClass} mt-3 min-h-28`} /></section>
       </div>
-    </section>
+    </main>
   );
 };

--- a/src/store/validationWorkspaceUiStore.ts
+++ b/src/store/validationWorkspaceUiStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+export type ValidationWorkspaceView = 'define' | 'execute' | 'review' | 'coverage' | 'factory-qa';
+export type ValidationDrawerSection = 'tests' | 'coverage' | 'factory-qa' | 'runs';
+
+interface ValidationWorkspaceUiState {
+  view: ValidationWorkspaceView;
+  drawerSection: ValidationDrawerSection;
+  selectedTestId: string | null;
+  selectedRunId: string | null;
+  inspectorOpen: boolean;
+  bottomDockOpen: boolean;
+  setView: (view: ValidationWorkspaceView) => void;
+  setDrawerSection: (section: ValidationDrawerSection) => void;
+  setSelectedTestId: (id: string | null) => void;
+  setSelectedRunId: (id: string | null) => void;
+  setInspectorOpen: (open: boolean) => void;
+  setBottomDockOpen: (open: boolean) => void;
+  resetTransientSelection: () => void;
+}
+
+export const useValidationWorkspaceUiStore = create<ValidationWorkspaceUiState>((set) => ({
+  view: 'define',
+  drawerSection: 'tests',
+  selectedTestId: null,
+  selectedRunId: null,
+  inspectorOpen: true,
+  bottomDockOpen: false,
+  setView: (view) => set({ view }),
+  setDrawerSection: (drawerSection) => set({ drawerSection }),
+  setSelectedTestId: (selectedTestId) => set({ selectedTestId, selectedRunId: null }),
+  setSelectedRunId: (selectedRunId) => set({ selectedRunId }),
+  setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
+  setBottomDockOpen: (bottomDockOpen) => set({ bottomDockOpen }),
+  resetTransientSelection: () => set({ selectedTestId: null, selectedRunId: null, bottomDockOpen: false }),
+}));


### PR DESCRIPTION
Closes #114
Parent: #19 / #43 / #46
Execution ledger: `docs/development/STUDIO_PHASE_EXECUTION_STATUS.md`

## Replaces
- two independent implicit first-test fallbacks (`visibleTests[0]` and `linkedTests[0] || validationTests[0]`);
- the internal test-list overlay inside `ValidationStudio`;
- the floating run/evidence side panel;
- editable execution-state fields (`step.completed`, `measurement.actualValue`) inside the Define surface;
- visual conflation of editable definition references with immutable run evidence.

## Canonical context
- `validationTests` / `validationRuns` stay in the existing project store;
- `validationWorkspaceUiStore` contains only view/drawer/selected test/selected run/Inspector/bottom-dock state;
- no new validation project model or execution engine is introduced.

## User jobs
One Validation grammar:
- **Define:** test specification, procedure, expected/tolerance schema, requirement links, pass criteria, editable definition references;
- **Execute:** explicit selected test, bounded execution authority, observed result, evidence reference, reviewer/verdict, append-only run/retest;
- **Review:** explicit selected run, frozen run snapshot/history displayed read-only;
- **Coverage / Factory QA:** contextual Validation views inside the same shell.

## Shell
- one shell-owned `ValidationProjectDrawer`: Tests / Coverage / Factory / Runs;
- shared `EngineeringEditorBar` for Define / Execute / Review;
- shared `EngineeringInspector` for selected test/run;
- shared `EngineeringBottomDock` for selected run output/logs;
- shared `EngineeringStatusBar`.

## Truth constraints preserved
- DRC automation is limited to implemented local rules;
- firmware-state automation is structural only;
- Mechanical execution remains an approximate AABB screen and cannot auto-pass exact clearance;
- Thermal has no internal solver and requires external evidence + reviewer for a verdict;
- manual/physical tests do not Pass from text/measurement alone;
- run history remains append-only;
- current run evidence is still project-record evidence, not #19-grade durable hashed/version/DUT/equipment/reviewer evidence;
- #19 remains open.

## Proof
Adds `validationConvergence.test.ts` guarding:
- UI-only state;
- one-drawer ownership;
- no first-test/run fallback;
- Define/Execute/Review separation;
- shared Inspector/bottom-dock grammar;
- existing bounded execution authority.

## Completion gate
Do not merge until exact PR head passes lint, typecheck, full tests, production build, and deployment-status inspection. After merge, update Validation notes + phase ledger before U8.