### PR TITLE
Docs: complete U7 handoff and activate U8

### DIFF
--- a/docs/development/STUDIO_PHASE_EXECUTION_STATUS.md
+++ b/docs/development/STUDIO_PHASE_EXECUTION_STATUS.md
@@ -1,6 +1,6 @@
 # Hardware Studio — Studio phase execution status
 
-**Status date:** 2026-09-01  
+**Status date:** 2026-09-02  
 **Primary direction:** `STUDIO_UX_CONVERGENCE_EXECUTION_PLAN.md`  
 **Engineering authority:** `PRODUCT_RECOVERY_EXECUTION_PLAN.md`
 
@@ -11,10 +11,11 @@ This is the live execution ledger for the U0–U9 Studio phases. It records what
 After every bounded phase slice:
 
 1. merge only after exact-head verification;
-2. record the merged PR/commit here and in the relevant domain notes;
-3. state what the slice deliberately did **not** complete;
-4. keep parent engineering issues open until their real acceptance criteria are satisfied;
-5. start the next phase slice from the new verified master.
+2. double-check PR scope, stale/duplicate paths, parent issue boundaries and deployment status;
+3. record the merged PR/commit here and in the relevant domain notes;
+4. state what the slice deliberately did **not** complete;
+5. keep parent engineering issues open until their real acceptance criteria are satisfied;
+6. start the next phase slice from the new verified and documented master.
 
 Open-issue count is not the completion metric. The product gates and verified user workflows are.
 
@@ -24,147 +25,130 @@ Open-issue count is not the completion metric. The product gates and verified us
 | --- | --- | --- | --- |
 | **U0 — Architecture lock** | Landed | One Studio grammar, freeze rules, issue reconciliation and convergence plan established. | Maintain freeze rules while later phases land. |
 | **U1 — Shared Studio shell** | Foundation landed; broader recovery still open | Workbench tabs, shared Project Drawer host, shared Inspector/bottom-dock/status primitives are in production code. Routing/repository/layout durability remain governed by their engineering issues. | Reuse shell primitives; do not fork per-domain shells. |
-| **U2 — Project Home** | Truthful Home model landed; not a substitute for durable history | Next action/blocker/lifecycle logic uses real domain evidence. Do not fabricate “recent changes” from timestamps/counts. | Add durable recent engineering change history only when command/repository history supports it. |
+| **U2 — Project Home** | Truthful Home model landed; not a substitute for durable history | Next action/blocker/lifecycle logic uses real domain evidence. Do not fabricate recent changes from timestamps/counts. | Add durable engineering-change history only when command/repository history supports it. |
 | **U3 — Electronics reference workbench** | Substantially converged; engineering depth still open | Shared identity, Schematic/PCB/BOM/contextual tools and common editor grammar are established. | Preserve canonical identity while #13–#15 deepen engineering capability. |
