### PR TITLE
U8.1: Converge Release on explicit provisional context

### DIFF
--- a/src/__tests__/releaseConvergence.test.ts
+++ b/src/__tests__/releaseConvergence.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { useReleaseWorkspaceUiStore } from '../store/releaseWorkspaceUiStore';
+
+function source(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+describe('U8 Release convergence', () => {
+  beforeEach(() => {
+    useReleaseWorkspaceUiStore.setState({
+      drawerSection: 'readiness',
+      selectedKind: null,
+      selectedRecordId: null,
+      inspectorOpen: true,
+      bottomDockOpen: false,
+    });
+  });
+
+  it('keeps release selection and shell state UI-only', () => {
+    const ui = useReleaseWorkspaceUiStore.getState();
+    ui.selectRecord('snapshot', 'rev-explicit');
+    ui.setDrawerSection('snapshots');
+    ui.setBottomDockOpen(true);
+
+    expect(useReleaseWorkspaceUiStore.getState()).toMatchObject({
+      selectedKind: 'snapshot',
+      selectedRecordId: 'rev-explicit',
+      drawerSection: 'snapshots',
+      bottomDockOpen: true,
+    });
+
+    const uiSource = source('../store/releaseWorkspaceUiStore.ts');
+    expect(uiSource).not.toContain('useProjectStore');
+    expect(uiSource).not.toContain('revisions:');
+    expect(uiSource).not.toContain('releaseCandidates:');
+    expect(uiSource).not.toContain('releases:');
+  });
+
+  it('uses one shell-owned Release Project Drawer and one Release workbench authority', () => {
+    const navigation = source('../components/StudioWorkbenchNavigation.tsx');
+    const drawer = source('../components/release/ReleaseProjectDrawer.tsx');
+    const appShell = source('../components/AppShell.tsx');
+
+    expect(navigation).toContain("activeWorkbench.id === 'release'");
+    expect(navigation).toContain('<ReleaseProjectDrawer />');
+    expect(drawer).toContain("label: 'Readiness'");
+    expect(drawer).toContain("label: 'Snapshots'");
+    expect(drawer).toContain("label: 'Outputs'");
+    expect(drawer).toContain("label: 'Drawings'");
+    expect(drawer).toContain("label: 'Factory'");
+
+    expect(appShell).toContain('<UnifiedReleaseWorkbench mode="readiness" />');
+    expect(appShell).toContain('<UnifiedReleaseWorkbench mode="snapshots" />');
+    expect(appShell).toContain('<UnifiedReleaseWorkbench mode="outputs" />');
+    expect(appShell).toContain('<UnifiedReleaseWorkbench mode="drawings" />');
+    expect(appShell).toContain('<UnifiedReleaseWorkbench mode="factory" />');
+    expect(appShell).not.toContain('<ExportCenter />');
+    expect(appShell).not.toContain('<FactoryPackageBuilder />');
+    expect(appShell).not.toContain('<RevisionsStudio />');
+  });
+
+  it('requires explicit source snapshot context for branch and candidate creation', () => {
+    const revisions = source('../components/revisions/RevisionsStudio.tsx');
+    const drawer = source('../components/release/ReleaseProjectDrawer.tsx');
+
+    expect(revisions).not.toContain('revisions[revisions.length - 1]');
+    expect(revisions).not.toContain('latestRevision');
+    expect(revisions).toContain("selectedKind === 'snapshot'");
+    expect(revisions).toContain('revisions.find((revision) => revision.id === selectedRecordId)');
+    expect(revisions).toContain('if (!name || !selectedSnapshot) return;');
+    expect(revisions).toContain('if (!tag || !selectedSnapshot) return;');
+    expect(drawer).toContain("onClick={() => selectRecord(kind, record.id)}");
+    expect(drawer).toContain('Opening Release never creates or selects one.');
+  });
+
+  it('bounds snapshot/candidate/release wording to current local authority', () => {
+    const revisions = source('../components/revisions/RevisionsStudio.tsx');
+    const workbench = source('../components/release/UnifiedReleaseWorkbench.tsx');
+
+    expect(revisions).toContain('Capture local snapshot');
+    expect(revisions).toContain('Provisional candidate');
+    expect(revisions).toContain('Local release records');
+    expect(revisions).toContain('not a #20-grade content-addressed immutable version');
+    expect(revisions).toContain('Trusted approval/immutable publication remain #20');
+    expect(workbench).toContain('not a #20-grade content-addressed version, trusted approval, or immutable published release');
+  });
+
+  it('treats readiness as local preflight rather than fabrication/release authorization', () => {
+    const readiness = source('../components/ReadinessDashboard.tsx');
+
+    expect(readiness).not.toContain('Fabrication evidence satisfied');
+    expect(readiness).not.toContain('Review and publish the frozen release candidate');
+    expect(readiness).toContain('Local helper preflight has no fabrication blocker');
+    expect(readiness).toContain('This is not fabrication or release authorization');
+    expect(readiness).toContain('Supporting signal only. It is not a release score, approval, fabrication authorization, or artifact qualification.');
+  });
+
+  it('keeps live manufacturing outputs Draft / Unqualified and avoids release-manifest overclaiming', () => {
+    const outputs = source('../components/release/ReleaseOutputsSurface.tsx');
+    const factory = source('../components/release/ReleaseFactorySurface.tsx');
+
+    for (const surface of [outputs, factory]) {
+      expect(surface).toContain('Draft / Unqualified');
+      expect(surface).toContain('draft_package_manifest.json');
+      expect(surface).toContain('Draft package manifest');
+      expect(surface).not.toContain("'release_manifest.json'");
+    }
+
+    expect(outputs).toContain('not #21-qualified manufacturing/release artifacts');
+    expect(factory).toContain('Checklist state records review notes only');
+    expect(factory).toContain('does not mark a package Verified');
+    expect(factory).toContain('still unqualified');
+  });
+
+  it('keeps #20/#21 qualification gaps visible in the shared Release grammar', () => {
+    const workbench = source('../components/release/UnifiedReleaseWorkbench.tsx');
+    const drawer = source('../components/release/ReleaseProjectDrawer.tsx');
+
+    expect(workbench).toContain('trusted versions/releases remain #20');
+    expect(workbench).toContain('qualified artifacts remain #21');
+    expect(workbench).toContain('Helper blockers only');
+    expect(drawer).toContain('Trusted release/qualification remain #20/#21.');
+  });
+});

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -14,19 +14,15 @@ import { RECOVER_TO_DASHBOARD_KEY } from '../lib/reliability';
 import { TopBar } from './TopBar';
 import { StudioProjectDrawer, StudioWorkbenchTabs } from './StudioWorkbenchNavigation';
 import { BlueprintCanvas } from './BlueprintCanvas';
-import { ExportCenter } from './ExportCenter';
 import { PropertiesPanel } from './PropertiesPanel';
 import { ProductVisualizer } from './ProductVisualizer';
-import { ReadinessDashboard } from './ReadinessDashboard';
 import { ProjectDashboard } from './ProjectDashboard';
-import { BlueprintSheets } from './BlueprintSheets';
-import { FactoryPackageBuilder } from './FactoryPackageBuilder';
-import { RevisionsStudio } from './revisions/RevisionsStudio';
 import { ProductStudio } from './product/ProductStudio';
 import { EngineeringFirmwareWorkbench } from './firmware/EngineeringFirmwareWorkbench';
 import { UnifiedValidationWorkbench } from './studio/UnifiedValidationWorkbench';
 import { UnifiedMechanicalWorkbench } from './studio/UnifiedWorkbenchAdapters';
 import { ElectronicsWorkspace, ELECTRONICS_WORKSPACE_VIEW_IDS } from './studio/ElectronicsWorkspace';
+import { UnifiedReleaseWorkbench } from './release/UnifiedReleaseWorkbench';
 
 function renderSurface(surface: NavigationSurface, viewId: string): React.ReactNode {
   if (ELECTRONICS_WORKSPACE_VIEW_IDS.has(viewId)) return <ElectronicsWorkspace />;
@@ -35,7 +31,7 @@ function renderSurface(surface: NavigationSurface, viewId: string): React.ReactN
     case 'dashboard': return <ProjectDashboard />;
     case 'legacy-blueprint': return <BlueprintCanvas />;
     case 'product-studio': return <ProductStudio initialMode={viewId} />;
-    case 'readiness': return <ReadinessDashboard />;
+    case 'readiness': return <UnifiedReleaseWorkbench mode="readiness" />;
     case 'mechanical-canvas': return <UnifiedMechanicalWorkbench defaultMode="canvas" />;
     case 'mechanical-assembly': return <UnifiedMechanicalWorkbench defaultMode="assembly" />;
     case 'firmware-modules': return <EngineeringFirmwareWorkbench initialMode={viewId === 'firmware-evidence' ? 'evidence' : 'modules'} />;
@@ -45,10 +41,10 @@ function renderSurface(surface: NavigationSurface, viewId: string): React.ReactN
     case 'validation-tests': return <UnifiedValidationWorkbench initialMode="tests" />;
     case 'validation-coverage': return <UnifiedValidationWorkbench initialMode="coverage" />;
     case 'validation-factory-qa': return <UnifiedValidationWorkbench initialMode="factory-qa" />;
-    case 'blueprint-sheets': return <BlueprintSheets />;
-    case 'exports': return <ExportCenter />;
-    case 'revisions': return <RevisionsStudio />;
-    case 'factory-builder': return <FactoryPackageBuilder />;
+    case 'blueprint-sheets': return <UnifiedReleaseWorkbench mode="drawings" />;
+    case 'exports': return <UnifiedReleaseWorkbench mode="outputs" />;
+    case 'revisions': return <UnifiedReleaseWorkbench mode="snapshots" />;
+    case 'factory-builder': return <UnifiedReleaseWorkbench mode="factory" />;
     case 'component-library':
     case 'schematic-editor':
     case 'power-budget':

--- a/src/components/ReadinessDashboard.tsx
+++ b/src/components/ReadinessDashboard.tsx
@@ -1,15 +1,7 @@
 'use client';
 
 import React from 'react';
-import {
-  AlertTriangle,
-  ArrowRight,
-  CheckCircle2,
-  CircleDot,
-  FileCheck2,
-  LockKeyhole,
-  ShieldAlert,
-} from 'lucide-react';
+import { AlertTriangle, ArrowRight, CheckCircle2, FileCheck2, ShieldAlert } from 'lucide-react';
 import { useProjectStore } from '../store/projectStore';
 import { calculateReadinessScore } from '../lib/readinessScore';
 
@@ -27,12 +19,12 @@ function routeForIssue(issue: string): IssueRoute {
   if (text.includes('pcb drc') || text.includes('footprint') || text.includes('placement')) return { viewId: 'pcb-drc', label: 'Open board review' };
   if (text.includes('schematic') || text.includes('erc') || text.includes('circuit')) return { viewId: 'schematic-editor', label: 'Open schematic' };
   if (text.includes('gnd') || text.includes('net') || text.includes('routing')) return { viewId: 'board-designer', label: 'Open routing' };
-  if (text.includes('battery') || text.includes('power')) return { viewId: 'power-tree', label: 'Open power tree' };
+  if (text.includes('battery') || text.includes('power')) return { viewId: 'power-tree', label: 'Open power' };
   if (text.includes('pin')) return { viewId: 'pin-map', label: 'Open pin map' };
   if (text.includes('firmware') || text.includes('driver')) return { viewId: 'firmware-studio', label: 'Open firmware' };
   if (text.includes('test') || text.includes('validation')) return { viewId: 'validation-studio', label: 'Open validation' };
-  if (text.includes('factory') || text.includes('handoff') || text.includes('production')) return { viewId: 'factory-builder', label: 'Open factory package' };
-  if (text.includes('export') || text.includes('drawing')) return { viewId: 'exports', label: 'Open outputs' };
+  if (text.includes('factory') || text.includes('handoff') || text.includes('production')) return { viewId: 'factory-builder', label: 'Open factory preflight' };
+  if (text.includes('export') || text.includes('drawing')) return { viewId: 'exports', label: 'Open draft outputs' };
   return { viewId: 'dashboard', label: 'Open project overview' };
 }
 
@@ -40,160 +32,122 @@ export const ReadinessDashboard: React.FC = () => {
   const project = useProjectStore();
   const { setActiveView } = project;
   const report = calculateReadinessScore(project);
-
   const firstBlocker = report.blockers[0];
-  const blockerRoute = firstBlocker ? routeForIssue(firstBlocker) : null;
+  const firstRoute = firstBlocker ? routeForIssue(firstBlocker) : null;
 
-  const currentDecision = report.canMoveToFabrication
+  const nextAction = firstBlocker && firstRoute
     ? {
-        eyebrow: 'Fabrication evidence satisfied',
-        title: 'Review and publish the frozen release candidate',
-        detail: 'Automated lifecycle gates no longer report a blocker. The remaining act is a human release decision against the frozen candidate and its evidence.',
-        consequence: 'Publishing creates a release record. It must not silently change the working design.',
-        action: { viewId: 'releases', label: 'Review release candidate' },
-        tone: 'emerald',
+        eyebrow: `${report.blockers.length} local preflight blocker${report.blockers.length === 1 ? '' : 's'}`,
+        title: firstBlocker,
+        detail: 'Resolve this engineering evidence before the current local preflight can advance.',
+        action: firstRoute,
       }
-    : report.canMoveToFactoryHandoff
+    : report.canMoveToFabrication
       ? {
-          eyebrow: 'Prototype gate satisfied',
-          title: 'Decide whether the factory package is ready for independent review',
-          detail: 'Prototype evidence is sufficient, but fabrication still depends on the manufacturing package and explicit review evidence.',
-          consequence: 'Moving forward opens factory review; it does not authorize fabrication by itself.',
-          action: { viewId: 'factory-builder', label: 'Review factory package' },
-          tone: 'sky',
+          eyebrow: 'Local helper preflight has no fabrication blocker',
+          title: 'Review provisional release context and outstanding qualification',
+          detail: 'The current helper checks report no blocker. This is not fabrication or release authorization: #20 immutable version/release guarantees and #21 qualified artifact checks are still required.',
+          action: { viewId: 'revisions', label: 'Review snapshots & candidates' },
         }
-      : report.canMoveToPrototype
+      : report.canMoveToFactoryHandoff
         ? {
-            eyebrow: 'Planning evidence satisfied',
-            title: 'Decide whether the design is ready for prototype preparation',
-            detail: 'Planning gates are satisfied. Review physical, electrical, firmware, and validation evidence before spending money on a prototype.',
-            consequence: 'Advancing means prototype preparation can begin; unresolved factory requirements remain separate.',
-            action: { viewId: 'validation-studio', label: 'Review validation evidence' },
-            tone: 'sky',
+            eyebrow: 'Local prototype evidence preflight satisfied',
+            title: 'Review the draft factory package',
+            detail: 'Current project evidence is sufficient to prepare draft outputs for independent review. It does not authorize fabrication.',
+            action: { viewId: 'factory-builder', label: 'Open factory preflight' },
           }
-        : firstBlocker && blockerRoute
+        : report.canMoveToPrototype
           ? {
-              eyebrow: `${report.blockers.length} blocking decision${report.blockers.length === 1 ? '' : 's'}`,
-              title: firstBlocker,
-              detail: 'This is the first unresolved condition preventing the next lifecycle decision. Resolve the responsible engineering evidence before advancing.',
-              consequence: 'Until it is resolved, prototype/release readiness must remain blocked regardless of the numerical score.',
-              action: blockerRoute,
-              tone: 'rose',
+              eyebrow: 'Local planning preflight satisfied',
+              title: 'Review validation evidence before prototype preparation',
+              detail: 'Planning helpers have no current blocker. Validation and physical evidence still control the engineering decision.',
+              action: { viewId: 'validation-studio', label: 'Review validation' },
             }
           : {
               eyebrow: 'Verification work remains',
               title: report.warnings[0] || 'Review the next incomplete engineering gate',
-              detail: 'There is no hard blocker recorded, but evidence is still incomplete. Close the highest-value verification gap rather than adding more project records.',
-              consequence: 'The lifecycle stays at its current gate until the missing evidence is recorded.',
+              detail: 'There is no hard blocker recorded, but the current evidence set is incomplete.',
               action: routeForIssue(report.warnings[0] || ''),
-              tone: 'amber',
             };
 
   const gates = [
     { label: 'Planning', passed: report.isPlanningReady, viewId: 'dashboard' },
-    { label: 'Blueprint', passed: report.isBlueprintPackReady, viewId: 'blueprint-sheets' },
-    { label: 'Editor geometry', passed: report.isEditorLayoutReady, viewId: 'mechanical-studio' },
-    { label: 'Schematic', passed: report.isSchematicDraftReady, viewId: 'schematic-editor' },
-    { label: 'PCB layout', passed: report.isPcbLayoutDraftReady, viewId: 'board-designer' },
-    { label: 'Routing', passed: report.isRoutingDraftReady, viewId: 'board-designer' },
-    { label: 'Prototype', passed: report.canMoveToPrototype, viewId: 'validation-studio' },
-    { label: 'Factory handoff', passed: report.canMoveToFactoryHandoff, viewId: 'factory-builder' },
-    { label: 'Fabrication', passed: report.canMoveToFabrication, viewId: 'releases' },
+    { label: 'Drawing preflight', passed: report.isBlueprintPackReady, viewId: 'blueprint-sheets' },
+    { label: 'Mechanical evidence', passed: report.isEditorLayoutReady, viewId: 'mechanical-studio' },
+    { label: 'Schematic evidence', passed: report.isSchematicDraftReady, viewId: 'schematic-editor' },
+    { label: 'PCB layout evidence', passed: report.isPcbLayoutDraftReady, viewId: 'board-designer' },
+    { label: 'Routing evidence', passed: report.isRoutingDraftReady, viewId: 'board-designer' },
+    { label: 'Prototype preflight', passed: report.canMoveToPrototype, viewId: 'validation-studio' },
+    { label: 'Factory-draft preflight', passed: report.canMoveToFactoryHandoff, viewId: 'factory-builder' },
+    { label: 'Fabrication helper preflight', passed: report.canMoveToFabrication, viewId: 'revisions' },
   ];
 
-  const categories = [
-    ['Product architecture', report.categories.architecture],
-    ['Mechanical', report.categories.mechanical],
-    ['Assembly', report.categories.assembly],
-    ['Board preparation', report.categories.boardPrep],
-    ['Component placement', report.categories.components],
-    ['Schematic / electronics', report.categories.electronics],
-    ['Nets / routing', report.categories.nets],
-    ['Pin map', report.categories.pinMap],
-    ['Power', report.categories.power],
-    ['Firmware', report.categories.firmware],
-    ['Validation', report.categories.testing],
-    ['Manufacturing', report.categories.manufacturing],
-    ['Native exports', report.categories.nativeExports],
-    ['Factory files', report.categories.factoryFiles],
-    ['Safety', report.categories.safety],
-  ] as const;
-
   return (
-    <div className="h-full overflow-y-auto bg-slate-50 px-4 py-5 text-slate-900 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-7xl">
-        <header className="flex flex-col gap-3 border-b border-slate-300 pb-5 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="text-[10px] font-semibold text-slate-500">Lifecycle decision review</p>
-            <h1 className="mt-1 text-2xl font-semibold tracking-tight text-slate-950">What can this project safely do next?</h1>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">Scores are supporting evidence only. Explicit gates, blockers, and recorded engineering evidence control lifecycle decisions.</p>
+    <div className="h-full overflow-y-auto bg-slate-50 px-4 py-4 text-slate-900">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
+          <div className="border-l-4 border-slate-950 bg-white p-4">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">{nextAction.eyebrow}</p>
+            <h1 className="mt-1 text-lg font-semibold tracking-tight text-slate-950">{nextAction.title}</h1>
+            <p className="mt-2 max-w-3xl text-xs leading-5 text-slate-600">{nextAction.detail}</p>
+            <button type="button" onClick={() => setActiveView(nextAction.action.viewId)} className="mt-3 inline-flex min-h-8 items-center gap-2 bg-slate-950 px-3 text-[10px] font-semibold text-white hover:bg-slate-800">{nextAction.action.label}<ArrowRight className="h-3.5 w-3.5" aria-hidden="true" /></button>
           </div>
-          <div className="flex items-baseline gap-2 border-l border-slate-300 pl-3" aria-label={`Readiness score ${report.overallScore} out of 100`}><span className="text-2xl font-semibold tabular-nums text-slate-950">{report.overallScore}</span><span className="text-[10px] text-slate-500">evidence index / 100</span></div>
-        </header>
 
-        <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_310px]">
-          <main className="min-w-0 space-y-5">
-            <section className="border-l-4 border-slate-950 bg-white px-5 py-5" aria-labelledby="current-decision-title">
-              <div className="flex items-start gap-3">
-                <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-md bg-slate-100">{currentDecision.tone === 'rose' ? <LockKeyhole className="h-4 w-4 text-rose-700" aria-hidden="true" /> : currentDecision.tone === 'emerald' ? <CheckCircle2 className="h-4 w-4 text-emerald-700" aria-hidden="true" /> : <CircleDot className="h-4 w-4 text-slate-700" aria-hidden="true" />}</span>
-                <div className="min-w-0 flex-1">
-                  <p className="text-[10px] font-semibold text-slate-500">{currentDecision.eyebrow}</p>
-                  <h2 id="current-decision-title" className="mt-1 text-xl font-semibold tracking-tight text-slate-950">{currentDecision.title}</h2>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">{currentDecision.detail}</p>
-                  <div className="mt-4 border-t border-slate-200 pt-3"><p className="text-[10px] font-semibold text-slate-500">Consequence</p><p className="mt-1 text-xs leading-5 text-slate-700">{currentDecision.consequence}</p></div>
-                  <button type="button" onClick={() => setActiveView(currentDecision.action.viewId)} className="mt-4 inline-flex min-h-9 items-center gap-2 rounded-md bg-slate-950 px-4 text-sm font-semibold text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2">{currentDecision.action.label}<ArrowRight className="h-4 w-4" aria-hidden="true" /></button>
-                </div>
-              </div>
-            </section>
+          <div className="border border-slate-200 bg-white p-4">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Local evidence index</p>
+            <div className="mt-1 flex items-baseline gap-2"><strong className="text-3xl font-semibold tabular-nums text-slate-950">{report.overallScore}</strong><span className="text-[10px] text-slate-400">/ 100</span></div>
+            <p className="mt-2 text-[10px] leading-4 text-slate-500">Supporting signal only. It is not a release score, approval, fabrication authorization, or artifact qualification.</p>
+          </div>
+        </section>
 
-            <section aria-labelledby="blocking-evidence-title" className="overflow-hidden border-y border-slate-300 bg-white">
-              <div className="border-b border-slate-200 px-4 py-3"><div className="flex items-center gap-2"><ShieldAlert className={`h-4 w-4 ${report.blockers.length ? 'text-rose-600' : 'text-emerald-600'}`} aria-hidden="true" /><h2 id="blocking-evidence-title" className="text-sm font-semibold text-slate-950">Blocking evidence</h2></div><p className="mt-1 text-xs leading-5 text-slate-500">Evidence text is inert. Use the explicit Resolve button to change workspaces.</p></div>
-              {report.blockers.length > 0 ? (
-                <div className="divide-y divide-slate-100">
-                  {report.blockers.map((blocker, index) => {
-                    const route = routeForIssue(blocker);
-                    return <div key={`${blocker}-${index}`} className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center"><div className="min-w-0 flex-1"><p className="text-sm font-semibold leading-5 text-slate-900">{blocker}</p><p className="mt-1 text-xs leading-5 text-slate-500">Must be resolved before the next lifecycle gate can pass.</p></div><button type="button" onClick={() => setActiveView(route.viewId)} className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-400">{route.label}</button></div>;
-                  })}
-                </div>
-              ) : <div className="flex items-start gap-3 px-4 py-4 text-emerald-900"><CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" aria-hidden="true" /><div><p className="text-sm font-semibold">No hard blockers are currently recorded.</p><p className="mt-1 text-xs leading-5 text-slate-600">This does not automatically authorize fabrication; gate evidence still controls what may happen next.</p></div></div>}
-            </section>
+        <section className="border border-amber-200 bg-amber-50 p-3 text-[10px] leading-5 text-amber-950">
+          <strong>Release boundary:</strong> current readiness helpers are local preflight evidence. Trusted immutable versions/releases remain #20; qualified reproducible manufacturing/drawing artifacts remain #21.
+        </section>
 
-            {(report.warnings.length > 0 || report.suggestions.length > 0) && (
-              <details className="group overflow-hidden border-y border-slate-300 bg-white">
-                <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-semibold text-slate-900 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400 [&::-webkit-details-marker]:hidden"><span className="inline-flex items-center gap-2"><AlertTriangle className="h-4 w-4 text-amber-600" aria-hidden="true" /> Review warnings and improvement evidence</span><span className="text-xs font-normal text-slate-500">{report.warnings.length + report.suggestions.length} items</span></summary>
-                <div className="divide-y divide-slate-100 border-t border-slate-200">
-                  {report.warnings.map((warning, index) => {
-                    const route = routeForIssue(warning);
-                    return <div key={`${warning}-${index}`} className="flex items-center gap-3 px-4 py-3"><p className="min-w-0 flex-1 text-xs leading-5 text-amber-950">{warning}</p><button type="button" onClick={() => setActiveView(route.viewId)} className="min-h-8 shrink-0 rounded-md border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100">Open</button></div>;
-                  })}
-                  {report.suggestions.map((suggestion, index) => <div key={`${suggestion}-${index}`} className="px-4 py-3 text-xs leading-5 text-slate-600">{suggestion}</div>)}
-                </div>
-              </details>
-            )}
-
-            <details className="group overflow-hidden border-y border-slate-300 bg-white">
-              <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-semibold text-slate-900 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400 [&::-webkit-details-marker]:hidden"><span>Supporting category scores</span><span className="text-xs font-normal text-slate-500">Secondary evidence</span></summary>
-              <div className="grid gap-x-6 gap-y-4 border-t border-slate-200 p-4 md:grid-cols-2">
-                {categories.map(([label, value]) => <div key={label}><div className="flex items-center justify-between gap-3 text-xs"><span className="font-medium text-slate-700">{label}</span><span className="tabular-nums text-slate-500">{value}%</span></div><div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-slate-100" role="progressbar" aria-label={`${label} evidence score`} aria-valuemin={0} aria-valuemax={100} aria-valuenow={value}><div className="h-full rounded-full bg-slate-700" style={{ width: `${Math.max(0, Math.min(100, value))}%` }} /></div></div>)}
-              </div>
-            </details>
-          </main>
-
-          <aside className="h-fit border border-slate-300 bg-white p-4 xl:sticky xl:top-4" aria-label="Lifecycle gate evidence">
-            <div className="flex items-center gap-2"><FileCheck2 className="h-4 w-4 text-slate-500" aria-hidden="true" /><h2 className="text-sm font-semibold text-slate-950">Gate evidence</h2></div>
-            <p className="mt-1 text-xs leading-5 text-slate-500">Gate rows show state. Only Review changes the workspace.</p>
-            <div className="mt-4 divide-y divide-slate-100">
-              {gates.map((gate, index) => (
-                <div key={gate.label} className="flex min-h-11 items-center gap-2 py-2">
-                  <span className={`grid h-6 w-6 shrink-0 place-items-center rounded-full text-[10px] font-semibold ${gate.passed ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-500'}`} aria-hidden="true">{gate.passed ? '✓' : index + 1}</span>
-                  <div className="min-w-0 flex-1"><p className="text-xs font-semibold text-slate-800">{gate.label}</p><p className={`text-[9px] ${gate.passed ? 'text-emerald-700' : 'text-slate-400'}`}>{gate.passed ? 'passed' : 'locked / incomplete'}</p></div>
-                  <button type="button" onClick={() => setActiveView(gate.viewId)} className="min-h-7 shrink-0 rounded-md border border-slate-300 bg-white px-2 text-[9px] font-semibold text-slate-600 hover:bg-slate-100">Review</button>
-                </div>
-              ))}
+        <section className="border-y border-slate-300 bg-white">
+          <div className="flex items-start gap-2 border-b border-slate-200 px-4 py-3">
+            <ShieldAlert className={`mt-0.5 h-4 w-4 ${report.blockers.length ? 'text-rose-600' : 'text-emerald-600'}`} aria-hidden="true" />
+            <div><h2 className="text-sm font-semibold text-slate-950">Blocking evidence</h2><p className="mt-0.5 text-[10px] text-slate-500">Evidence text is inert. Use the explicit Resolve button to change workspaces.</p></div>
+          </div>
+          {report.blockers.length > 0 ? (
+            <div className="divide-y divide-slate-100">
+              {report.blockers.map((blocker, index) => {
+                const route = routeForIssue(blocker);
+                return (
+                  <div key={`${blocker}-${index}`} className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center">
+                    <p className="min-w-0 flex-1 text-xs font-medium leading-5 text-slate-800">{blocker}</p>
+                    <button type="button" onClick={() => setActiveView(route.viewId)} className="min-h-8 shrink-0 border border-slate-300 bg-white px-2.5 text-[10px] font-semibold text-slate-700 hover:bg-slate-100">{route.label}</button>
+                  </div>
+                );
+              })}
             </div>
-            {report.isDirectFabReviewRequired && <div className="mt-4 border-t border-amber-200 pt-3"><p className="text-[10px] font-semibold text-amber-800">Independent review required</p><p className="mt-1 text-xs leading-5 text-amber-950">A manufacturing package exists, but fabrication evidence is not fully verified. Review it instead of treating file existence as approval.</p><button type="button" onClick={() => setActiveView('factory-builder')} className="mt-3 inline-flex min-h-9 w-full items-center justify-center gap-2 rounded-md bg-amber-900 px-3 text-xs font-semibold text-white hover:bg-amber-800">Open factory review<ArrowRight className="h-3.5 w-3.5" /></button></div>}
-          </aside>
-        </div>
+          ) : (
+            <div className="flex gap-2 px-4 py-4 text-[10px] leading-5 text-slate-600"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />No blocker is reported by the current helper. This does not authorize fabrication or publication.</div>
+          )}
+        </section>
+
+        <section className="border border-slate-200 bg-white p-4" aria-label="Lifecycle gate evidence">
+          <div className="flex items-center gap-2"><FileCheck2 className="h-4 w-4 text-slate-500" aria-hidden="true" /><h2 className="text-sm font-semibold text-slate-950">Local gate evidence</h2></div>
+          <p className="mt-1 text-[10px] leading-5 text-slate-500">Gate rows show state. Only Review changes the workspace. Passing these helper rows does not replace #20/#21 qualification.</p>
+          <div className="mt-3 grid gap-px bg-slate-200 sm:grid-cols-2 lg:grid-cols-3">
+            {gates.map((gate) => (
+              <button key={gate.label} type="button" onClick={() => setActiveView(gate.viewId)} className="flex min-h-14 items-center justify-between gap-3 bg-white px-3 py-2 text-left hover:bg-slate-50">
+                <span className="text-[10px] font-semibold text-slate-700">{gate.label}</span>
+                <span className={`text-[9px] font-semibold ${gate.passed ? 'text-emerald-700' : 'text-slate-400'}`}>{gate.passed ? 'local pass' : 'open'}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {(report.warnings.length > 0 || report.suggestions.length > 0) && (
+          <details className="border border-slate-200 bg-white">
+            <summary className="cursor-pointer px-4 py-3 text-xs font-semibold text-slate-800">Warnings & improvement evidence ({report.warnings.length + report.suggestions.length})</summary>
+            <div className="divide-y divide-slate-100 border-t border-slate-200">
+              {report.warnings.map((warning, index) => <div key={`${warning}-${index}`} className="flex gap-2 px-4 py-2.5 text-[10px] leading-5 text-amber-900"><AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />{warning}</div>)}
+              {report.suggestions.map((suggestion, index) => <div key={`${suggestion}-${index}`} className="px-4 py-2.5 text-[10px] leading-5 text-slate-600">{suggestion}</div>)}
+            </div>
+          </details>
+        )}
       </div>
     </div>
   );

--- a/src/components/StudioWorkbenchNavigation.tsx
+++ b/src/components/StudioWorkbenchNavigation.tsx
@@ -38,6 +38,7 @@ import { PcbProjectDrawer } from './board/PcbProjectDrawer';
 import { MechanicalProjectDrawer } from './mechanical/MechanicalProjectDrawer';
 import { FirmwareProjectDrawer } from './firmware/FirmwareProjectDrawer';
 import { ValidationProjectDrawer } from './validation/ValidationProjectDrawer';
+import { ReleaseProjectDrawer } from './release/ReleaseProjectDrawer';
 
 interface StudioWorkbenchTabsProps {
   drawerOpen: boolean;
@@ -94,7 +95,7 @@ export const StudioWorkbenchTabs: React.FC<StudioWorkbenchTabsProps> = ({ drawer
   const setActiveView = useProjectStore((state) => state.setActiveView);
   const activeWorkbench = getWorkbenchForView(activeView);
   const contextualItems = getContextualNavigationItemsForView(activeView);
-  const hasDrawer = contextualItems.length > 0 || ['pcb', 'mechanical', 'firmware', 'validation'].includes(activeWorkbench?.id || '');
+  const hasDrawer = contextualItems.length > 0 || ['pcb', 'mechanical', 'firmware', 'validation', 'release'].includes(activeWorkbench?.id || '');
 
   return (
     <div className="flex h-10 shrink-0 items-stretch border-b border-[#cfc9bd] bg-[#f4f0e7]" data-studio-shell="workbench-tabs">
@@ -161,6 +162,7 @@ export const StudioProjectDrawer: React.FC<StudioProjectDrawerProps> = ({ open }
   if (activeWorkbench.id === 'mechanical') return <MechanicalProjectDrawer />;
   if (activeWorkbench.id === 'firmware') return <FirmwareProjectDrawer />;
   if (activeWorkbench.id === 'validation') return <ValidationProjectDrawer />;
+  if (activeWorkbench.id === 'release') return <ReleaseProjectDrawer />;
   if (contextualItems.length === 0) return null;
 
   return (

--- a/src/components/release/ReleaseFactorySurface.tsx
+++ b/src/components/release/ReleaseFactorySurface.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle, CheckCircle2, Download, FileCheck2, RotateCcw } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import {
+  exportBomCsv,
+  generateNativeCplDraftCsv,
+  generateNativeExcellonDrills,
+  generateNativeGerberBoardOutline,
+  generateNativeGerberCopperBottom,
+  generateNativeGerberCopperTop,
+  generateReleasePackageManifest,
+} from '../../lib/nativeExports';
+import { evaluateManufacturingContext } from '../../lib/manufacturing/manufacturingContext';
+import { useFeedback } from '../feedback/FeedbackProvider';
+
+const checklistItems = [
+  { key: 'gerber_viewer', label: 'Independent Gerber viewer checked' },
+  { key: 'board_dims', label: 'Board contour and dimensions checked' },
+  { key: 'drill_align', label: 'Drill table, plating and alignment checked' },
+  { key: 'rotations', label: 'Component side and rotation checked' },
+  { key: 'bom_quantities', label: 'BOM part numbers and quantities reconciled' },
+  { key: 'cpl_rotations', label: 'CPL origin / assembly-house convention checked' },
+  { key: 'dfm_run', label: 'External DFM review noted' },
+  { key: 'drc_erc', label: 'ERC/DRC blockers reviewed' },
+] as const;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Draft package generation failed.';
+}
+
+export const ReleaseFactorySurface: React.FC = () => {
+  const store = useProjectStore();
+  const { notify } = useFeedback();
+  const factoryReviewChecks = store.factoryReviewChecks || {};
+  const manufacturing = evaluateManufacturingContext(store);
+  const reviewComplete = checklistItems.every((item) => factoryReviewChecks[item.key] === true);
+
+  const draftFiles = [
+    { label: 'Top copper draft', filename: 'top_copper.gbr', mime: 'text/plain', generate: () => generateNativeGerberCopperTop(store) },
+    { label: 'Bottom copper draft', filename: 'bottom_copper.gbr', mime: 'text/plain', generate: () => generateNativeGerberCopperBottom(store) },
+    { label: 'Board outline draft', filename: 'board_outline.gbr', mime: 'text/plain', generate: () => generateNativeGerberBoardOutline(store) },
+    { label: 'NC drill draft', filename: 'drills.drl', mime: 'text/plain', generate: () => generateNativeExcellonDrills(store) },
+    { label: 'Pick & place draft', filename: 'cpl.csv', mime: 'text/csv', generate: () => generateNativeCplDraftCsv(store) },
+    { label: 'BOM draft', filename: 'bom.csv', mime: 'text/csv', generate: () => exportBomCsv(store) },
+  ];
+
+  const downloadFile = (content: string, filename: string, mimeType: string) => {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  };
+
+  const handlePrepareDraft = () => {
+    if (!manufacturing.ready) {
+      notify({ tone: 'error', title: 'Draft package preflight blocked', detail: manufacturing.blockers[0]?.message || 'Resolve manufacturing preflight first.' });
+      return;
+    }
+    try {
+      draftFiles.forEach((file) => file.generate());
+      generateReleasePackageManifest(store);
+      store.updateFactoryFileStatus('gerberZip', 'Not Generated', 'No authoritative ZIP bundle is synthesized.', 'Hardware Studio');
+      store.updateFactoryFileStatus('drillFiles', 'Needs Final Review', 'Draft NC drill generated from recorded geometry.', 'Hardware Studio', 'drills.drl');
+      store.updateFactoryFileStatus('bomCsv', 'Needs Final Review', 'Draft BOM generated from board-bound components.', 'Hardware Studio', 'bom.csv');
+      store.updateFactoryFileStatus('cplCsv', 'Needs Final Review', 'Draft CPL generated from explicit placement/rotation.', 'Hardware Studio', 'cpl.csv');
+      store.updateFactoryFileStatus('boardDrawing', 'Needs Final Review', 'Draft outline generated from selected-board contour.', 'Hardware Studio', 'board_outline.gbr');
+      store.setFactoryPackageStatus('Needs Review');
+      notify({
+        tone: 'success',
+        title: 'Draft package prepared for review',
+        detail: 'Supported draft outputs were generated from the current canonical project state. They remain unqualified until #21-grade independent checks and trusted review exist.',
+      });
+    } catch (error) {
+      store.setFactoryPackageStatus('Blocked');
+      notify({ tone: 'error', title: 'Draft package preflight blocked', detail: errorMessage(error) });
+    }
+  };
+
+  const handleReset = () => {
+    store.resetFactoryReview();
+    store.updateFactoryFileStatus('gerberZip', 'Not Generated');
+    store.updateFactoryFileStatus('drillFiles', 'Not Generated');
+    store.updateFactoryFileStatus('bomCsv', 'Not Generated');
+    store.updateFactoryFileStatus('cplCsv', 'Not Generated');
+    store.updateFactoryFileStatus('boardDrawing', 'Conceptual');
+    notify({ tone: 'info', title: 'Local factory review reset', detail: 'Review notes and declared draft-file statuses returned to draft state.' });
+  };
+
+  return (
+    <div className="h-full overflow-y-auto bg-slate-50 p-4 text-slate-900">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <section className="border border-amber-300 bg-amber-50 p-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div><h1 className="text-sm font-semibold text-amber-950">Factory package · Draft / Unqualified</h1><p className="mt-1 max-w-3xl text-[10px] leading-5 text-amber-900">This surface prepares review drafts only. A successful generator, checklist, or local status does not create a #21-qualified manufacturing package or a #20 release artifact.</p></div>
+            <span className="shrink-0 border border-amber-300 bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.08em] text-amber-800">Draft / Unqualified</span>
+          </div>
+        </section>
+
+        <section className="border border-slate-200 bg-white">
+          <div className="flex flex-col gap-3 border-b border-slate-200 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div><h2 className="text-sm font-semibold text-slate-950">Manufacturing preflight</h2><p className="mt-1 text-[10px] text-slate-500">Explicit board geometry, placement and supported manufacturing context are required before draft generation.</p></div>
+            <div className="flex gap-2">
+              <button type="button" onClick={handlePrepareDraft} disabled={!manufacturing.ready} className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-3 text-[10px] font-semibold text-white disabled:opacity-40"><FileCheck2 className="h-3.5 w-3.5" /> Preflight & prepare draft</button>
+              <button type="button" onClick={handleReset} className="inline-flex h-8 items-center gap-1.5 border border-slate-300 bg-white px-3 text-[10px] font-semibold text-slate-700"><RotateCcw className="h-3.5 w-3.5" /> Reset review notes</button>
+            </div>
+          </div>
+
+          {!manufacturing.ready ? (
+            <div className="divide-y divide-rose-100 bg-rose-50/60">
+              {manufacturing.blockers.map((blocker) => <div key={`${blocker.code}-${blocker.objectId || blocker.message}`} className="flex gap-2 px-4 py-2.5 text-[10px] leading-5 text-rose-900"><AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />{blocker.message}</div>)}
+            </div>
+          ) : (
+            <div className="grid gap-px bg-slate-200 sm:grid-cols-2 lg:grid-cols-3">
+              {draftFiles.map((file) => (
+                <button key={file.filename} type="button" onClick={() => {
+                  try { downloadFile(file.generate(), file.filename, file.mime); }
+                  catch (error) { notify({ tone: 'error', title: `${file.label} blocked`, detail: errorMessage(error) }); }
+                }} className="flex min-h-20 items-center justify-between gap-3 bg-white px-3.5 py-3 text-left hover:bg-slate-50">
+                  <div className="min-w-0"><div className="text-[11px] font-semibold text-slate-800">{file.label}</div><div className="mt-1 truncate font-mono text-[9px] text-slate-400">{file.filename}</div></div><Download className="h-3.5 w-3.5 shrink-0 text-slate-400" />
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
+          <div className="border border-slate-200 bg-white p-4">
+            <h2 className="text-sm font-semibold text-slate-950">Draft package preflight manifest</h2>
+            <p className="mt-1 text-[10px] leading-5 text-slate-500">Describes current local draft-package state. It is not a signed/content-addressed release manifest.</p>
+            <button type="button" disabled={!manufacturing.ready} onClick={() => {
+              try { downloadFile(generateReleasePackageManifest(store), 'draft_package_manifest.json', 'application/json'); }
+              catch (error) { notify({ tone: 'error', title: 'Draft package manifest blocked', detail: errorMessage(error) }); }
+            }} className="mt-3 inline-flex h-8 items-center gap-1.5 border border-slate-300 bg-white px-3 text-[10px] font-semibold text-slate-700 disabled:opacity-40"><Download className="h-3.5 w-3.5" /> Draft package manifest</button>
+            <div className="mt-4 border border-slate-200 bg-slate-50 p-3 text-[10px] leading-5 text-slate-600">Unsupported or incomplete fabrication outputs remain unsupported. No synthetic Gerber ZIP, authoritative solder-mask/paste/silkscreen qualification, or independent parser/DFM proof is implied.</div>
+          </div>
+
+          <div className="border border-slate-200 bg-white p-4">
+            <div className="flex items-center justify-between gap-2"><div><p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Local review notes</p><h2 className="mt-1 text-sm font-semibold text-slate-950">Evidence checklist</h2></div>{reviewComplete && <CheckCircle2 className="h-5 w-5 text-emerald-600" />}</div>
+            <p className="mt-2 text-[10px] leading-5 text-slate-500">Checklist state records review notes only. It does not mark a package Verified, bind a trusted reviewer to a manifest hash, or satisfy #21.</p>
+            <div className="mt-3 divide-y divide-slate-100 border-y border-slate-100">
+              {checklistItems.map((item) => (
+                <label key={item.key} className="flex cursor-pointer items-start gap-2.5 py-2.5">
+                  <input type="checkbox" checked={factoryReviewChecks[item.key] === true} onChange={(event) => store.setFactoryReviewCheck(item.key, event.target.checked)} className="mt-0.5 h-3.5 w-3.5" />
+                  <span className="text-[10px] leading-4 text-slate-700">{item.label}</span>
+                </label>
+              ))}
+            </div>
+            <p className={`mt-3 text-[9px] font-semibold ${reviewComplete ? 'text-emerald-700' : 'text-slate-400'}`}>{reviewComplete ? 'All local review notes checked · still unqualified' : 'Local review notes incomplete'}</p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/src/components/release/ReleaseOutputsSurface.tsx
+++ b/src/components/release/ReleaseOutputsSurface.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle, Download, FileArchive, ShieldCheck } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import { exportProjectJson } from '../../lib/exportJson';
+import { exportProjectMarkdown } from '../../lib/exportMarkdown';
+import {
+  exportBomCsv,
+  generateNativeCplDraftCsv,
+  generateNativeExcellonDrills,
+  generateNativeGerberBoardOutline,
+  generateNativeGerberCopperBottom,
+  generateNativeGerberCopperTop,
+  generateReleasePackageManifest,
+} from '../../lib/nativeExports';
+import { evaluateManufacturingContext } from '../../lib/manufacturing/manufacturingContext';
+import { useFeedback } from '../feedback/FeedbackProvider';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'The draft output could not be generated from the current project state.';
+}
+
+export const ReleaseOutputsSurface: React.FC = () => {
+  const project = useProjectStore();
+  const { notify } = useFeedback();
+  const manufacturing = evaluateManufacturingContext(project);
+
+  const downloadText = (filename: string, content: string, mimeType = 'text/plain') => {
+    if (typeof window === 'undefined') return;
+    const blob = new Blob([content], { type: `${mimeType};charset=utf-8` });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const safeDraftDownload = (label: string, filename: string, generate: () => string, mimeType = 'text/plain') => {
+    try {
+      downloadText(filename, generate(), mimeType);
+    } catch (error) {
+      notify({ tone: 'error', title: `${label} draft blocked`, detail: errorMessage(error) });
+    }
+  };
+
+  const boardDrafts = [
+    { label: 'Top copper draft', filename: 'top_copper.gbr', generate: () => generateNativeGerberCopperTop(project) },
+    { label: 'Bottom copper draft', filename: 'bottom_copper.gbr', generate: () => generateNativeGerberCopperBottom(project) },
+    { label: 'Board outline draft', filename: 'board_outline.gbr', generate: () => generateNativeGerberBoardOutline(project) },
+    { label: 'NC drill draft', filename: 'drills.drl', generate: () => generateNativeExcellonDrills(project) },
+    { label: 'Pick & place draft', filename: 'cpl.csv', mime: 'text/csv', generate: () => generateNativeCplDraftCsv(project) },
+    { label: 'BOM draft', filename: 'bom.csv', mime: 'text/csv', generate: () => exportBomCsv(project) },
+  ];
+
+  return (
+    <div className="h-full overflow-y-auto bg-slate-50 p-4 text-slate-900">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <section className="flex flex-col gap-3 border border-amber-300 bg-amber-50 p-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2"><FileArchive className="h-4 w-4 text-amber-700" aria-hidden="true" /><h1 className="text-sm font-semibold text-amber-950">Draft / Unqualified outputs</h1></div>
+            <p className="mt-1 max-w-3xl text-[10px] leading-5 text-amber-900">Generation means only that the current local generator could produce a file from recorded project state. These files are not #21-qualified manufacturing/release artifacts until provenance, independent parsing/viewing, reproducibility and trusted review are implemented.</p>
+          </div>
+          <span className="shrink-0 border border-amber-300 bg-white px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.08em] text-amber-800">Draft / Unqualified</span>
+        </section>
+
+        <section className="border border-slate-200 bg-white">
+          <div className="border-b border-slate-200 px-4 py-3"><h2 className="text-sm font-semibold text-slate-950">Project backups & review documents</h2><p className="mt-1 text-[10px] text-slate-500">Portable working-state documents. They are not manufacturing qualification files.</p></div>
+          <div className="flex flex-wrap gap-2 p-4">
+            <button type="button" onClick={() => exportProjectJson(project)} className="inline-flex h-8 items-center gap-1.5 bg-slate-950 px-3 text-[10px] font-semibold text-white"><Download className="h-3.5 w-3.5" /> Project JSON</button>
+            <button type="button" onClick={() => exportProjectMarkdown(project)} className="inline-flex h-8 items-center gap-1.5 border border-slate-300 bg-white px-3 text-[10px] font-semibold text-slate-700"><Download className="h-3.5 w-3.5" /> Project summary</button>
+          </div>
+        </section>
+
+        <section className="border border-slate-200 bg-white">
+          <div className="flex flex-col gap-2 border-b border-slate-200 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div><h2 className="text-sm font-semibold text-slate-950">Board-bound manufacturing drafts</h2><p className="mt-1 text-[10px] text-slate-500">Requires explicit board/geometry/placement data from the existing manufacturing preflight.</p></div>
+            <div className={`inline-flex items-center gap-1.5 text-[9px] font-semibold ${manufacturing.ready ? 'text-emerald-700' : 'text-rose-700'}`}>{manufacturing.ready ? <ShieldCheck className="h-3.5 w-3.5" /> : <AlertTriangle className="h-3.5 w-3.5" />}{manufacturing.ready ? 'Draft generation preflight available' : `${manufacturing.blockers.length} blocker${manufacturing.blockers.length === 1 ? '' : 's'}`}</div>
+          </div>
+
+          {!manufacturing.ready ? (
+            <div className="divide-y divide-rose-100 bg-rose-50/60">
+              {manufacturing.blockers.map((blocker) => <div key={`${blocker.code}-${blocker.objectId || blocker.message}`} className="flex gap-2 px-4 py-2.5 text-[10px] leading-5 text-rose-900"><AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />{blocker.message}</div>)}
+            </div>
+          ) : (
+            <div className="grid gap-px bg-slate-200 sm:grid-cols-2 lg:grid-cols-3">
+              {boardDrafts.map((file) => (
+                <button key={file.filename} type="button" onClick={() => safeDraftDownload(file.label, file.filename, file.generate, file.mime)} className="flex min-h-20 items-center justify-between gap-3 bg-white px-3.5 py-3 text-left hover:bg-slate-50">
+                  <div className="min-w-0"><div className="text-[11px] font-semibold text-slate-800">{file.label}</div><div className="mt-1 truncate font-mono text-[9px] text-slate-400">{file.filename}</div></div><Download className="h-3.5 w-3.5 shrink-0 text-slate-400" />
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="border border-slate-200 bg-white p-4">
+          <h2 className="text-sm font-semibold text-slate-950">Draft package preflight manifest</h2>
+          <p className="mt-1 text-[10px] leading-5 text-slate-500">This local manifest describes generated draft-package state. It is deliberately not named or presented as a release manifest.</p>
+          <button type="button" disabled={!manufacturing.ready} onClick={() => safeDraftDownload('Draft package manifest', 'draft_package_manifest.json', () => generateReleasePackageManifest(project), 'application/json')} className="mt-3 inline-flex h-8 items-center gap-1.5 border border-slate-300 bg-white px-3 text-[10px] font-semibold text-slate-700 disabled:opacity-40"><Download className="h-3.5 w-3.5" /> Draft package manifest</button>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/src/components/release/ReleaseProjectDrawer.tsx
+++ b/src/components/release/ReleaseProjectDrawer.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import React from 'react';
+import { FileArchive, FileCheck2, FileText, Layers3, PackageCheck, ShieldCheck } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import {
+  useReleaseWorkspaceUiStore,
+  type ReleaseDrawerSection,
+  type ReleaseSelectionKind,
+} from '../../store/releaseWorkspaceUiStore';
+
+const sectionItems: ReadonlyArray<{
+  id: ReleaseDrawerSection;
+  viewId: string;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+}> = [
+  { id: 'readiness', viewId: 'readiness', label: 'Readiness', description: 'Local evidence preflight', icon: ShieldCheck },
+  { id: 'snapshots', viewId: 'revisions', label: 'Snapshots', description: 'Local snapshots & candidates', icon: Layers3 },
+  { id: 'outputs', viewId: 'exports', label: 'Outputs', description: 'Draft / unqualified files', icon: FileArchive },
+  { id: 'drawings', viewId: 'blueprint-sheets', label: 'Drawings', description: 'Review drawing sheets', icon: FileText },
+  { id: 'factory', viewId: 'factory-builder', label: 'Factory', description: 'Draft package preflight', icon: PackageCheck },
+];
+
+const recordTone: Record<ReleaseSelectionKind, string> = {
+  snapshot: 'Snapshot',
+  candidate: 'Provisional candidate',
+  release: 'Local release record',
+};
+
+export const ReleaseProjectDrawer: React.FC = () => {
+  const activeView = useProjectStore((state) => state.activeView);
+  const setActiveView = useProjectStore((state) => state.setActiveView);
+  const revisions = useProjectStore((state) => state.revisions || []);
+  const candidates = useProjectStore((state) => state.releaseCandidates || []);
+  const releases = useProjectStore((state) => state.releases || []);
+  const selectedKind = useReleaseWorkspaceUiStore((state) => state.selectedKind);
+  const selectedRecordId = useReleaseWorkspaceUiStore((state) => state.selectedRecordId);
+  const setDrawerSection = useReleaseWorkspaceUiStore((state) => state.setDrawerSection);
+  const selectRecord = useReleaseWorkspaceUiStore((state) => state.selectRecord);
+
+  const navigate = (section: ReleaseDrawerSection, viewId: string) => {
+    setDrawerSection(section);
+    setActiveView(viewId);
+  };
+
+  const records = [
+    ...revisions.map((record) => ({ kind: 'snapshot' as const, record })),
+    ...candidates.map((record) => ({ kind: 'candidate' as const, record })),
+    ...releases.map((record) => ({ kind: 'release' as const, record })),
+  ];
+
+  return (
+    <aside
+      className="z-20 flex h-full w-[224px] shrink-0 flex-col overflow-hidden border-r border-[#cfc9bd] bg-[#f7f3eb]"
+      aria-label="Release project drawer"
+      data-studio-shell="project-drawer"
+    >
+      <div className="shrink-0 border-b border-[#d8d1c5] px-3 py-2.5">
+        <div className="text-[8px] font-semibold uppercase tracking-[0.13em] text-slate-400">Release control</div>
+        <h2 className="mt-1 text-[12px] font-semibold tracking-[-0.01em] text-slate-950">Review before handoff</h2>
+        <p className="mt-1 text-[9px] leading-4 text-slate-500">Local preflight and draft artifacts. Trusted release/qualification remain #20/#21.</p>
+      </div>
+
+      <nav className="shrink-0 border-b border-[#d8d1c5] p-1.5" aria-label="Release jobs">
+        {sectionItems.map((item) => {
+          const Icon = item.icon;
+          const active = activeView === item.viewId || (item.id === 'snapshots' && ['branches', 'releases'].includes(activeView));
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => navigate(item.id, item.viewId)}
+              className={`relative flex min-h-10 w-full items-center gap-2 px-2 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-400/70 ${active ? 'bg-[#e4ddd0] text-slate-950' : 'text-slate-600 hover:bg-[#ece6dc] hover:text-slate-950'}`}
+              aria-current={active ? 'page' : undefined}
+            >
+              {active && <span className="absolute inset-y-0 left-0 w-0.5 bg-slate-950" aria-hidden="true" />}
+              <span className={`grid h-6 w-6 shrink-0 place-items-center border ${active ? 'border-slate-950 bg-slate-950 text-white' : 'border-slate-300 bg-[#fbfaf6] text-slate-500'}`}>
+                <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[10px] font-semibold">{item.label}</span>
+                <span className="mt-0.5 block truncate text-[8px] text-slate-400">{item.description}</span>
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-9 shrink-0 items-center gap-2 border-b border-[#ded8cc] px-3">
+          <FileCheck2 className="h-3 w-3 text-slate-400" aria-hidden="true" />
+          <span className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-500">Explicit release context</span>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+          {records.map(({ kind, record }) => {
+            const selected = selectedKind === kind && selectedRecordId === record.id;
+            return (
+              <button
+                key={`${kind}-${record.id}`}
+                type="button"
+                onClick={() => selectRecord(kind, record.id)}
+                className={`mb-1 w-full border px-2 py-2 text-left ${selected ? 'border-slate-950 bg-white text-slate-950' : 'border-transparent text-slate-600 hover:border-slate-300 hover:bg-white/70'}`}
+              >
+                <span className="block text-[8px] font-semibold uppercase tracking-[0.08em] text-slate-400">{recordTone[kind]}</span>
+                <span className="mt-0.5 block truncate text-[10px] font-semibold">{record.name}</span>
+                <span className="mt-0.5 block truncate font-mono text-[8px] text-slate-400">{record.id}</span>
+              </button>
+            );
+          })}
+          {records.length === 0 && (
+            <div className="px-2 py-4 text-center text-[9px] leading-4 text-slate-400">No release records yet. Opening Release never creates or selects one.</div>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+};

--- a/src/components/release/UnifiedReleaseWorkbench.tsx
+++ b/src/components/release/UnifiedReleaseWorkbench.tsx
@@ -6,11 +6,11 @@ import { useProjectStore } from '../../store/projectStore';
 import { useReleaseWorkspaceUiStore } from '../../store/releaseWorkspaceUiStore';
 import { validateReleaseEligibility } from '../../lib/releaseEngine';
 import { ReadinessDashboard } from '../ReadinessDashboard';
-import { ExportCenter } from '../ExportCenter';
 import { BlueprintSheets } from '../BlueprintSheets';
-import { FactoryPackageBuilder } from '../FactoryPackageBuilder';
 import { RevisionsStudio } from '../revisions/RevisionsStudio';
 import { EditorDockButton } from '../editor/EditorDockButton';
+import { ReleaseOutputsSurface } from './ReleaseOutputsSurface';
+import { ReleaseFactorySurface } from './ReleaseFactorySurface';
 import {
   EngineeringBottomDock,
   EngineeringEditorBar,
@@ -69,9 +69,14 @@ export const UnifiedReleaseWorkbench: React.FC<{ mode: ReleaseWorkbenchMode }> =
         <div className="h-full min-h-0 overflow-hidden">
           {mode === 'readiness' && <ReadinessDashboard />}
           {mode === 'snapshots' && <RevisionsStudio />}
-          {mode === 'outputs' && <ExportCenter />}
-          {mode === 'drawings' && <BlueprintSheets />}
-          {mode === 'factory' && <FactoryPackageBuilder />}
+          {mode === 'outputs' && <ReleaseOutputsSurface />}
+          {mode === 'drawings' && (
+            <div className="flex h-full min-h-0 flex-col overflow-hidden">
+              <div className="shrink-0 border-b border-amber-200 bg-amber-50 px-3 py-2 text-[9px] leading-4 text-amber-900"><strong>Drawing review:</strong> current sheets are review/draft outputs. Qualified versioned drawings, controlled regeneration, standards metadata and release-bound approval remain #21.</div>
+              <div className="min-h-0 flex-1 overflow-hidden"><BlueprintSheets /></div>
+            </div>
+          )}
+          {mode === 'factory' && <ReleaseFactorySurface />}
         </div>
 
         <EngineeringInspector

--- a/src/components/release/UnifiedReleaseWorkbench.tsx
+++ b/src/components/release/UnifiedReleaseWorkbench.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle, PanelRight, ShieldAlert } from 'lucide-react';
+import { useProjectStore } from '../../store/projectStore';
+import { useReleaseWorkspaceUiStore } from '../../store/releaseWorkspaceUiStore';
+import { validateReleaseEligibility } from '../../lib/releaseEngine';
+import { ReadinessDashboard } from '../ReadinessDashboard';
+import { ExportCenter } from '../ExportCenter';
+import { BlueprintSheets } from '../BlueprintSheets';
+import { FactoryPackageBuilder } from '../FactoryPackageBuilder';
+import { RevisionsStudio } from '../revisions/RevisionsStudio';
+import { EditorDockButton } from '../editor/EditorDockButton';
+import {
+  EngineeringBottomDock,
+  EngineeringEditorBar,
+  EngineeringInspector,
+  EngineeringStatusBar,
+} from '../editor/EngineeringEditorShell';
+
+export type ReleaseWorkbenchMode = 'readiness' | 'snapshots' | 'outputs' | 'drawings' | 'factory';
+
+const modeTitle: Record<ReleaseWorkbenchMode, string> = {
+  readiness: 'Readiness preflight',
+  snapshots: 'Snapshots & candidates',
+  outputs: 'Draft outputs',
+  drawings: 'Drawing review',
+  factory: 'Factory package preflight',
+};
+
+export const UnifiedReleaseWorkbench: React.FC<{ mode: ReleaseWorkbenchMode }> = ({ mode }) => {
+  const revisions = useProjectStore((state) => state.revisions || []);
+  const candidates = useProjectStore((state) => state.releaseCandidates || []);
+  const releases = useProjectStore((state) => state.releases || []);
+  const project = useProjectStore();
+  const selectedKind = useReleaseWorkspaceUiStore((state) => state.selectedKind);
+  const selectedRecordId = useReleaseWorkspaceUiStore((state) => state.selectedRecordId);
+  const inspectorOpen = useReleaseWorkspaceUiStore((state) => state.inspectorOpen);
+  const bottomDockOpen = useReleaseWorkspaceUiStore((state) => state.bottomDockOpen);
+  const setInspectorOpen = useReleaseWorkspaceUiStore((state) => state.setInspectorOpen);
+  const setBottomDockOpen = useReleaseWorkspaceUiStore((state) => state.setBottomDockOpen);
+
+  const selectedRecord = selectedKind === 'snapshot'
+    ? revisions.find((record) => record.id === selectedRecordId) || null
+    : selectedKind === 'candidate'
+      ? candidates.find((record) => record.id === selectedRecordId) || null
+      : selectedKind === 'release'
+        ? releases.find((record) => record.id === selectedRecordId) || null
+        : null;
+
+  const localBlockers = validateReleaseEligibility(project);
+  const hardBlockers = localBlockers.filter((blocker) => blocker.severity !== 'Warning');
+
+  return (
+    <section className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-[#fbfaf6]" aria-label="Release workbench">
+      <EngineeringEditorBar
+        domain="Release"
+        title={modeTitle[mode]}
+        meta="Local preflight and draft handoff only · trusted versions/releases remain #20 · qualified artifacts remain #21"
+        docks={(
+          <>
+            <EditorDockButton label="Inspector" icon={PanelRight} active={inspectorOpen} onClick={() => setInspectorOpen(!inspectorOpen)} />
+            <EditorDockButton label="Preflight" icon={ShieldAlert} active={bottomDockOpen} count={hardBlockers.length} onClick={() => setBottomDockOpen(!bottomDockOpen)} />
+          </>
+        )}
+      />
+
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <div className="h-full min-h-0 overflow-hidden">
+          {mode === 'readiness' && <ReadinessDashboard />}
+          {mode === 'snapshots' && <RevisionsStudio />}
+          {mode === 'outputs' && <ExportCenter />}
+          {mode === 'drawings' && <BlueprintSheets />}
+          {mode === 'factory' && <FactoryPackageBuilder />}
+        </div>
+
+        <EngineeringInspector
+          open={inspectorOpen}
+          subtitle={selectedRecord ? `${selectedKind} · explicit selection` : 'No release record selected'}
+          onClose={() => setInspectorOpen(false)}
+        >
+          {selectedRecord ? (
+            <div className="space-y-3 p-3 text-[10px]">
+              <div>
+                <p className="text-[8px] font-semibold uppercase tracking-[0.12em] text-slate-400">
+                  {selectedKind === 'snapshot' ? 'Local snapshot' : selectedKind === 'candidate' ? 'Provisional candidate' : 'Local release record'}
+                </p>
+                <p className="mt-1 text-[12px] font-semibold text-slate-950">{selectedRecord.name}</p>
+                <p className="mt-1 break-all font-mono text-[8px] text-slate-400">{selectedRecord.id}</p>
+              </div>
+              <dl className="divide-y divide-slate-100 border-y border-slate-200">
+                <div className="flex justify-between gap-3 py-2"><dt className="text-slate-500">Status</dt><dd className="text-right font-semibold text-slate-800">{selectedRecord.status}</dd></div>
+                <div className="flex justify-between gap-3 py-2"><dt className="text-slate-500">Branch label</dt><dd className="max-w-[160px] truncate text-right font-mono text-slate-700">{selectedRecord.branchName || '—'}</dd></div>
+                <div className="flex justify-between gap-3 py-2"><dt className="text-slate-500">Created</dt><dd className="text-right text-slate-700">{selectedRecord.createdAt || '—'}</dd></div>
+              </dl>
+              <div className="border border-amber-200 bg-amber-50 p-2 text-[9px] leading-4 text-amber-900">
+                This record uses the current local snapshot/release model. It is not a #20-grade content-addressed version, trusted approval, or immutable published release.
+              </div>
+            </div>
+          ) : (
+            <div className="p-4 text-[10px] leading-5 text-slate-500">Select a snapshot, provisional candidate, or local release record explicitly from the Release Project Drawer. Opening Release never chooses one for you.</div>
+          )}
+        </EngineeringInspector>
+
+        <EngineeringBottomDock
+          open={bottomDockOpen}
+          title="Local release preflight"
+          subtitle="Helper blockers only — this does not establish #20/#21 release or fabrication qualification"
+          onClose={() => setBottomDockOpen(false)}
+        >
+          <div className="divide-y divide-slate-100">
+            {localBlockers.map((blocker, index) => (
+              <div key={`${blocker.domain}-${index}`} className="flex gap-2 px-3 py-2.5 text-[10px] leading-4 text-slate-700">
+                <AlertTriangle className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${blocker.severity === 'Warning' ? 'text-amber-500' : 'text-rose-600'}`} aria-hidden="true" />
+                <div><strong className="text-slate-900">{blocker.domain}</strong><span className="ml-1 text-slate-500">{blocker.message}</span></div>
+              </div>
+            ))}
+            {localBlockers.length === 0 && (
+              <div className="px-3 py-4 text-[10px] leading-5 text-slate-600">No blocker is reported by the current local preflight helper. This is not fabrication authorization: immutable version/release guarantees (#20) and qualified artifacts/reproducible independent checks (#21) remain separate engineering gates.</div>
+            )}
+          </div>
+        </EngineeringBottomDock>
+      </div>
+
+      <EngineeringStatusBar
+        left={`${modeTitle[mode]} · local/provisional authority`}
+        center={selectedRecord ? `Explicit context: ${selectedRecord.name}` : 'No release record selected'}
+        right={`${hardBlockers.length} local blocker${hardBlockers.length === 1 ? '' : 's'}`}
+      />
+    </section>
+  );
+};

--- a/src/components/revisions/RevisionsStudio.tsx
+++ b/src/components/revisions/RevisionsStudio.tsx
@@ -1,17 +1,9 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
-import {
-  AlertCircle,
-  CheckCircle2,
-  Fingerprint,
-  GitBranch,
-  LockKeyhole,
-  Plus,
-  ShieldCheck,
-  Tag,
-} from 'lucide-react';
+import React, { useState } from 'react';
+import { AlertCircle, CheckCircle2, Fingerprint, GitBranch, Plus, ShieldCheck } from 'lucide-react';
 import { useProjectStore } from '../../store/projectStore';
+import { useReleaseWorkspaceUiStore } from '../../store/releaseWorkspaceUiStore';
 import {
   approveRelease,
   createBranch,
@@ -20,7 +12,6 @@ import {
   validateReleaseEligibility,
   verifyReleaseCandidateIntegrity,
   type ProductRevision,
-  type ReleaseBlocker,
   type ReleaseRevision,
 } from '../../lib/releaseEngine';
 import type { Project } from '../../types';
@@ -29,215 +20,225 @@ import { useFeedback } from '../feedback/FeedbackProvider';
 export const RevisionsStudio: React.FC = () => {
   const store = useProjectStore();
   const { confirm: requestConfirmation, notify } = useFeedback();
-  const [versionName, setVersionName] = useState('');
+  const [snapshotName, setSnapshotName] = useState('');
   const [branchName, setBranchName] = useState('');
-  const [rcTag, setRcTag] = useState('');
-  const [signoff, setSignoff] = useState('');
+  const [candidateTag, setCandidateTag] = useState('');
+  const [reviewerNote, setReviewerNote] = useState('');
+
+  const selectedKind = useReleaseWorkspaceUiStore((state) => state.selectedKind);
+  const selectedRecordId = useReleaseWorkspaceUiStore((state) => state.selectedRecordId);
+  const selectRecord = useReleaseWorkspaceUiStore((state) => state.selectRecord);
 
   const revisions: ProductRevision[] = store.revisions || [];
   const branches: ProductRevision[] = store.branches || [];
   const releaseCandidates = (store.releaseCandidates || []) as ReleaseRevision[];
   const releases = (store.releases || []) as ReleaseRevision[];
   const activeBranch = store.activeBranch || 'main';
-  const blockers: ReleaseBlocker[] = validateReleaseEligibility(store);
-  const isEligible = blockers.filter((blocker) => blocker.severity !== 'Warning').length === 0;
-  const latestRevision = revisions[revisions.length - 1];
+  const selectedSnapshot = selectedKind === 'snapshot'
+    ? revisions.find((revision) => revision.id === selectedRecordId) || null
+    : null;
 
-  const latestRevisionBlockers = useMemo(() => {
-    if (!latestRevision?.projectSnapshot) return [];
-    return validateReleaseEligibility(latestRevision.projectSnapshot as Project);
-  }, [latestRevision]);
-  const latestRevisionEligible = latestRevisionBlockers.filter((blocker) => blocker.severity !== 'Warning').length === 0;
+  const selectedSnapshotBlockers = selectedSnapshot?.projectSnapshot
+    ? validateReleaseEligibility(selectedSnapshot.projectSnapshot as Project)
+    : [];
+  const selectedSnapshotHardBlockers = selectedSnapshotBlockers.filter((blocker) => blocker.severity !== 'Warning');
 
-  const handleCreateVersion = () => {
-    const name = versionName.trim();
+  const handleCreateSnapshot = () => {
+    const name = snapshotName.trim();
     if (!name) return;
-    const revision = createNamedRevision(store, name, `Named snapshot from ${activeBranch}`, activeBranch);
-    store.updateProjectState({ revisions: [...revisions, revision] });
-    setVersionName('');
-    notify({ tone: 'success', title: 'Named version frozen', detail: `${revision.name} captured the current project state.` });
+    const snapshot = createNamedRevision(store, name, `Local named snapshot from ${activeBranch}`, activeBranch);
+    store.updateProjectState({ revisions: [...revisions, snapshot] });
+    selectRecord('snapshot', snapshot.id);
+    setSnapshotName('');
+    notify({
+      tone: 'success',
+      title: 'Local snapshot captured',
+      detail: `${snapshot.name} captured the current project JSON state. It is not a #20-grade content-addressed immutable version.`,
+    });
   };
 
   const handleCreateBranch = () => {
     const name = branchName.trim();
-    if (!name || !latestRevision) return;
-    const branch = createBranch(latestRevision, name);
+    if (!name || !selectedSnapshot) return;
+    const branch = createBranch(selectedSnapshot, name);
     store.updateProjectState({ branches: [...branches, branch], activeBranch: branch.branchName });
     setBranchName('');
-    notify({ tone: 'success', title: 'Working branch created', detail: `${branch.branchName} starts from ${latestRevision.name}.` });
+    notify({
+      tone: 'success',
+      title: 'Local working branch record created',
+      detail: `${branch.branchName} references explicitly selected snapshot ${selectedSnapshot.name}. Full ancestry/merge semantics remain #20.`,
+    });
   };
 
-  const handleCreateRC = () => {
-    const tag = rcTag.trim();
-    if (!tag || !latestRevision) return;
-    if (!latestRevisionEligible) {
+  const handleCreateCandidate = () => {
+    const tag = candidateTag.trim();
+    if (!tag || !selectedSnapshot) return;
+    if (selectedSnapshotHardBlockers.length > 0) {
       notify({
         tone: 'warning',
-        title: 'Named version is not release-eligible',
-        detail: latestRevisionBlockers.map((blocker) => blocker.message).join(' '),
+        title: 'Selected snapshot fails local preflight',
+        detail: selectedSnapshotHardBlockers.map((blocker) => blocker.message).join(' '),
         durationMs: 0,
       });
       return;
     }
 
     try {
-      const candidate = createReleaseCandidate(latestRevision, tag);
+      const candidate = createReleaseCandidate(selectedSnapshot, tag);
       store.updateProjectState({ releaseCandidates: [...releaseCandidates, candidate] });
-      setRcTag('');
+      selectRecord('candidate', candidate.id);
+      setCandidateTag('');
       notify({
         tone: 'success',
-        title: 'Release Candidate frozen',
-        detail: `${candidate.name} is a separate immutable snapshot with SHA-256 integrity evidence.`,
+        title: 'Provisional candidate captured',
+        detail: `${candidate.name} has a local snapshot fingerprint. This is integrity evidence, not a trusted #20 release approval.`,
       });
     } catch (error: unknown) {
-      notify({ tone: 'error', title: 'Could not create Release Candidate', detail: error instanceof Error ? error.message : String(error), durationMs: 0 });
+      notify({ tone: 'error', title: 'Could not create provisional candidate', detail: error instanceof Error ? error.message : String(error), durationMs: 0 });
     }
   };
 
-  const handleApproveRelease = async (candidate: ReleaseRevision) => {
+  const handleCreateLocalReleaseRecord = async (candidate: ReleaseRevision) => {
     const integrity = verifyReleaseCandidateIntegrity(candidate);
     if (!integrity.valid) {
-      notify({ tone: 'error', title: 'Release Candidate integrity failed', detail: integrity.reason || 'Snapshot fingerprint does not match.', durationMs: 0 });
+      notify({ tone: 'error', title: 'Candidate snapshot integrity failed', detail: integrity.reason || 'Local snapshot fingerprint does not match.', durationMs: 0 });
       return;
     }
-    const reviewer = signoff.trim();
+    const reviewer = reviewerNote.trim();
     if (!reviewer) {
-      notify({ tone: 'warning', title: 'Reviewer sign-off required', detail: 'Enter the actual reviewer/operator identity before approving a release.' });
+      notify({ tone: 'warning', title: 'Reviewer note required', detail: 'Record who performed this local review. Trusted actor/role approval remains #20.' });
       return;
     }
 
     const candidateBlockers = validateReleaseEligibility(candidate.projectSnapshot as Project).filter((blocker) => blocker.severity !== 'Warning');
     if (candidateBlockers.length > 0) {
-      notify({ tone: 'error', title: 'Frozen candidate is blocked', detail: candidateBlockers.map((blocker) => blocker.message).join(' '), durationMs: 0 });
+      notify({ tone: 'error', title: 'Provisional candidate fails local preflight', detail: candidateBlockers.map((blocker) => blocker.message).join(' '), durationMs: 0 });
       return;
     }
 
-    const approved = await requestConfirmation({
-      title: `Release “${candidate.name}”?`,
-      description: `This publishes the frozen candidate snapshot reviewed by ${reviewer}. Working-state changes are not included. The candidate SHA-256 fingerprint will remain attached to the release record.`,
-      confirmLabel: 'Publish release',
+    const confirmed = await requestConfirmation({
+      title: `Record local release review for “${candidate.name}”?`,
+      description: `This records the current local candidate snapshot and reviewer note (${reviewer}). It is not a trusted signed/content-addressed #20 release and does not qualify manufacturing artifacts under #21.`,
+      confirmLabel: 'Create local release record',
       variant: 'default',
     });
-    if (!approved) return;
+    if (!confirmed) return;
 
     try {
       const release = approveRelease(candidate, reviewer);
       store.updateProjectState({ releases: [...releases, release] });
-      setSignoff('');
-      notify({ tone: 'success', title: 'Release published', detail: `${release.name} was published from candidate ${candidate.id}. No artifact IDs were fabricated.` });
+      selectRecord('release', release.id);
+      setReviewerNote('');
+      notify({
+        tone: 'success',
+        title: 'Local release record created',
+        detail: `${release.name} references candidate ${candidate.id}. Trusted approval/immutable publication remain #20.`,
+      });
     } catch (error: unknown) {
-      notify({ tone: 'error', title: 'Release approval failed', detail: error instanceof Error ? error.message : String(error), durationMs: 0 });
+      notify({ tone: 'error', title: 'Could not create local release record', detail: error instanceof Error ? error.message : String(error), durationMs: 0 });
     }
   };
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-50 text-slate-900">
-      <header className="shrink-0 border-b border-slate-200 bg-white px-5 py-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.12em] text-indigo-700"><LockKeyhole className="h-4 w-4" /> Release workspace</div>
-            <h1 className="mt-1 text-xl font-semibold tracking-tight text-slate-950">Freeze what was reviewed. Release only that snapshot.</h1>
-            <p className="mt-1 max-w-3xl text-xs leading-5 text-slate-600">Working state, named versions, Release Candidates, and published releases are kept distinct so later edits cannot silently change approved hardware evidence.</p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 text-xs">
-            <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 font-mono text-slate-700">branch: {activeBranch}</span>
-            <span className={`rounded-full border px-2.5 py-1 font-semibold ${isEligible ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-amber-200 bg-amber-50 text-amber-800'}`}>{isEligible ? 'Working state eligible' : `${blockers.length} working blocker${blockers.length === 1 ? '' : 's'}`}</span>
-          </div>
-        </div>
-      </header>
+    <section className="h-full min-h-0 overflow-y-auto bg-slate-50 p-4 text-slate-900">
+      <div className="mx-auto max-w-5xl space-y-4">
+        <section className="border border-amber-200 bg-amber-50 p-3 text-[10px] leading-5 text-amber-950">
+          <strong>Current authority:</strong> these are local JSON snapshot / candidate / release-review records. They are useful for workflow review, but they are not the content-addressed immutable versions, full branch ancestry, trusted approvals, or published releases required by #20.
+        </section>
 
-      <div className="grid min-h-0 flex-1 lg:grid-cols-[290px_minmax(0,1fr)]">
-        <aside className="min-h-0 overflow-y-auto border-r border-slate-200 bg-white p-4">
-          <div className="flex items-center gap-2 text-xs font-bold text-slate-800"><Tag className="h-4 w-4 text-emerald-600" /> Named versions</div>
-          <div className="mt-3 flex gap-2">
-            <input value={versionName} onChange={(event) => setVersionName(event.target.value)} placeholder="Rev-1.1-EVT" className="h-9 min-w-0 flex-1 rounded-lg border border-slate-300 px-2.5 text-xs outline-none focus:border-indigo-500" />
-            <button type="button" onClick={handleCreateVersion} disabled={!versionName.trim()} className="inline-flex h-9 items-center gap-1 rounded-lg bg-slate-950 px-3 text-xs font-bold text-white disabled:opacity-40"><Plus className="h-3.5 w-3.5" /> Freeze</button>
-          </div>
-
-          <div className="mt-4 space-y-2">
-            {revisions.slice().reverse().map((revision) => (
-              <div key={revision.id} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                <div className="flex items-start justify-between gap-2"><strong className="min-w-0 truncate text-xs text-slate-900">{revision.name}</strong><span className="shrink-0 text-[9px] font-semibold text-slate-500">{revision.status}</span></div>
-                <p className="mt-1 truncate font-mono text-[9px] text-slate-500">{revision.id}</p>
-              </div>
-            ))}
-            {revisions.length === 0 && <p className="rounded-xl border border-dashed border-slate-300 p-4 text-center text-xs text-slate-500">Freeze a named version before creating a Release Candidate.</p>}
-          </div>
-
-          <details className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-3">
-            <summary className="cursor-pointer text-xs font-bold text-slate-700">Working branches</summary>
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="border border-slate-200 bg-white p-4">
+            <div className="flex items-center gap-2"><Plus className="h-4 w-4 text-slate-500" /><h2 className="text-sm font-semibold text-slate-950">Capture local snapshot</h2></div>
+            <p className="mt-1 text-[10px] leading-5 text-slate-500">Captures the current project JSON state on branch label <span className="font-mono">{activeBranch}</span>. This does not create a #20 immutable version.</p>
             <div className="mt-3 flex gap-2">
-              <input value={branchName} onChange={(event) => setBranchName(event.target.value)} placeholder="feature/enclosure-b" className="h-8 min-w-0 flex-1 rounded-lg border border-slate-300 px-2 text-[10px] outline-none" />
-              <button type="button" onClick={handleCreateBranch} disabled={!branchName.trim() || !latestRevision} className="h-8 rounded-lg border border-slate-300 bg-white px-2.5 text-[10px] font-bold disabled:opacity-40">Branch</button>
+              <input value={snapshotName} onChange={(event) => setSnapshotName(event.target.value)} placeholder="Rev-1.1-EVT" className="h-9 min-w-0 flex-1 border border-slate-300 px-2.5 text-xs outline-none focus:border-slate-500" />
+              <button type="button" onClick={handleCreateSnapshot} disabled={!snapshotName.trim()} className="h-9 bg-slate-950 px-3 text-xs font-semibold text-white disabled:opacity-40">Capture</button>
             </div>
-            <p className="mt-2 text-[9px] text-slate-500">{branches.length} recorded working branch{branches.length === 1 ? '' : 'es'}.</p>
-          </details>
-        </aside>
-
-        <main className="min-h-0 overflow-y-auto p-5">
-          <div className="mx-auto max-w-5xl space-y-5">
-            <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-              <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2 text-xs font-bold text-slate-900"><ShieldCheck className="h-4 w-4 text-amber-600" /> Candidate gate</div>
-                  <p className="mt-1 text-xs leading-5 text-slate-600">The candidate is created from the latest named version, not from whatever happens to be open afterward.</p>
-                </div>
-                {latestRevision && <span className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold ${latestRevisionEligible ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-amber-200 bg-amber-50 text-amber-800'}`}>{latestRevision.name}: {latestRevisionEligible ? 'eligible' : 'blocked'}</span>}
-              </div>
-
-              {latestRevisionBlockers.length > 0 && (
-                <div className="mt-3 space-y-2">
-                  {latestRevisionBlockers.map((blocker, index) => <div key={`${blocker.domain}-${index}`} className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-[10px] leading-5 text-amber-900"><AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" /> {blocker.message}</div>)}
-                </div>
-              )}
-
-              <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-                <input value={rcTag} onChange={(event) => setRcTag(event.target.value)} placeholder="RC-1.0.0-EVT" className="h-10 min-w-0 flex-1 rounded-lg border border-slate-300 px-3 text-xs font-semibold outline-none focus:border-indigo-500" />
-                <button type="button" onClick={handleCreateRC} disabled={!latestRevision || !latestRevisionEligible || !rcTag.trim()} className="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 text-xs font-bold text-slate-950 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-40"><LockKeyhole className="h-4 w-4" /> Freeze Release Candidate</button>
-              </div>
-            </section>
-
-            <section>
-              <div className="mb-2 flex items-center justify-between gap-3"><h2 className="text-sm font-bold text-slate-900">Frozen candidates</h2><span className="text-[10px] text-slate-500">Integrity is checked again at approval time.</span></div>
-              <div className="space-y-3">
-                {releaseCandidates.slice().reverse().map((candidate) => {
-                  const integrity = verifyReleaseCandidateIntegrity(candidate);
-                  const candidateBlockers = candidate.projectSnapshot ? validateReleaseEligibility(candidate.projectSnapshot as Project).filter((blocker) => blocker.severity !== 'Warning') : [];
-                  return (
-                    <article key={candidate.id} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-                      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                        <div className="min-w-0">
-                          <div className="flex flex-wrap items-center gap-2"><strong className="text-sm text-slate-950">{candidate.name}</strong><span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[9px] font-bold text-amber-800">Release Candidate</span><span className={`rounded-full border px-2 py-0.5 text-[9px] font-bold ${integrity.valid ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-red-200 bg-red-50 text-red-700'}`}>{integrity.valid ? 'snapshot intact' : 'integrity failed'}</span></div>
-                          <div className="mt-2 flex min-w-0 items-center gap-2 rounded-lg bg-slate-50 px-2.5 py-2 font-mono text-[9px] text-slate-600"><Fingerprint className="h-3.5 w-3.5 shrink-0" /><span className="truncate">SHA-256 {candidate.integrity?.snapshotSha256 || 'missing'}</span></div>
-                          <p className="mt-2 text-[10px] text-slate-500">Source {candidate.integrity?.sourceRevisionId || candidate.parentRevisionId || 'unknown'} · {(candidate.integrity?.validationRunIds || []).length} validation run ID{(candidate.integrity?.validationRunIds || []).length === 1 ? '' : 's'} captured</p>
-                        </div>
-                        <div className="min-w-[240px] space-y-2">
-                          <input value={signoff} onChange={(event) => setSignoff(event.target.value)} placeholder="Actual reviewer / approver" className="h-9 w-full rounded-lg border border-slate-300 px-2.5 text-xs outline-none focus:border-indigo-500" />
-                          <button type="button" onClick={() => void handleApproveRelease(candidate)} disabled={!integrity.valid || candidateBlockers.length > 0 || !signoff.trim()} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-lg bg-emerald-600 px-3 text-xs font-bold text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-40"><CheckCircle2 className="h-4 w-4" /> Publish this frozen snapshot</button>
-                        </div>
-                      </div>
-                      {candidateBlockers.length > 0 && <p className="mt-3 rounded-lg border border-red-200 bg-red-50 p-2 text-[10px] leading-5 text-red-800">Candidate blocked: {candidateBlockers.map((blocker) => blocker.message).join(' ')}</p>}
-                    </article>
-                  );
-                })}
-                {releaseCandidates.length === 0 && <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-xs text-slate-500">No Release Candidate exists yet.</div>}
-              </div>
-            </section>
-
-            <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-              <div className="flex items-center gap-2"><CheckCircle2 className="h-4 w-4 text-emerald-600" /><h2 className="text-sm font-bold text-slate-900">Published release history</h2></div>
-              <div className="mt-3 divide-y divide-slate-100">
-                {releases.slice().reverse().map((release) => (
-                  <div key={release.id} className="flex flex-col gap-1 py-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div><strong className="text-xs text-slate-900">{release.name}</strong><p className="mt-0.5 text-[9px] text-slate-500">Approved by {release.releaseArtifacts?.approvalSignoff || 'unattributed'} · {release.createdAt}</p></div>
-                    <span className="max-w-sm truncate font-mono text-[9px] text-slate-500">{release.integrity?.snapshotSha256 || 'legacy release without fingerprint'}</span>
-                  </div>
-                ))}
-                {releases.length === 0 && <p className="py-6 text-center text-xs text-slate-500">No published releases yet.</p>}
-              </div>
-            </section>
           </div>
-        </main>
+
+          <div className="border border-slate-200 bg-white p-4">
+            <p className="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-400">Explicit source snapshot</p>
+            {selectedSnapshot ? (
+              <>
+                <p className="mt-1 truncate text-sm font-semibold text-slate-950">{selectedSnapshot.name}</p>
+                <p className="mt-1 break-all font-mono text-[8px] text-slate-400">{selectedSnapshot.id}</p>
+                <p className={`mt-2 text-[10px] font-semibold ${selectedSnapshotHardBlockers.length === 0 ? 'text-emerald-700' : 'text-rose-700'}`}>{selectedSnapshotHardBlockers.length === 0 ? 'Local preflight has no hard blocker' : `${selectedSnapshotHardBlockers.length} local blocker${selectedSnapshotHardBlockers.length === 1 ? '' : 's'}`}</p>
+              </>
+            ) : (
+              <p className="mt-2 text-[10px] leading-5 text-slate-500">Select a local snapshot explicitly in the Release Project Drawer. Branch/candidate creation is disabled until you do.</p>
+            )}
+          </div>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-2">
+          <div className="border border-slate-200 bg-white p-4">
+            <div className="flex items-center gap-2"><GitBranch className="h-4 w-4 text-slate-500" /><h2 className="text-sm font-semibold text-slate-950">Local branch record</h2></div>
+            <p className="mt-1 text-[10px] leading-5 text-slate-500">Uses only the explicitly selected snapshot. True ancestry, switching safety and three-way merge remain #20.</p>
+            <div className="mt-3 flex gap-2">
+              <input value={branchName} onChange={(event) => setBranchName(event.target.value)} placeholder="feature/enclosure-b" className="h-9 min-w-0 flex-1 border border-slate-300 px-2.5 text-xs outline-none" />
+              <button type="button" onClick={handleCreateBranch} disabled={!selectedSnapshot || !branchName.trim()} className="h-9 border border-slate-300 bg-white px-3 text-xs font-semibold text-slate-700 disabled:opacity-40">Create</button>
+            </div>
+            <p className="mt-2 text-[9px] text-slate-400">{branches.length} local working branch record{branches.length === 1 ? '' : 's'}.</p>
+          </div>
+
+          <div className="border border-slate-200 bg-white p-4">
+            <div className="flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-amber-600" /><h2 className="text-sm font-semibold text-slate-950">Provisional candidate</h2></div>
+            <p className="mt-1 text-[10px] leading-5 text-slate-500">Captures a locally fingerprinted snapshot after the current helper preflight. It is not a trusted release candidate under #20.</p>
+            <div className="mt-3 flex gap-2">
+              <input value={candidateTag} onChange={(event) => setCandidateTag(event.target.value)} placeholder="RC-1.0.0-EVT" className="h-9 min-w-0 flex-1 border border-slate-300 px-2.5 text-xs outline-none" />
+              <button type="button" onClick={handleCreateCandidate} disabled={!selectedSnapshot || selectedSnapshotHardBlockers.length > 0 || !candidateTag.trim()} className="h-9 bg-amber-400 px-3 text-xs font-semibold text-slate-950 disabled:opacity-40">Capture</button>
+            </div>
+          </div>
+        </section>
+
+        <section className="border border-slate-200 bg-white">
+          <div className="border-b border-slate-200 px-4 py-3"><h2 className="text-sm font-semibold text-slate-950">Provisional candidates</h2><p className="mt-1 text-[10px] text-slate-500">Local SHA-256 checks detect snapshot changes; they do not provide signed approval, role policy, artifact qualification, or repository-enforced immutability.</p></div>
+          <div className="divide-y divide-slate-100">
+            {releaseCandidates.map((candidate) => {
+              const integrity = verifyReleaseCandidateIntegrity(candidate);
+              const blockers = candidate.projectSnapshot ? validateReleaseEligibility(candidate.projectSnapshot as Project).filter((blocker) => blocker.severity !== 'Warning') : [];
+              return (
+                <article key={candidate.id} className="p-4">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2"><strong className="text-sm text-slate-950">{candidate.name}</strong><span className="border border-amber-200 bg-amber-50 px-2 py-0.5 text-[9px] font-semibold text-amber-800">Provisional candidate</span></div>
+                      <div className="mt-2 flex min-w-0 items-center gap-2 bg-slate-50 px-2.5 py-2 font-mono text-[9px] text-slate-600"><Fingerprint className="h-3.5 w-3.5 shrink-0" /><span className="truncate">Local snapshot SHA-256 {candidate.integrity?.snapshotSha256 || 'missing'}</span></div>
+                      <p className={`mt-2 text-[10px] ${integrity.valid && blockers.length === 0 ? 'text-emerald-700' : 'text-rose-700'}`}>{integrity.valid ? 'Local snapshot fingerprint matches.' : integrity.reason || 'Fingerprint check failed.'} {blockers.length > 0 ? `${blockers.length} local blocker(s).` : ''}</p>
+                    </div>
+                    <div className="w-full space-y-2 lg:w-[260px]">
+                      <input value={reviewerNote} onChange={(event) => setReviewerNote(event.target.value)} placeholder="Local reviewer / operator note" className="h-9 w-full border border-slate-300 px-2.5 text-xs outline-none" />
+                      <button type="button" onClick={() => void handleCreateLocalReleaseRecord(candidate)} disabled={!integrity.valid || blockers.length > 0 || !reviewerNote.trim()} className="inline-flex h-9 w-full items-center justify-center gap-2 bg-slate-950 px-3 text-xs font-semibold text-white disabled:opacity-40"><CheckCircle2 className="h-4 w-4" /> Create local release record</button>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+            {releaseCandidates.length === 0 && <p className="p-5 text-center text-[10px] text-slate-400">No provisional candidates recorded.</p>}
+          </div>
+        </section>
+
+        {selectedSnapshotBlockers.length > 0 && (
+          <section className="border border-rose-200 bg-rose-50">
+            <div className="border-b border-rose-200 px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-rose-700">Selected snapshot local preflight</div>
+            <div className="divide-y divide-rose-100">
+              {selectedSnapshotBlockers.map((blocker, index) => <div key={`${blocker.domain}-${index}`} className="flex gap-2 px-4 py-2.5 text-[10px] leading-5 text-rose-900"><AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />{blocker.message}</div>)}
+            </div>
+          </section>
+        )}
+
+        <section className="border border-slate-200 bg-white p-4">
+          <h2 className="text-sm font-semibold text-slate-950">Local release records</h2>
+          <p className="mt-1 text-[10px] leading-5 text-slate-500">These preserve current local workflow output only. They are not immutable published releases until #20 is implemented.</p>
+          <div className="mt-3 divide-y divide-slate-100 border-y border-slate-100">
+            {releases.map((release) => (
+              <button key={release.id} type="button" onClick={() => selectRecord('release', release.id)} className="flex w-full flex-col gap-1 py-3 text-left sm:flex-row sm:items-center sm:justify-between">
+                <div><strong className="text-xs text-slate-900">{release.name}</strong><p className="mt-0.5 text-[9px] text-slate-500">Local reviewer note: {release.releaseArtifacts?.approvalSignoff || 'unattributed'} · {release.createdAt}</p></div>
+                <span className="max-w-sm truncate font-mono text-[9px] text-slate-500">{release.integrity?.snapshotSha256 || 'no local fingerprint'}</span>
+              </button>
+            ))}
+            {releases.length === 0 && <p className="py-4 text-center text-[10px] text-slate-400">No local release records.</p>}
+          </div>
+        </section>
       </div>
     </section>
   );

--- a/src/store/releaseWorkspaceUiStore.ts
+++ b/src/store/releaseWorkspaceUiStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+export type ReleaseDrawerSection = 'readiness' | 'snapshots' | 'outputs' | 'drawings' | 'factory';
+export type ReleaseSelectionKind = 'snapshot' | 'candidate' | 'release';
+
+interface ReleaseWorkspaceUiState {
+  drawerSection: ReleaseDrawerSection;
+  selectedKind: ReleaseSelectionKind | null;
+  selectedRecordId: string | null;
+  inspectorOpen: boolean;
+  bottomDockOpen: boolean;
+  setDrawerSection: (section: ReleaseDrawerSection) => void;
+  selectRecord: (kind: ReleaseSelectionKind, id: string) => void;
+  clearSelection: () => void;
+  setInspectorOpen: (open: boolean) => void;
+  setBottomDockOpen: (open: boolean) => void;
+}
+
+export const useReleaseWorkspaceUiStore = create<ReleaseWorkspaceUiState>((set) => ({
+  drawerSection: 'readiness',
+  selectedKind: null,
+  selectedRecordId: null,
+  inspectorOpen: true,
+  bottomDockOpen: false,
+  setDrawerSection: (drawerSection) => set({ drawerSection }),
+  selectRecord: (selectedKind, selectedRecordId) => set({ selectedKind, selectedRecordId, inspectorOpen: true }),
+  clearSelection: () => set({ selectedKind: null, selectedRecordId: null }),
+  setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
+  setBottomDockOpen: (bottomDockOpen) => set({ bottomDockOpen }),
+}));


### PR DESCRIPTION
Closes #118
Parents: #20 / #21 / #43 / #46
Execution ledger: `docs/development/STUDIO_PHASE_EXECUTION_STATUS.md`

## Replaces
- generic Release contextual navigation with one shell-owned `ReleaseProjectDrawer`;
- separate AppShell routing directly to Readiness/Revisions/Outputs/Drawings/Factory mini-apps;
- hidden `revisions[revisions.length - 1]` authority for branch/candidate creation;
- user-facing immutable/version/release wording that exceeded the current #20 model;
- live `Release manifest` language for unqualified draft package state;
- readiness wording that could imply fabrication authorization.

## Canonical context
- clean URL / active route remains the active Release surface authority;
- `releaseWorkspaceUiStore` contains only drawer/explicit record/Inspector/dock UI state;
- revisions/candidates/releases and output/factory engineering state remain in the existing project store;
- no new release/version/output engineering data model.

## Live Release grammar
- one Release Project Drawer: Readiness / Snapshots / Outputs / Drawings / Factory;
- one `UnifiedReleaseWorkbench` for all Release routes;
- right Inspector only shows an explicitly selected local snapshot / provisional candidate / local release record;
- bottom dock shows current **local preflight** blockers only;
- route-controlled center surfaces preserve clean URLs.

## Truth corrections
- local JSON records are called snapshots, not #20-grade immutable content-addressed versions;
- branch/candidate creation requires explicit selected source snapshot;
- local candidate SHA-256 is described as local snapshot integrity evidence, not trusted approval;
- release output is described as a **local release record**, not immutable published release;
- Readiness is explicitly local helper preflight and never fabrication/release authorization;
- live manufacturing/download surfaces are visibly **Draft / Unqualified**;
- live package manifest downloads use `draft_package_manifest.json` / `Draft package manifest`;
- checklist completion remains local review notes and explicitly does not mark a package Verified;
- #20/#21 boundaries stay visible in shared Release chrome.

## Preserve
- clean Release routes;
- manufacturing blockers from `evaluateManufacturingContext`;
- useful local candidate snapshot-integrity checks;
- explicit unsupported-output warnings;
- current blueprint drawing review surface, now under Release with an explicit #21 draft boundary.

## Completion gate
Do not merge until exact PR head passes lint, typecheck, all tests, production build and deployment-status inspection. Before merge perform the owner-requested double-check: exact changed-file scope, stale/duplicate/implicit-selection scan, #20/#21 state, truth wording and deployment status. After merge, update Release notes + phase ledger before U9.