-| **U4 — PCB editor depth** | Structural convergence landed; real PCB engine remains open | PCB owns one Project Drawer, one Inspector, one Problems dock, explicit board identity/rules and no fake auto-place/autoroute claims. | Continue #15 for real PCB depth; do not confuse UX convergence with ECAD completion. |
-| **U5 — Mechanical** | **Structural UX convergence complete** | PR #107/#106 established one drawer + explicit physical input. PR #110/#109 converged 2D Layout / 3D Review / Assembly. #16/#17 remain open for real sketch/CAD engineering. | Continue #16/#17 in parallel; do not fake solver/CAD depth in UX phases. |
-| **U6 — Firmware** | **Structural UX convergence complete** | PR #113/#112: one Firmware drawer/workbench/Inspector/dock, explicit module/file/build selection, duplicate `FirmwareStudio` removed. #18 remains open for real filesystem/PlatformIO/device/serial engineering. | Continue #18 in parallel through the shared Firmware grammar. |
-| **U7 — Validation** | **Active — U7.1 scoped in #114** | Existing runner/history foundations are useful but current UI has two implicit first-test fallbacks and blends Define/Execute/Review. #19 remains the durable-validation authority. | U7.1: explicit test/run selection, one drawer, Define → Execute → Review, bottom execution/evidence dock. |
-| **U8 — Release** | Pending dedicated phase pass | Version/output/release foundations exist but remain governed by #20/#21 and release truth gates. | Run dedicated U8 control-surface convergence after U7 handoff. |
-| **U9 — Final polish** | Not started by design | Structural work must stabilize first. | After U7–U8: final visual hierarchy, functional visuals, accessibility, responsive layouts, motion/performance and interaction predictability. |
+| **U4 — PCB editor depth** | Structural convergence landed; real PCB engine remains open | One PCB drawer, one Inspector, one Problems dock, explicit board identity/rules, no fake auto-place/autoroute claims. | Continue #15 separately for real ECAD depth. |
+| **U5 — Mechanical** | **Structural UX convergence complete** | PR #107/#106: one drawer + explicit physical input. PR #110/#109: 2D Layout / 3D Review / Assembly in one workbench. | Continue #16/#17 separately for real sketch/CAD engineering. |
+| **U6 — Firmware** | **Structural UX convergence complete** | PR #113/#112: one Firmware drawer/workbench/Inspector/dock, explicit module/file/build selection, duplicate `FirmwareStudio` removed. | Continue #18 separately for filesystem/PlatformIO/device/serial engineering. |
+| **U7 — Validation** | **Structural UX convergence complete** | PR #116/#114: one Validation drawer, explicit test/run selection, Define → Execute → Review, shared Inspector/dock, execution truth preserved. | Continue #19 separately for durable evidence/execution/review infrastructure. |
+| **U8 — Release** | **Active** | Current readiness/revision/output/package foundations exist but must not be confused with #20-grade immutable versions/releases or #21-grade qualified artifacts. | Converge Release control surfaces with explicit context and draft/unqualified truth. |
+| **U9 — Final polish** | Not started by design | Structural work must stabilize first. | After U8: full visual hierarchy, functional visuals, accessibility, responsive layouts, motion/performance and interaction predictability. |
 
-## Latest completed slice — U6.1 Firmware convergence
+## Latest completed slice — U7.1 Validation convergence
 
-**PR:** #113 — `U6.1: Converge Firmware on one drawer and explicit evidence grammar`  
-**Issue:** #112 — completed  
-**Merged master:** `ab4312f0f929103fc7baf3f2b52a80610639e72f`  
-**Verified exact PR head:** `646e70a581dc524ac8a8bfcd2899fe488a6dfdae`
+**PR:** #116 — `U7.1: Converge Validation on explicit Define Execute Review`  
+**Issue:** #114 — completed  
+**Merged master:** `754fbabff639cddeeb4e68c6b2d2d547665d4571`  
+**Verified exact PR head:** `643757f7f942702bbef4408e1edca621b1bf6ac3`
 
 Exact-head verification before merge:
 
 - lint: pass;
 - typecheck: pass;
-- tests: 332/332 pass;
+- tests: **339/339 pass across 89 test files**;
 - production build: pass;
-- Vercel: inspected external Hobby-plan build-rate-limit status; not an application build failure.
+- Vercel deployment status: pass.
 
-### U6.1 landed behavior
+Final double-check before merge:
 
-- one shell-owned Firmware Project Drawer: **Modules / Files / Map / Environment**;
-- one `EngineeringFirmwareWorkbench` authority for all live Firmware routes;
-- the retired 676-line `FirmwareStudio.tsx` duplicate mini-app is physically deleted;
-- module responsibility, Behavior/state-machine, Hardware Map and Source are representations of one Firmware workbench;
-- right Inspector is selection-aware;
-- bottom dock owns **Problems / Build Evidence / Device Evidence**;
-- `firmwareWorkspaceUiStore` contains only UI/session state;
-- canonical firmware modules, states, transitions, mappings, source records and evidence remain in project state;
-- opening Firmware does not auto-select the first module;
-- opening Source does not auto-select the first file;
-- generated scaffolding does not silently become the selected/authoritative implementation;
-- device evidence requires an explicitly chosen successful build record;
-- source-editor tree ownership moved to the shared Firmware drawer;
-- source editor retains line numbers, cursor position, keyboard save and explicit generated-file truth labels.
+- changed files were limited to Validation shell/workbench/state plus direct regression guards;
+- no landing-page or schema changes;
+- no PCB, Mechanical, Firmware or Release production changes;
+- #19 confirmed open;
+- explicit regression guards reject silent first-test/first-run fallback and retired floating-panel ownership.
 
-### U6.1 truth boundary
+### U7.1 landed behavior
 
-U6.1 deliberately did **not** claim real firmware execution capability.
+- one shell-owned Validation Project Drawer: **Tests / Coverage / Factory QA / Runs**;
+- selection/job/dock state lives only in `validationWorkspaceUiStore`;
+- project `validationTests` and `validationRuns` remain in canonical project state;
+- opening Validation no longer silently chooses the first test or first run;
+- center work is explicitly divided into **Define / Execute / Review**;
+- Define owns specification: procedure, expected/tolerance schema, links, pass criteria and editable definition references;
+- Define no longer exposes actual measurements or step-completion state as if they were specification truth;
+- Execute owns observed result, evidence reference, reviewer/verdict and run/retest creation;
+- Review owns read-only historical run snapshot/history;
+- selected run logs use the shared bottom dock;
+- the internal test-list overlay and floating run/evidence side panel are retired;
+- component-linked validation derives actual canonical net IDs from component pin `netId` values.
 
-Current Build Evidence:
-- records externally produced build metadata/logs;
-- does not claim Hardware Studio ran a compiler.
+### U7 execution truth preserved
 
-Current Device Evidence:
-- records an externally observed device result;
-- does not claim Hardware Studio flashed, queried or monitored the device.
+- local DRC automation covers implemented local DRC rules only;
+- firmware-state automation validates state-machine structure only;
+- Mechanical execution remains an approximate AABB collision screen and cannot auto-pass exact physical clearance;
+- Thermal has no internal solver and requires external simulation/lab evidence plus reviewer identity;
+- arbitrary text or a measurement alone does not become a trusted manual/physical Pass;
+- retests add a new run while prior history remains present.
 
-Generated source:
-- remains scaffolding;
-- remains `Generated · not verification`.
+Full handoff details: `U7_VALIDATION_CONVERGENCE_NOTES.md`.
 
-State-machine diagnostics:
-- validate structural reachability/transition integrity only;
-- do not prove compilation, timing, hardware behavior or runtime correctness.
+## Validation engineering boundary after U7
 
-## Firmware engineering boundary after U6
+Issue #19 remains open for:
 
-Issue #18 remains the authority for:
+- durable hashed evidence/object storage and provenance;
+- exact product-version/procedure/DUT/sample/operator/environment binding;
+- equipment and calibration policy;
+- typed uncertainty/statistical measurement support;
+- durable pause/resume/cancel/recovery execution jobs;
+- immutable reviewer/sign-off records and roles;
+- waivers/deviations;
+- trusted retest lineage/comparison;
+- deterministic stale propagation;
+- release-grade accepted-evidence policy.
 
-- filesystem-backed project tree and conflict/recovery semantics;
-- Monaco/equivalent source editor and language services;
-- authoritative PlatformIO environments and dependency/toolchain configuration;
-- real build/clean/upload/erase/device-list operations;
-- hardened exact-payload approval flow;
-- durable queued/running/completed/failed/cancelled operation records;
-- streaming stdout/stderr, timeout, retry and cancellation;
-- real serial monitor and evidence capture;
-- atomic file writes/backups plus path/origin/symlink hardening;
-- content-addressed artifacts tied to source snapshot, tools and product version;
-- richer typed hardware maps/conflict detection;
-- a reference-device edit → build → approved flash → serial → Validation workflow.
+Do not close #19 because the Validation workbench is structurally coherent.
 
-Do not close #18 because U6 is structurally coherent.
+## Active phase — U8 Release convergence
 
-## Active bounded slice — U7.1 Validation convergence
+### Confirmed engineering boundary
 
-**Issue:** #114 — `[U7.1][Validation] Converge Define / Execute / Review with explicit test selection`
+Issue #20 remains the authority for real versions, branches and releases. Current revision/snapshot/status UI must **not** be presented as equivalent to:
 
-### Current structural defects confirmed by audit
+- immutable content-addressed named versions;
+- explicit branch ancestry/base semantics;
+- domain-aware comparisons;
+- true three-way merges/conflicts;
+- repository-enforced freezes;
+- exact candidate/artifact hashes;
+- trusted approval bound to exact payload hash;
+- immutable published releases with supersession/withdrawal.
 
-Validation currently has two independent implicit-selection paths:
+Issue #21 remains the authority for real drawings/manufacturing/qualified outputs. Current generators/download surfaces must **not** imply that generation alone establishes qualification.
 
-1. `ValidationStudio` resolves its selected test as explicit ID **or `visibleTests[0]`**;
-2. `UnifiedValidationWorkbench` resolves execution target as explicit ID **or `linkedTests[0]` or `validationTests[0]`**.
+Qualified output eventually requires canonical source data, provenance/tool/input/output hashes, independent parser/viewer checks, review policy, reproducibility and exact release integration.
 
-That means authoring and execution can silently point at a test the user never selected, and the two surfaces can reason about different implicit tests.
+### U8 target grammar
 
-Other confirmed problems:
+The U8 structural target is one connected Release workbench:
 
-- run/evidence interaction is a floating right-side panel instead of the shared bottom-dock grammar;
-- definition fields, mutable test evidence, execution, and historical review are visually blended;
-- Coverage and Factory QA are route modes rather than clearly contextual jobs inside one Validation workbench;
-- current append-only run records are useful but are not the durable hashed/reviewed evidence model required by #19.
-
-### U7.1 target grammar
-
-- **Left Project Drawer:** explicit Tests / Coverage / Factory QA / Runs context backed by existing project data;
-- **Center:** explicit **Define / Execute / Review** job surface;
-- **Right Inspector:** explicitly selected test/run context only;
-- **Bottom dock:** execution output, Problems and evidence/history context rather than a floating side mini-app;
+- **Left Project Drawer:** Readiness / Versions or Revisions / Outputs / Drawings / Factory Package / release context supported by real state;
+- **Center:** selected Release job/surface rather than disconnected mini-app pages;
+- **Right Inspector:** explicitly selected revision/output/candidate/package context only;
+- **Bottom dock:** blockers, generation/preflight jobs, logs and review evidence where real records exist;
 - **Top:** contextual actions only.
 
-### Execution truth to preserve
+### U8 truth constraints
 
-The current runner has bounded useful authority and U7 must preserve it:
+- no silent first revision/release/artifact selection;
+- no JSON snapshot presented as a content-addressed immutable version;
+- no status toggle presented as trusted release approval;
+- no generated filename/ZIP presented as manufacturing-qualified merely because generation succeeded;
+- missing geometry/version/provenance/qualification remains visible and blocking where appropriate;
+- draft/unqualified artifacts remain visually distinct from release evidence;
+- do not create a second version/output data model merely for UX convergence;
+- keep #20 and #21 open.
 
-- DRC automation derives only from implemented local DRC rules;
-- firmware-state automation validates structural state-machine consistency only;
-- Mechanical automation is an approximate AABB collision screen and cannot auto-pass exact physical clearance;
-- Thermal has no internal solver and requires external evidence + reviewer for a verdict;
-- manual/physical validation cannot Pass from arbitrary text or a measurement alone;
-- retests append a new run while prior runs remain present.
+## Double-check discipline for U8 and U9
 
-## Validation engineering boundary during U7
+Before calling a phase slice complete:
 
-Issue #19 remains open for the real durable validation system, including:
-
-- version/procedure/DUT/equipment/calibration binding;
-- durable hashed evidence storage and provenance;
-- typed measurement uncertainty/statistical analysis;
-- pause/resume/cancel/incomplete execution recovery;
-- immutable reviewed/sign-off records;
-- waivers/deviations;
-- retest lineage and dependency-change comparison;
-- deterministic stale propagation;
-- release-grade validation policy.
-
-U7 structural convergence must not hide those gaps or close #19.
-
-## Phase handoff discipline
-
-For U7 and U8:
-
-1. implement one bounded structural/truth slice at a time;
-2. merge only after exact-head lint/typecheck/tests/build/deployment inspection;
-3. update this ledger plus domain-specific notes immediately after merge;
-4. keep #19/#20/#21 open until their engineering completion guards are genuinely satisfied;
-5. do not start U9 polish until U7/U8 structure is stable enough that polish will not be thrown away.
+1. review exact PR changed-file scope;
+2. run exact-head lint, typecheck, all tests and production build;
+3. inspect Vercel/deployment status;
+4. scan for retired duplicate paths and implicit selection fallbacks;
+5. verify deep parent issues remain correctly open;
+6. verify truth labels and unsupported-capability boundaries;
+7. update domain notes and this ledger;
+8. start the next phase from the verified documented master only.

--- a/docs/development/U7_VALIDATION_CONVERGENCE_NOTES.md
+++ b/docs/development/U7_VALIDATION_CONVERGENCE_NOTES.md
@@ -1,0 +1,135 @@
+# U7 Validation convergence notes
+
+**Status date:** 2026-09-02  
+**Structural UX phase:** complete  
+**Engineering authority still open:** #19
+
+## Merged evidence
+
+- PR #116 — `U7.1: Converge Validation on explicit Define Execute Review`
+- Issue #114 — completed through PR #116
+- merged master: `754fbabff639cddeeb4e68c6b2d2d547665d4571`
+- verified exact PR head: `643757f7f942702bbef4408e1edca621b1bf6ac3`
+
+Exact-head verification before merge:
+
+- lint: pass;
+- typecheck: pass;
+- tests: **339/339 pass across 89 test files**;
+- production build: pass;
+- Vercel deployment status: pass.
+
+A final pre-merge double-check also confirmed:
+
+- PR scope was limited to Validation shell/workbench/test files;
+- no landing-page, schema, persistence, Firmware, PCB, Mechanical or Release production changes were included;
+- #19 remained open;
+- regression guards reject the retired implicit-selection and floating-panel patterns.
+
+## Landed interaction grammar
+
+Validation is now one connected workbench rather than overlapping authoring/execution mini-apps.
+
+### Left Project Drawer
+
+- Tests
+- Coverage
+- Factory QA
+- Runs
+
+Test and run selection are explicit UI/session state in `validationWorkspaceUiStore`. Opening Validation does not silently choose the first test or first run.
+
+### Center jobs
+
+#### Define
+Owns the mutable test specification:
+
+- test identity/name;
+- stage/category;
+- requirement linkage;
+- procedure instructions and expected results;
+- expected measurement schema and tolerances;
+- pass criteria;
+- editable **definition references**.
+
+Define no longer presents execution completion or actual readings as specification data. `step.completed` and `measurement.actualValue` are not editable execution controls in this surface.
+
+Definition references are explicitly labelled as editable planning/reference data, **not immutable validation run evidence**.
+
+#### Execute
+Requires an explicitly selected test and surfaces the existing bounded execution authority before recording a run/retest.
+
+Observed result, evidence reference, reviewer identity and manual verdict belong here rather than in test definition authoring.
+
+#### Review
+Requires an explicitly selected historical run and displays the frozen run snapshot/history read-only. Historical run logs use the shared bottom dock.
+
+## Shared shell
+
+U7 now uses the common Studio grammar:
+
+- shared `EngineeringEditorBar`;
+- shell-owned `ValidationProjectDrawer`;
+- contextual `EngineeringInspector`;
+- `EngineeringBottomDock` for selected-run output/logs;
+- shared `EngineeringStatusBar`.
+
+The former internal test-list overlay and floating run/evidence side panel are retired from the live Validation workflow.
+
+## Selection and identity truth
+
+The U7 regression suite explicitly guards against:
+
+- `visibleTests[0]` fallback;
+- `linkedTests[0]` fallback;
+- `validationTests[0]` fallback;
+- `runHistory[0]` fallback;
+- retired `testListOpen` ownership;
+- retired `runPanelOpen` ownership.
+
+Component-linked validation continues to derive actual linked net IDs from canonical component pin `netId` values rather than a display-name shortcut.
+
+## Execution truth preserved
+
+U7 reorganized existing useful validation behavior without broadening its claimed authority.
+
+- **DRC:** automated verdicts are limited to implemented local DRC rules.
+- **Firmware state:** automated checks validate state-machine structure/reachability only; they do not prove build/runtime/hardware behavior.
+- **Mechanical:** local execution is an approximate AABB collision screen. A clean screen is not exact CAD/physical clearance verification.
+- **Thermal:** Hardware Studio has no internal thermal solver. A verdict requires external simulation/lab evidence plus reviewer identity.
+- **Manual/physical:** arbitrary text or a measurement alone cannot produce a trusted Pass.
+- **Retest:** a new run is appended/prepended in history while prior run records remain present; prior history is not silently overwritten.
+
+## What U7 deliberately did not complete
+
+U7 is structural UX convergence, not closure of #19.
+
+Issue #19 remains the authority for:
+
+- durable object/blob evidence storage and content hashes;
+- exact product version / procedure revision binding;
+- DUT, sample, lot/build, operator and environment binding;
+- equipment/calibration records and policy;
+- typed units, uncertainty, resolution and statistical analysis;
+- durable execution jobs with pause/resume/cancel/recovery;
+- immutable reviewed/sign-off records and role policy;
+- waivers/deviations;
+- trusted retest comparison and lineage;
+- deterministic stale propagation after design/build/procedure changes;
+- release-grade accepted-evidence policy;
+- end-to-end browser workflow from execution through release gate.
+
+Do **not** close #19 because the Validation workbench is now coherent.
+
+## Handoff to U8
+
+The next Studio phase is U8 Release convergence.
+
+U8 must use the same truth discipline:
+
+- one Release control surface rather than independent readiness/revision/output/factory mini-apps;
+- explicit revision/version/candidate/artifact context;
+- current JSON snapshot revisions must not be presented as immutable content-addressed versions;
+- generated output filenames/ZIPs must not be presented as qualified manufacturing artifacts merely because generation succeeded;
+- draft/unqualified output state must remain visually distinct from release evidence;
+- #20 and #21 remain open until their full engineering completion guards are satisfied.


### PR DESCRIPTION
Documentation checkpoint after merged U7.1 PR #116.

Updates:
- marks U7 structural UX convergence complete;
- records exact #116 merge/head and 339/339 test evidence across 89 files;
- records the final double-check: bounded PR scope, no landing/schema drift, #19 still open, Vercel green;
- adds `U7_VALIDATION_CONVERGENCE_NOTES.md` with Define / Execute / Review and execution-authority truth boundaries;
- activates U8 Release convergence;
- records #20/#21 boundaries so snapshot revisions and generated packages are not misrepresented as immutable releases or qualified artifacts;
- adds the phase-level double-check checklist requested by the project owner.

Documentation-only; no runtime behavior changes.